### PR TITLE
Track prompt-cache tokens across providers and make local rates the source of truth

### DIFF
--- a/.claude/skills/update-pricing/SKILL.md
+++ b/.claude/skills/update-pricing/SKILL.md
@@ -1,91 +1,117 @@
 ---
 name: update-pricing
-description: Update LLM model pricing in Prompture. Pricing comes from two sources — models.dev live cache (primary) and JSON rate files in prompture/infra/rates/ (capabilities KB). Use when model prices change, new models launch, or models.dev data is stale.
+description: Update LLM model pricing in Prompture. Pricing resolves through a pluggable source registry — by default local KB JSON files (primary, curated) then models.dev (fallback). Use when model prices change, new models launch, models.dev data is stale, or you need to add a custom pricing source.
 metadata:
   author: prompture
-  version: "3.0"
+  version: "4.0"
 ---
 
 # Update Model Pricing
 
-## How Pricing Works
+## How Pricing Resolves
 
-Pricing is resolved by `CostMixin._calculate_cost()` using **models.dev live rates only** (per 1M tokens). If no live rates are found, cost is $0.00.
+Pricing flows through a **pluggable source registry** at `prompture/infra/pricing.py`. `get_model_rates(provider, model_id)` walks the registered sources in priority order (lowest first) and returns the first dict that includes both `input` and `output` per-1M rates.
 
-Model configuration (`tokens_param`, `supports_temperature`) is resolved by `CostMixin._get_model_config()` from the **capabilities knowledge base** (JSON rate files in `prompture/infra/rates/`) overlaid onto models.dev live data.
+Default registration (controlled by `Settings.pricing_source`):
 
-### models.dev Integration
+| Setting value | Sources registered (priority order) |
+|---------------|-------------------------------------|
+| `local_first` (default) | `LocalKBPricingSource` (priority 0) → `ModelsDevPricingSource` (priority 100) |
+| `local_only` | `LocalKBPricingSource` only |
+| `models_dev_only` | `ModelsDevPricingSource` only |
 
-The mapping from prompture provider names to models.dev provider names lives in `prompture/infra/model_rates.py`:
+**Use `local_first` (default)** when you want curated rates with automatic fallback. **`local_only`** for offline/locked-down envs or when you don't trust models.dev. **`models_dev_only`** as a temporary opt-out while local files are unmaintained.
 
-```python
-PROVIDER_MAP = {
-    "openai": "openai",
-    "claude": "anthropic",
-    "google": "google",
-    "groq": "groq",
-    "grok": "xai",
-    "azure": "azure",
-    "openrouter": "openrouter",
-    "moonshot": "moonshotai",
-    "zai": "zai",
-}
-```
+`CostMixin._calculate_cost()` consumes the resolved dict — `input`, `output`, optional `cache_read`, `cache_write`, `reasoning` rates per 1M tokens. Cached prompt tokens are billed at `cache_read` (falls back to `input` rate when not published).
 
-The cache is stored at `~/.prompture/cache/models_dev.json` with a TTL configured by `settings.model_rates_ttl_days` (default 7 days).
+## Local KB layout (the primary source)
 
-### Capabilities Knowledge Base (JSON rate files)
+Per-provider JSON files in `prompture/infra/rates/` carry both **capabilities** and **pricing** for each model. Adding a `cost` block makes that model use local pricing; omitting it falls through to models.dev.
 
-Per-provider JSON files in `prompture/infra/rates/` define model capabilities:
-
-| File | Provider | Notes |
-|------|----------|-------|
-| `rates/openai.json` | OpenAI | `tokens_param` varies by model |
-| `rates/anthropic.json` | Anthropic | All use `max_tokens` |
-| `rates/google.json` | Google | All use `max_tokens` |
-| `rates/groq.json` | Groq | All use `max_tokens` |
-| `rates/xai.json` | xAI/Grok | All use `max_tokens` |
-| `rates/azure.json` | Azure | Mixed OpenAI/Claude/Mistral models |
-| `rates/openrouter.json` | OpenRouter | All use `max_tokens` |
-| `rates/moonshot.json` | Moonshot | All use `max_tokens` |
-
-Each entry contains:
 ```json
 {
-  "model-name": {
-    "supports_temperature": true,
+  "gpt-5.5": {
+    "supports_temperature": false,
     "supports_tool_use": true,
     "supports_structured_output": true,
     "supports_vision": true,
-    "is_reasoning": false,
-    "context_window": 128000,
-    "max_output_tokens": 16384,
+    "is_reasoning": true,
+    "context_window": 1050000,
+    "max_output_tokens": 128000,
     "modalities_input": ["text", "image"],
     "modalities_output": ["text"],
     "api_type": "openai",
-    "tokens_param": "max_completion_tokens"
+    "tokens_param": "max_completion_tokens",
+    "cost": {
+      "input": 5.00,
+      "output": 30.00,
+      "cache_read": 0.50
+    }
   }
 }
 ```
 
-### Free/local drivers (always $0):
+**`cost` block keys** (USD per 1M tokens):
+- `input` — required for cost to compute
+- `output` — required
+- `cache_read` — optional. Discount rate for cached prompt tokens (Anthropic / OpenAI / Kimi all support this).
+- `cache_write` — optional. Anthropic only — premium rate for tokens written to prompt cache.
+- `reasoning` — optional. For models that bill reasoning tokens separately.
 
-`ollama_driver.py`, `lmstudio_driver.py`, `local_http_driver.py`, `airllm_driver.py`, `hugging_driver.py`
+## Vendor pricing pages (verify before editing)
 
-## When to Update What
+**Always cross-check rates against the vendor's official page**, not just models.dev — feeds get stale.
+
+| Provider | Pricing page |
+|----------|--------------|
+| OpenAI | https://developers.openai.com/api/docs/pricing |
+| Anthropic (Claude) | https://platform.claude.com/docs/en/about-claude/pricing |
+| Moonshot (Kimi) | https://platform.kimi.ai/docs (search "Model Pricing") |
+| xAI (Grok) | https://docs.x.ai/docs/models |
+| Google (Gemini) | https://ai.google.dev/gemini-api/docs/pricing |
+| Groq | https://groq.com/pricing |
+| OpenRouter | https://openrouter.ai/models |
+| Moonshot K2 | https://platform.moonshot.ai/docs/pricing/chat |
+| Z.ai (GLM) | https://docs.z.ai/guides/llm/pricing |
+
+When a vendor publishes "cache hit" / "cache read" pricing, encode it as `cache_read`. When they publish a "cache write" / "cache creation" rate (Anthropic only), encode it as `cache_write`.
+
+## When to update what
 
 | Scenario | Action |
 |----------|--------|
-| New model from an existing provider | Add entry to the provider's JSON rate file in `rates/` |
-| models.dev has wrong/outdated prices | Force refresh: see below |
-| New provider | Add `rates/{provider}.json`, entry to `PROVIDER_MAP`, discovery integration |
-| Model pricing changed | Usually nothing — models.dev updates automatically |
+| Vendor changed prices for a model already in the KB | Update the `cost` block in `rates/{provider}.json` |
+| New model from existing provider | Add entry with capabilities + `cost` block |
+| New provider | Create `rates/{provider}.json`, add to `PROVIDER_MAP` in `model_rates.py`, wire descriptor in `provider_descriptors.py` |
+| Model not in KB but in models.dev | Nothing — fallback already covers it |
+| You want to override what models.dev says | Add the `cost` block to local KB; it wins |
+| You want to lock pricing to local-only | Set `pricing_source=local_only` in env / `.env` |
 
-## Refreshing models.dev Cache
+## Adding a custom pricing source
+
+For internal price feeds, vendor APIs the registry doesn't cover, or per-environment overrides:
 
 ```python
-from prompture.model_rates import refresh_rates_cache
-refresh_rates_cache(force=True)  # Fetch fresh data regardless of TTL
+from prompture.infra.pricing import register_pricing_source
+
+class MyInternalFeed:
+    name = "internal_feed"
+    priority = 50  # between local_kb (0) and models_dev (100)
+
+    def get_rates(self, provider: str, model_id: str) -> dict[str, float] | None:
+        # Return {"input": ..., "output": ..., "cache_read": ...} or None
+        return _query_my_internal_service(provider, model_id)
+
+register_pricing_source(MyInternalFeed())
+```
+
+Sources are ordered by `(priority, name)`. The first to return a dict containing both `input` and `output` wins. Exceptions inside `get_rates` are swallowed and the next source is tried.
+
+## Refreshing the models.dev cache
+
+```python
+from prompture.infra.model_rates import refresh_rates_cache
+refresh_rates_cache(force=True)
 ```
 
 Or delete the cache file:
@@ -93,32 +119,46 @@ Or delete the cache file:
 rm ~/.prompture/cache/models_dev.json
 ```
 
-## Steps for Adding/Updating Models
+## Provider name → models.dev key mapping
 
-1. **Edit** the appropriate JSON file in `prompture/infra/rates/`
-2. **Set** `tokens_param` correctly — `"max_completion_tokens"` for newer OpenAI models (gpt-5.x, gpt-4o, o-series), `"max_tokens"` for everything else
-3. **Set** `api_type` — `"openai"`, `"anthropic"`, `"google"`, or `"openai-compatible"`
-4. **Run tests**: `pytest tests/ -x -q`
+Lives in `prompture/infra/model_rates.py` (`PROVIDER_MAP`):
 
-## Side Effects
+```python
+{"openai": "openai", "claude": "anthropic", "google": "google", "groq": "groq",
+ "grok": "xai", "azure": "azure", "openrouter": "openrouter",
+ "moonshot": "moonshotai", "zai": "zai"}
+```
 
-- `prompture/infra/discovery.py` reads KB model IDs via `get_kb_models_for_provider()` to list available models (static detection)
-- `PROVIDER_MAP` entries also feed discovery via `get_all_provider_models()` (models.dev detection)
-- Adding a model to the KB makes it appear in `get_available_models()` even without an API key configured
-- `CostMixin._get_model_config()` reads `tokens_param` and `supports_temperature` from the KB
+## Free / local drivers (always $0)
 
-## Verification
+`ollama_driver.py`, `lmstudio_driver.py`, `local_http_driver.py`, `airllm_driver.py`, `hugging_driver.py`.
+
+## Steps for adding / updating a model price
+
+1. **Open** the vendor's pricing page (table above) and copy the current rates.
+2. **Edit** `prompture/infra/rates/{provider}.json` — find the model entry (or add a new one with capabilities) and add/update the `cost` block.
+3. **Verify** with `python -c "from prompture.infra.model_rates import get_model_rates; print(get_model_rates('openai', 'gpt-5.5'))"`. The dict should include exactly the keys you wrote.
+4. **Run tests**: `pytest tests/test_pricing.py tests/test_cached_tokens.py -q`
+5. **For long-running processes** that imported the LocalKBPricingSource before the edit: the in-memory KB is loaded once at startup. Either restart, or call `LocalKBPricingSource().reload()` on the registered instance.
+
+## Verification commands
 
 ```bash
-# Check live rates for a model
-python -c "from prompture.model_rates import get_model_rates; print(get_model_rates('openai', 'gpt-4o'))"
+# Check resolved rates for a model
+python -c "from prompture.infra.model_rates import get_model_rates; print(get_model_rates('openai', 'gpt-5.5'))"
 
-# Check capabilities for a model
-python -c "from prompture.model_rates import get_model_capabilities; print(get_model_capabilities('openai', 'gpt-5.1'))"
+# Inspect which sources are registered
+python -c "from prompture.infra.pricing import get_pricing_sources; print([(s.name, s.priority) for s in get_pricing_sources()])"
 
-# Check cache age
-python -c "from prompture.model_rates import _META_FILE; import json; print(json.load(open(_META_FILE)))"
+# Check that capabilities still load
+python -c "from prompture.infra.model_rates import get_model_capabilities; print(get_model_capabilities('openai', 'gpt-5.5'))"
 
-# Run tests
-pytest tests/ -x -q
+# Run pricing + cost tests
+pytest tests/test_pricing.py tests/test_cached_tokens.py tests/test_model_rates.py -q
 ```
+
+## Side effects of editing the KB
+
+- `prompture/infra/discovery.py` reads KB model IDs via `get_kb_models_for_provider()` for static detection (no API key needed).
+- `CostMixin._get_model_config()` still reads `tokens_param` / `supports_temperature` from the KB capabilities.
+- A model with a local `cost` block now appears in cost calculations regardless of models.dev cache state — useful when models.dev lags vendor announcements.

--- a/prompture/drivers/async_base.py
+++ b/prompture/drivers/async_base.py
@@ -233,6 +233,7 @@ class AsyncDriver(ABC):
                 completion_tokens=meta.get("completion_tokens", 0),
                 total_tokens=meta.get("total_tokens", 0),
                 cached_prompt_tokens=meta.get("cached_prompt_tokens", 0),
+                cache_creation_tokens=meta.get("cache_creation_tokens", 0),
                 cost=meta.get("cost", 0.0),
                 elapsed_ms=elapsed_ms,
                 status=status,

--- a/prompture/drivers/async_base.py
+++ b/prompture/drivers/async_base.py
@@ -232,6 +232,7 @@ class AsyncDriver(ABC):
                 prompt_tokens=meta.get("prompt_tokens", 0),
                 completion_tokens=meta.get("completion_tokens", 0),
                 total_tokens=meta.get("total_tokens", 0),
+                cached_prompt_tokens=meta.get("cached_prompt_tokens", 0),
                 cost=meta.get("cost", 0.0),
                 elapsed_ms=elapsed_ms,
                 status=status,

--- a/prompture/drivers/async_claude_driver.py
+++ b/prompture/drivers/async_claude_driver.py
@@ -20,6 +20,7 @@ from .claude_driver import (
     _build_anthropic_meta,
     _build_anthropic_stream_done,
     _convert_tools_to_anthropic,
+    _extract_anthropic_cache_tokens,
     _extract_anthropic_system_and_messages,
     _extract_anthropic_text_and_tool_calls,
 )
@@ -104,8 +105,14 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
         if not text and reasoning_content:
             text = reasoning_content
 
+        cache_read, cache_create = _extract_anthropic_cache_tokens(resp.usage)
         total_cost = self._calculate_cost(
-            "claude", model, resp.usage.input_tokens, resp.usage.output_tokens
+            "claude",
+            model,
+            resp.usage.input_tokens + cache_read + cache_create,
+            resp.usage.output_tokens,
+            cached_tokens=cache_read,
+            cache_creation_tokens=cache_create,
         )
         meta = _build_anthropic_meta(resp, model, total_cost)
 
@@ -157,8 +164,14 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
 
         resp = await client.messages.create(**kwargs)
 
+        cache_read, cache_create = _extract_anthropic_cache_tokens(resp.usage)
         total_cost = self._calculate_cost(
-            "claude", model, resp.usage.input_tokens, resp.usage.output_tokens
+            "claude",
+            model,
+            resp.usage.input_tokens + cache_read + cache_create,
+            resp.usage.output_tokens,
+            cached_tokens=cache_read,
+            cache_creation_tokens=cache_create,
         )
         meta = _build_anthropic_meta(resp, model, total_cost)
 
@@ -205,8 +218,10 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
 
         full_text = ""
         full_reasoning = ""
-        prompt_tokens = 0
+        base_input = 0
         completion_tokens = 0
+        cache_read = 0
+        cache_create = 0
 
         async with client.messages.stream(**kwargs) as stream:
             async for event in stream:
@@ -228,9 +243,19 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
                     elif event.type == "message_start" and hasattr(event, "message"):
                         usage = getattr(event.message, "usage", None)
                         if usage:
-                            prompt_tokens = getattr(usage, "input_tokens", 0)
+                            base_input = getattr(usage, "input_tokens", 0)
+                            cache_read, cache_create = _extract_anthropic_cache_tokens(usage)
 
-        total_cost = self._calculate_cost("claude", model, prompt_tokens, completion_tokens)
+        prompt_tokens = base_input + cache_read + cache_create
+        total_cost = self._calculate_cost(
+            "claude",
+            model,
+            prompt_tokens,
+            completion_tokens,
+            cached_tokens=cache_read,
+            cache_creation_tokens=cache_create,
+        )
         yield _build_anthropic_stream_done(
-            model, full_text, full_reasoning, prompt_tokens, completion_tokens, total_cost
+            model, full_text, full_reasoning, prompt_tokens, completion_tokens, total_cost,
+            cached_prompt_tokens=cache_read, cache_creation_tokens=cache_create,
         )

--- a/prompture/drivers/async_google_driver.py
+++ b/prompture/drivers/async_google_driver.py
@@ -64,11 +64,18 @@ class AsyncGoogleDriver(CostMixin, AsyncDriver):
     def _extract_usage_metadata(self, response: Any, messages: list[dict[str, Any]]) -> dict[str, Any]:
         """Extract token counts from response, falling back to character estimation."""
         usage = getattr(response, "usage_metadata", None)
+        cached_prompt_tokens = 0
         if usage:
             prompt_tokens = getattr(usage, "prompt_token_count", 0) or 0
             completion_tokens = getattr(usage, "candidates_token_count", 0) or 0
             total_tokens = getattr(usage, "total_token_count", 0) or (prompt_tokens + completion_tokens)
-            cost = self._calculate_cost("google", self.model, prompt_tokens, completion_tokens)
+            raw_cached = getattr(usage, "cached_content_token_count", 0) or 0
+            if isinstance(raw_cached, (int, float)):
+                cached_prompt_tokens = int(raw_cached)
+            cost = self._calculate_cost(
+                "google", self.model, prompt_tokens, completion_tokens,
+                cached_tokens=cached_prompt_tokens,
+            )
         else:
             # Fallback: estimate from character counts
             total_prompt_chars = 0
@@ -92,6 +99,7 @@ class AsyncGoogleDriver(CostMixin, AsyncDriver):
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": total_tokens,
+            "cached_prompt_tokens": cached_prompt_tokens,
             "cost": round(cost, 6),
         }
 

--- a/prompture/drivers/async_grok_driver.py
+++ b/prompture/drivers/async_grok_driver.py
@@ -81,17 +81,24 @@ class AsyncGrokDriver(CostMixin, AsyncDriver):
             except Exception as e:
                 raise RuntimeError(f"Grok API request failed: {e!s}") from e
 
+        from .moonshot_driver import _extract_moonshot_cached_tokens
+
         usage = resp.get("usage", {})
         prompt_tokens = usage.get("prompt_tokens", 0)
         completion_tokens = usage.get("completion_tokens", 0)
         total_tokens = usage.get("total_tokens", 0)
+        cached_prompt_tokens = _extract_moonshot_cached_tokens(usage)
 
-        total_cost = self._calculate_cost("grok", model, prompt_tokens, completion_tokens)
+        total_cost = self._calculate_cost(
+            "grok", model, prompt_tokens, completion_tokens,
+            cached_tokens=cached_prompt_tokens,
+        )
 
         meta = {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": total_tokens,
+            "cached_prompt_tokens": cached_prompt_tokens,
             "cost": round(total_cost, 6),
             "raw_response": resp,
             "model_name": model,
@@ -159,16 +166,23 @@ class AsyncGrokDriver(CostMixin, AsyncDriver):
             except Exception as e:
                 raise RuntimeError(f"Grok API request failed: {e!s}") from e
 
+        from .moonshot_driver import _extract_moonshot_cached_tokens
+
         usage = resp.get("usage", {})
         prompt_tokens = usage.get("prompt_tokens", 0)
         completion_tokens = usage.get("completion_tokens", 0)
         total_tokens = usage.get("total_tokens", 0)
-        total_cost = self._calculate_cost("grok", model, prompt_tokens, completion_tokens)
+        cached_prompt_tokens = _extract_moonshot_cached_tokens(usage)
+        total_cost = self._calculate_cost(
+            "grok", model, prompt_tokens, completion_tokens,
+            cached_tokens=cached_prompt_tokens,
+        )
 
         meta = {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": total_tokens,
+            "cached_prompt_tokens": cached_prompt_tokens,
             "cost": round(total_cost, 6),
             "raw_response": resp,
             "model_name": model,

--- a/prompture/drivers/async_groq_driver.py
+++ b/prompture/drivers/async_groq_driver.py
@@ -75,17 +75,24 @@ class AsyncGroqDriver(CostMixin, AsyncDriver):
 
         resp = await self.client.chat.completions.create(**kwargs)
 
+        from .openai_driver import _extract_openai_cached_tokens
+
         usage = getattr(resp, "usage", None)
         prompt_tokens = getattr(usage, "prompt_tokens", 0)
         completion_tokens = getattr(usage, "completion_tokens", 0)
         total_tokens = getattr(usage, "total_tokens", 0)
+        cached_prompt_tokens = _extract_openai_cached_tokens(usage)
 
-        total_cost = self._calculate_cost("groq", model, prompt_tokens, completion_tokens)
+        total_cost = self._calculate_cost(
+            "groq", model, prompt_tokens, completion_tokens,
+            cached_tokens=cached_prompt_tokens,
+        )
 
         meta = {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": total_tokens,
+            "cached_prompt_tokens": cached_prompt_tokens,
             "cost": round(total_cost, 6),
             "raw_response": resp.model_dump(),
             "model_name": model,
@@ -137,16 +144,23 @@ class AsyncGroqDriver(CostMixin, AsyncDriver):
 
         resp = await self.client.chat.completions.create(**kwargs)
 
+        from .openai_driver import _extract_openai_cached_tokens
+
         usage = getattr(resp, "usage", None)
         prompt_tokens = getattr(usage, "prompt_tokens", 0)
         completion_tokens = getattr(usage, "completion_tokens", 0)
         total_tokens = getattr(usage, "total_tokens", 0)
-        total_cost = self._calculate_cost("groq", model, prompt_tokens, completion_tokens)
+        cached_prompt_tokens = _extract_openai_cached_tokens(usage)
+        total_cost = self._calculate_cost(
+            "groq", model, prompt_tokens, completion_tokens,
+            cached_tokens=cached_prompt_tokens,
+        )
 
         meta = {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": total_tokens,
+            "cached_prompt_tokens": cached_prompt_tokens,
             "cost": round(total_cost, 6),
             "raw_response": resp.model_dump(),
             "model_name": model,

--- a/prompture/drivers/async_moonshot_driver.py
+++ b/prompture/drivers/async_moonshot_driver.py
@@ -20,7 +20,7 @@ import httpx
 from ..infra.cost_mixin import CostMixin, prepare_strict_schema
 from .async_base import AsyncDriver
 from .base import _parse_tool_arguments
-from .moonshot_driver import MoonshotDriver
+from .moonshot_driver import MoonshotDriver, _extract_moonshot_cached_tokens
 
 logger = logging.getLogger("prompture.drivers.moonshot")
 
@@ -142,6 +142,7 @@ class AsyncMoonshotDriver(CostMixin, AsyncDriver):
         prompt_tokens = usage.get("prompt_tokens", 0)
         completion_tokens = usage.get("completion_tokens", 0)
         total_tokens = usage.get("total_tokens", 0)
+        cached_prompt_tokens = _extract_moonshot_cached_tokens(usage)
 
         message = resp["choices"][0]["message"]
         text = message.get("content") or ""
@@ -189,6 +190,7 @@ class AsyncMoonshotDriver(CostMixin, AsyncDriver):
                     prompt_tokens += fb_usage.get("prompt_tokens", 0)
                     completion_tokens = fb_usage.get("completion_tokens", 0)
                     total_tokens = prompt_tokens + completion_tokens
+                    cached_prompt_tokens += _extract_moonshot_cached_tokens(fb_usage)
                     resp = fb_resp
                     fb_message = fb_resp["choices"][0]["message"]
                     text = fb_message.get("content") or ""
@@ -196,12 +198,16 @@ class AsyncMoonshotDriver(CostMixin, AsyncDriver):
                     if not text and reasoning_content:
                         text = reasoning_content
 
-        total_cost = self._calculate_cost("moonshot", model, prompt_tokens, completion_tokens)
+        total_cost = self._calculate_cost(
+            "moonshot", model, prompt_tokens, completion_tokens,
+            cached_tokens=cached_prompt_tokens,
+        )
 
         meta = {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": total_tokens,
+            "cached_prompt_tokens": cached_prompt_tokens,
             "cost": round(total_cost, 6),
             "raw_response": resp,
             "model_name": model,
@@ -280,12 +286,17 @@ class AsyncMoonshotDriver(CostMixin, AsyncDriver):
         prompt_tokens = usage.get("prompt_tokens", 0)
         completion_tokens = usage.get("completion_tokens", 0)
         total_tokens = usage.get("total_tokens", 0)
-        total_cost = self._calculate_cost("moonshot", model, prompt_tokens, completion_tokens)
+        cached_prompt_tokens = _extract_moonshot_cached_tokens(usage)
+        total_cost = self._calculate_cost(
+            "moonshot", model, prompt_tokens, completion_tokens,
+            cached_tokens=cached_prompt_tokens,
+        )
 
         meta = {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": total_tokens,
+            "cached_prompt_tokens": cached_prompt_tokens,
             "cost": round(total_cost, 6),
             "raw_response": resp,
             "model_name": model,
@@ -365,6 +376,7 @@ class AsyncMoonshotDriver(CostMixin, AsyncDriver):
         full_reasoning = ""
         prompt_tokens = 0
         completion_tokens = 0
+        cached_prompt_tokens = 0
 
         async with (
             httpx.AsyncClient() as client,
@@ -392,6 +404,7 @@ class AsyncMoonshotDriver(CostMixin, AsyncDriver):
                 if usage:
                     prompt_tokens = usage.get("prompt_tokens", 0)
                     completion_tokens = usage.get("completion_tokens", 0)
+                    cached_prompt_tokens = _extract_moonshot_cached_tokens(usage)
 
                 choices = chunk.get("choices", [])
                 if choices:
@@ -407,7 +420,10 @@ class AsyncMoonshotDriver(CostMixin, AsyncDriver):
                         yield {"type": "delta", "text": content}
 
         total_tokens = prompt_tokens + completion_tokens
-        total_cost = self._calculate_cost("moonshot", model, prompt_tokens, completion_tokens)
+        total_cost = self._calculate_cost(
+            "moonshot", model, prompt_tokens, completion_tokens,
+            cached_tokens=cached_prompt_tokens,
+        )
 
         done_chunk: dict[str, Any] = {
             "type": "done",
@@ -416,6 +432,7 @@ class AsyncMoonshotDriver(CostMixin, AsyncDriver):
                 "prompt_tokens": prompt_tokens,
                 "completion_tokens": completion_tokens,
                 "total_tokens": total_tokens,
+                "cached_prompt_tokens": cached_prompt_tokens,
                 "cost": round(total_cost, 6),
                 "raw_response": {},
                 "model_name": model,

--- a/prompture/drivers/async_openai_driver.py
+++ b/prompture/drivers/async_openai_driver.py
@@ -19,6 +19,7 @@ from .openai_driver import (
     _build_openai_base_kwargs,
     _build_openai_json_mode_response_format,
     _build_openai_stream_done,
+    _extract_openai_cached_tokens,
     _extract_openai_meta,
     _extract_openai_tool_calls,
 )
@@ -90,9 +91,13 @@ class AsyncOpenAIDriver(CostMixin, AsyncDriver):
 
         resp = await self.client.chat.completions.create(**kwargs)
 
-        prompt_tokens = getattr(getattr(resp, "usage", None), "prompt_tokens", 0)
-        completion_tokens = getattr(getattr(resp, "usage", None), "completion_tokens", 0)
-        total_cost = self._calculate_cost("openai", model, prompt_tokens, completion_tokens)
+        usage = getattr(resp, "usage", None)
+        prompt_tokens = getattr(usage, "prompt_tokens", 0)
+        completion_tokens = getattr(usage, "completion_tokens", 0)
+        cached_prompt_tokens = _extract_openai_cached_tokens(usage)
+        total_cost = self._calculate_cost(
+            "openai", model, prompt_tokens, completion_tokens, cached_tokens=cached_prompt_tokens
+        )
         meta = _extract_openai_meta(resp, model, total_cost)
 
         text = resp.choices[0].message.content
@@ -126,9 +131,13 @@ class AsyncOpenAIDriver(CostMixin, AsyncDriver):
 
         resp = await self.client.chat.completions.create(**kwargs)
 
-        prompt_tokens = getattr(getattr(resp, "usage", None), "prompt_tokens", 0)
-        completion_tokens = getattr(getattr(resp, "usage", None), "completion_tokens", 0)
-        total_cost = self._calculate_cost("openai", model, prompt_tokens, completion_tokens)
+        usage = getattr(resp, "usage", None)
+        prompt_tokens = getattr(usage, "prompt_tokens", 0)
+        completion_tokens = getattr(usage, "completion_tokens", 0)
+        cached_prompt_tokens = _extract_openai_cached_tokens(usage)
+        total_cost = self._calculate_cost(
+            "openai", model, prompt_tokens, completion_tokens, cached_tokens=cached_prompt_tokens
+        )
         meta = _extract_openai_meta(resp, model, total_cost)
 
         choice = resp.choices[0]
@@ -177,12 +186,14 @@ class AsyncOpenAIDriver(CostMixin, AsyncDriver):
         full_text = ""
         prompt_tokens = 0
         completion_tokens = 0
+        cached_prompt_tokens = 0
 
         async for chunk in stream:
             # Usage comes in the final chunk
             if getattr(chunk, "usage", None):
                 prompt_tokens = chunk.usage.prompt_tokens or 0
                 completion_tokens = chunk.usage.completion_tokens or 0
+                cached_prompt_tokens = _extract_openai_cached_tokens(chunk.usage)
 
             if chunk.choices:
                 delta = chunk.choices[0].delta
@@ -191,5 +202,9 @@ class AsyncOpenAIDriver(CostMixin, AsyncDriver):
                     full_text += content
                     yield {"type": "delta", "text": content}
 
-        total_cost = self._calculate_cost("openai", model, prompt_tokens, completion_tokens)
-        yield _build_openai_stream_done(model, full_text, prompt_tokens, completion_tokens, total_cost)
+        total_cost = self._calculate_cost(
+            "openai", model, prompt_tokens, completion_tokens, cached_tokens=cached_prompt_tokens
+        )
+        yield _build_openai_stream_done(
+            model, full_text, prompt_tokens, completion_tokens, total_cost, cached_prompt_tokens
+        )

--- a/prompture/drivers/base.py
+++ b/prompture/drivers/base.py
@@ -403,6 +403,7 @@ class Driver(ABC):
                 completion_tokens=meta.get("completion_tokens", 0),
                 total_tokens=meta.get("total_tokens", 0),
                 cached_prompt_tokens=meta.get("cached_prompt_tokens", 0),
+                cache_creation_tokens=meta.get("cache_creation_tokens", 0),
                 cost=meta.get("cost", 0.0),
                 elapsed_ms=elapsed_ms,
                 status=status,

--- a/prompture/drivers/base.py
+++ b/prompture/drivers/base.py
@@ -402,6 +402,7 @@ class Driver(ABC):
                 prompt_tokens=meta.get("prompt_tokens", 0),
                 completion_tokens=meta.get("completion_tokens", 0),
                 total_tokens=meta.get("total_tokens", 0),
+                cached_prompt_tokens=meta.get("cached_prompt_tokens", 0),
                 cost=meta.get("cost", 0.0),
                 elapsed_ms=elapsed_ms,
                 status=status,

--- a/prompture/drivers/claude_driver.py
+++ b/prompture/drivers/claude_driver.py
@@ -112,13 +112,41 @@ def _convert_tools_to_anthropic(tools: list[dict[str, Any]]) -> list[dict[str, A
     return anthropic_tools
 
 
+def _extract_anthropic_cache_tokens(usage: Any) -> tuple[int, int]:
+    """Return ``(cache_read_input_tokens, cache_creation_input_tokens)``.
+
+    Anthropic reports prompt-cache reads and writes as **separate** fields
+    on ``usage`` — they are NOT included in ``input_tokens``. Both default
+    to zero when caching is not used or when the SDK version doesn't
+    populate the fields.
+    """
+    if usage is None:
+        return 0, 0
+
+    def _safe(name: str) -> int:
+        val = getattr(usage, name, 0)
+        if val is None or not isinstance(val, (int, float)):
+            return 0
+        return int(val)
+
+    return _safe("cache_read_input_tokens"), _safe("cache_creation_input_tokens")
+
+
 def _build_anthropic_meta(resp: Any, model: str, total_cost: float) -> dict[str, Any]:
-    prompt_tokens = resp.usage.input_tokens
+    base_input = resp.usage.input_tokens
     completion_tokens = resp.usage.output_tokens
+    cache_read, cache_create = _extract_anthropic_cache_tokens(resp.usage)
+    # Anthropic reports cache reads/writes separately from input_tokens.
+    # Surface a synthesized prompt_tokens that represents the *total* input
+    # tokens consumed (matching how OpenAI reports prompt_tokens), so
+    # downstream tracking and dashboards see comparable numbers.
+    prompt_tokens = base_input + cache_read + cache_create
     return {
         "prompt_tokens": prompt_tokens,
         "completion_tokens": completion_tokens,
         "total_tokens": prompt_tokens + completion_tokens,
+        "cached_prompt_tokens": cache_read,
+        "cache_creation_tokens": cache_create,
         "cost": round(total_cost, 6),
         "raw_response": dict(resp),
         "model_name": model,
@@ -157,6 +185,8 @@ def _build_anthropic_stream_done(
     prompt_tokens: int,
     completion_tokens: int,
     total_cost: float,
+    cached_prompt_tokens: int = 0,
+    cache_creation_tokens: int = 0,
 ) -> dict[str, Any]:
     done_chunk: dict[str, Any] = {
         "type": "done",
@@ -165,6 +195,8 @@ def _build_anthropic_stream_done(
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": prompt_tokens + completion_tokens,
+            "cached_prompt_tokens": cached_prompt_tokens,
+            "cache_creation_tokens": cache_creation_tokens,
             "cost": round(total_cost, 6),
             "raw_response": {},
             "model_name": model,
@@ -293,8 +325,14 @@ class ClaudeDriver(CostMixin, Driver):
         if not text and reasoning_content:
             text = reasoning_content
 
+        cache_read, cache_create = _extract_anthropic_cache_tokens(resp.usage)
         total_cost = self._calculate_cost(
-            "claude", model, resp.usage.input_tokens, resp.usage.output_tokens
+            "claude",
+            model,
+            resp.usage.input_tokens + cache_read + cache_create,
+            resp.usage.output_tokens,
+            cached_tokens=cache_read,
+            cache_creation_tokens=cache_create,
         )
         meta = _build_anthropic_meta(resp, model, total_cost)
 
@@ -357,8 +395,14 @@ class ClaudeDriver(CostMixin, Driver):
 
         resp = client.messages.create(**kwargs)
 
+        cache_read, cache_create = _extract_anthropic_cache_tokens(resp.usage)
         total_cost = self._calculate_cost(
-            "claude", model, resp.usage.input_tokens, resp.usage.output_tokens
+            "claude",
+            model,
+            resp.usage.input_tokens + cache_read + cache_create,
+            resp.usage.output_tokens,
+            cached_tokens=cache_read,
+            cache_creation_tokens=cache_create,
         )
         meta = _build_anthropic_meta(resp, model, total_cost)
 
@@ -405,8 +449,10 @@ class ClaudeDriver(CostMixin, Driver):
 
         full_text = ""
         full_reasoning = ""
-        prompt_tokens = 0
+        base_input = 0
         completion_tokens = 0
+        cache_read = 0
+        cache_create = 0
 
         with client.messages.stream(**kwargs) as stream:
             for event in stream:
@@ -428,9 +474,19 @@ class ClaudeDriver(CostMixin, Driver):
                     elif event.type == "message_start" and hasattr(event, "message"):
                         usage = getattr(event.message, "usage", None)
                         if usage:
-                            prompt_tokens = getattr(usage, "input_tokens", 0)
+                            base_input = getattr(usage, "input_tokens", 0)
+                            cache_read, cache_create = _extract_anthropic_cache_tokens(usage)
 
-        total_cost = self._calculate_cost("claude", model, prompt_tokens, completion_tokens)
+        prompt_tokens = base_input + cache_read + cache_create
+        total_cost = self._calculate_cost(
+            "claude",
+            model,
+            prompt_tokens,
+            completion_tokens,
+            cached_tokens=cache_read,
+            cache_creation_tokens=cache_create,
+        )
         yield _build_anthropic_stream_done(
-            model, full_text, full_reasoning, prompt_tokens, completion_tokens, total_cost
+            model, full_text, full_reasoning, prompt_tokens, completion_tokens, total_cost,
+            cached_prompt_tokens=cache_read, cache_creation_tokens=cache_create,
         )

--- a/prompture/drivers/google_driver.py
+++ b/prompture/drivers/google_driver.py
@@ -103,11 +103,21 @@ class GoogleDriver(CostMixin, Driver):
     def _extract_usage_metadata(self, response: Any, messages: list[dict[str, Any]]) -> dict[str, Any]:
         """Extract token counts from response, falling back to character estimation."""
         usage = getattr(response, "usage_metadata", None)
+        cached_prompt_tokens = 0
         if usage:
             prompt_tokens = getattr(usage, "prompt_token_count", 0) or 0
             completion_tokens = getattr(usage, "candidates_token_count", 0) or 0
             total_tokens = getattr(usage, "total_token_count", 0) or (prompt_tokens + completion_tokens)
-            cost = self._calculate_cost("google", self.model, prompt_tokens, completion_tokens)
+            # Gemini's prompt_token_count includes the cached portion (similar
+            # to OpenAI), so we don't need to add cached_content_token_count
+            # back into prompt_tokens — just surface it for cost discounting.
+            raw_cached = getattr(usage, "cached_content_token_count", 0) or 0
+            if isinstance(raw_cached, (int, float)):
+                cached_prompt_tokens = int(raw_cached)
+            cost = self._calculate_cost(
+                "google", self.model, prompt_tokens, completion_tokens,
+                cached_tokens=cached_prompt_tokens,
+            )
         else:
             # Fallback: estimate from character counts
             total_prompt_chars = 0
@@ -131,6 +141,7 @@ class GoogleDriver(CostMixin, Driver):
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": total_tokens,
+            "cached_prompt_tokens": cached_prompt_tokens,
             "cost": round(cost, 6),
         }
 

--- a/prompture/drivers/grok_driver.py
+++ b/prompture/drivers/grok_driver.py
@@ -99,19 +99,26 @@ class GrokDriver(CostMixin, Driver):
             raise RuntimeError(f"Grok API request failed: {e!s}") from e
 
         # Extract usage info
+        from .moonshot_driver import _extract_moonshot_cached_tokens
+
         usage = resp.get("usage", {})
         prompt_tokens = usage.get("prompt_tokens", 0)
         completion_tokens = usage.get("completion_tokens", 0)
         total_tokens = usage.get("total_tokens", 0)
+        cached_prompt_tokens = _extract_moonshot_cached_tokens(usage)
 
-        # Calculate cost via shared mixin
-        total_cost = self._calculate_cost("grok", model, prompt_tokens, completion_tokens)
+        # Calculate cost via shared mixin (cache hits at cache_read rate)
+        total_cost = self._calculate_cost(
+            "grok", model, prompt_tokens, completion_tokens,
+            cached_tokens=cached_prompt_tokens,
+        )
 
         # Standardized meta object
         meta = {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": total_tokens,
+            "cached_prompt_tokens": cached_prompt_tokens,
             "cost": round(total_cost, 6),
             "raw_response": resp,
             "model_name": model,
@@ -174,16 +181,23 @@ class GrokDriver(CostMixin, Driver):
         except requests.exceptions.RequestException as e:
             raise RuntimeError(f"Grok API request failed: {e!s}") from e
 
+        from .moonshot_driver import _extract_moonshot_cached_tokens
+
         usage = resp.get("usage", {})
         prompt_tokens = usage.get("prompt_tokens", 0)
         completion_tokens = usage.get("completion_tokens", 0)
         total_tokens = usage.get("total_tokens", 0)
-        total_cost = self._calculate_cost("grok", model, prompt_tokens, completion_tokens)
+        cached_prompt_tokens = _extract_moonshot_cached_tokens(usage)
+        total_cost = self._calculate_cost(
+            "grok", model, prompt_tokens, completion_tokens,
+            cached_tokens=cached_prompt_tokens,
+        )
 
         meta = {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": total_tokens,
+            "cached_prompt_tokens": cached_prompt_tokens,
             "cost": round(total_cost, 6),
             "raw_response": resp,
             "model_name": model,

--- a/prompture/drivers/groq_driver.py
+++ b/prompture/drivers/groq_driver.py
@@ -102,19 +102,26 @@ class GroqDriver(CostMixin, Driver):
             raise
 
         # Extract usage statistics
+        from .openai_driver import _extract_openai_cached_tokens
+
         usage = getattr(resp, "usage", None)
         prompt_tokens = getattr(usage, "prompt_tokens", 0)
         completion_tokens = getattr(usage, "completion_tokens", 0)
         total_tokens = getattr(usage, "total_tokens", 0)
+        cached_prompt_tokens = _extract_openai_cached_tokens(usage)
 
-        # Calculate cost via shared mixin
-        total_cost = self._calculate_cost("groq", model, prompt_tokens, completion_tokens)
+        # Calculate cost via shared mixin (cache hits billed at cache_read rate)
+        total_cost = self._calculate_cost(
+            "groq", model, prompt_tokens, completion_tokens,
+            cached_tokens=cached_prompt_tokens,
+        )
 
         # Standard metadata object
         meta = {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": total_tokens,
+            "cached_prompt_tokens": cached_prompt_tokens,
             "cost": round(total_cost, 6),
             "raw_response": resp.model_dump(),
             "model_name": model,
@@ -167,16 +174,23 @@ class GroqDriver(CostMixin, Driver):
 
         resp = self.client.chat.completions.create(**kwargs)
 
+        from .openai_driver import _extract_openai_cached_tokens
+
         usage = getattr(resp, "usage", None)
         prompt_tokens = getattr(usage, "prompt_tokens", 0)
         completion_tokens = getattr(usage, "completion_tokens", 0)
         total_tokens = getattr(usage, "total_tokens", 0)
-        total_cost = self._calculate_cost("groq", model, prompt_tokens, completion_tokens)
+        cached_prompt_tokens = _extract_openai_cached_tokens(usage)
+        total_cost = self._calculate_cost(
+            "groq", model, prompt_tokens, completion_tokens,
+            cached_tokens=cached_prompt_tokens,
+        )
 
         meta = {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": total_tokens,
+            "cached_prompt_tokens": cached_prompt_tokens,
             "cost": round(total_cost, 6),
             "raw_response": resp.model_dump(),
             "model_name": model,

--- a/prompture/drivers/moonshot_driver.py
+++ b/prompture/drivers/moonshot_driver.py
@@ -23,6 +23,31 @@ from .base import Driver, _parse_tool_arguments
 logger = logging.getLogger("prompture.drivers.moonshot")
 
 
+def _extract_moonshot_cached_tokens(usage: dict[str, Any]) -> int:
+    """Return the count of input tokens served from Moonshot's prompt cache.
+
+    Moonshot's OpenAI-compatible API exposes the cache hit count in two
+    places depending on the model and SDK version:
+
+    1. ``usage.cached_tokens`` — direct top-level field (Kimi K2 family)
+    2. ``usage.prompt_tokens_details.cached_tokens`` — OpenAI-shaped nested
+
+    Both shapes are checked. Like OpenAI, Moonshot's ``prompt_tokens``
+    already includes the cached portion, so the resolver only needs to
+    surface the cached count for cost discounting.
+    """
+    if not usage:
+        return 0
+    direct = usage.get("cached_tokens")
+    if isinstance(direct, (int, float)):
+        return int(direct)
+    details = usage.get("prompt_tokens_details") or {}
+    nested = details.get("cached_tokens") if isinstance(details, dict) else None
+    if isinstance(nested, (int, float)):
+        return int(nested)
+    return 0
+
+
 class MoonshotDriver(CostMixin, Driver):
     supports_json_mode = True
     supports_json_schema = True
@@ -250,6 +275,7 @@ class MoonshotDriver(CostMixin, Driver):
         prompt_tokens = usage.get("prompt_tokens", 0)
         completion_tokens = usage.get("completion_tokens", 0)
         total_tokens = usage.get("total_tokens", 0)
+        cached_prompt_tokens = _extract_moonshot_cached_tokens(usage)
 
         message = resp["choices"][0]["message"]
         text = message.get("content") or ""
@@ -298,6 +324,7 @@ class MoonshotDriver(CostMixin, Driver):
                 prompt_tokens += fb_usage.get("prompt_tokens", 0)
                 completion_tokens = fb_usage.get("completion_tokens", 0)
                 total_tokens = prompt_tokens + completion_tokens
+                cached_prompt_tokens += _extract_moonshot_cached_tokens(fb_usage)
                 resp = fb_resp
                 fb_message = fb_resp["choices"][0]["message"]
                 text = fb_message.get("content") or ""
@@ -305,12 +332,16 @@ class MoonshotDriver(CostMixin, Driver):
                 if not text and reasoning_content:
                     text = reasoning_content
 
-        total_cost = self._calculate_cost("moonshot", model, prompt_tokens, completion_tokens)
+        total_cost = self._calculate_cost(
+            "moonshot", model, prompt_tokens, completion_tokens,
+            cached_tokens=cached_prompt_tokens,
+        )
 
         meta = {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": total_tokens,
+            "cached_prompt_tokens": cached_prompt_tokens,
             "cost": round(total_cost, 6),
             "raw_response": resp,
             "model_name": model,
@@ -391,12 +422,17 @@ class MoonshotDriver(CostMixin, Driver):
         prompt_tokens = usage.get("prompt_tokens", 0)
         completion_tokens = usage.get("completion_tokens", 0)
         total_tokens = usage.get("total_tokens", 0)
-        total_cost = self._calculate_cost("moonshot", model, prompt_tokens, completion_tokens)
+        cached_prompt_tokens = _extract_moonshot_cached_tokens(usage)
+        total_cost = self._calculate_cost(
+            "moonshot", model, prompt_tokens, completion_tokens,
+            cached_tokens=cached_prompt_tokens,
+        )
 
         meta = {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": total_tokens,
+            "cached_prompt_tokens": cached_prompt_tokens,
             "cost": round(total_cost, 6),
             "raw_response": resp,
             "model_name": model,
@@ -488,6 +524,7 @@ class MoonshotDriver(CostMixin, Driver):
         full_reasoning = ""
         prompt_tokens = 0
         completion_tokens = 0
+        cached_prompt_tokens = 0
 
         for line in response.iter_lines(decode_unicode=True):
             if not line or not line.startswith("data: "):
@@ -504,6 +541,7 @@ class MoonshotDriver(CostMixin, Driver):
             if usage:
                 prompt_tokens = usage.get("prompt_tokens", 0)
                 completion_tokens = usage.get("completion_tokens", 0)
+                cached_prompt_tokens = _extract_moonshot_cached_tokens(usage)
 
             choices = chunk.get("choices", [])
             if choices:
@@ -519,7 +557,10 @@ class MoonshotDriver(CostMixin, Driver):
                     yield {"type": "delta", "text": content}
 
         total_tokens = prompt_tokens + completion_tokens
-        total_cost = self._calculate_cost("moonshot", model, prompt_tokens, completion_tokens)
+        total_cost = self._calculate_cost(
+            "moonshot", model, prompt_tokens, completion_tokens,
+            cached_tokens=cached_prompt_tokens,
+        )
 
         done_chunk: dict[str, Any] = {
             "type": "done",
@@ -528,6 +569,7 @@ class MoonshotDriver(CostMixin, Driver):
                 "prompt_tokens": prompt_tokens,
                 "completion_tokens": completion_tokens,
                 "total_tokens": total_tokens,
+                "cached_prompt_tokens": cached_prompt_tokens,
                 "cost": round(total_cost, 6),
                 "raw_response": {},
                 "model_name": model,

--- a/prompture/drivers/openai_driver.py
+++ b/prompture/drivers/openai_driver.py
@@ -54,15 +54,32 @@ def _build_openai_json_mode_response_format(json_schema: dict[str, Any]) -> dict
     }
 
 
+def _extract_openai_cached_tokens(usage: Any) -> int:
+    """Return the count of input tokens served from OpenAI's prompt cache.
+
+    Returns 0 when the response carries no ``prompt_tokens_details`` block,
+    which is the case for older models or short prompts that don't trigger
+    automatic caching.
+    """
+    if usage is None:
+        return 0
+    details = getattr(usage, "prompt_tokens_details", None)
+    if details is None:
+        return 0
+    return int(getattr(details, "cached_tokens", 0) or 0)
+
+
 def _extract_openai_meta(resp: Any, model: str, total_cost: float) -> dict[str, Any]:
     usage = getattr(resp, "usage", None)
     prompt_tokens = getattr(usage, "prompt_tokens", 0)
     completion_tokens = getattr(usage, "completion_tokens", 0)
     total_tokens = getattr(usage, "total_tokens", 0)
+    cached_prompt_tokens = _extract_openai_cached_tokens(usage)
     return {
         "prompt_tokens": prompt_tokens,
         "completion_tokens": completion_tokens,
         "total_tokens": total_tokens,
+        "cached_prompt_tokens": cached_prompt_tokens,
         "cost": round(total_cost, 6),
         "raw_response": resp.model_dump(),
         "model_name": model,
@@ -90,6 +107,7 @@ def _build_openai_stream_done(
     prompt_tokens: int,
     completion_tokens: int,
     total_cost: float,
+    cached_prompt_tokens: int = 0,
 ) -> dict[str, Any]:
     return {
         "type": "done",
@@ -98,6 +116,7 @@ def _build_openai_stream_done(
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": prompt_tokens + completion_tokens,
+            "cached_prompt_tokens": cached_prompt_tokens,
             "cost": round(total_cost, 6),
             "raw_response": {},
             "model_name": model,
@@ -182,9 +201,13 @@ class OpenAIDriver(CostMixin, Driver):
 
         resp = self.client.chat.completions.create(**kwargs)
 
-        prompt_tokens = getattr(getattr(resp, "usage", None), "prompt_tokens", 0)
-        completion_tokens = getattr(getattr(resp, "usage", None), "completion_tokens", 0)
-        total_cost = self._calculate_cost("openai", model, prompt_tokens, completion_tokens)
+        usage = getattr(resp, "usage", None)
+        prompt_tokens = getattr(usage, "prompt_tokens", 0)
+        completion_tokens = getattr(usage, "completion_tokens", 0)
+        cached_prompt_tokens = _extract_openai_cached_tokens(usage)
+        total_cost = self._calculate_cost(
+            "openai", model, prompt_tokens, completion_tokens, cached_tokens=cached_prompt_tokens
+        )
         meta = _extract_openai_meta(resp, model, total_cost)
 
         text = resp.choices[0].message.content
@@ -218,9 +241,13 @@ class OpenAIDriver(CostMixin, Driver):
 
         resp = self.client.chat.completions.create(**kwargs)
 
-        prompt_tokens = getattr(getattr(resp, "usage", None), "prompt_tokens", 0)
-        completion_tokens = getattr(getattr(resp, "usage", None), "completion_tokens", 0)
-        total_cost = self._calculate_cost("openai", model, prompt_tokens, completion_tokens)
+        usage = getattr(resp, "usage", None)
+        prompt_tokens = getattr(usage, "prompt_tokens", 0)
+        completion_tokens = getattr(usage, "completion_tokens", 0)
+        cached_prompt_tokens = _extract_openai_cached_tokens(usage)
+        total_cost = self._calculate_cost(
+            "openai", model, prompt_tokens, completion_tokens, cached_tokens=cached_prompt_tokens
+        )
         meta = _extract_openai_meta(resp, model, total_cost)
 
         choice = resp.choices[0]
@@ -269,12 +296,14 @@ class OpenAIDriver(CostMixin, Driver):
         full_text = ""
         prompt_tokens = 0
         completion_tokens = 0
+        cached_prompt_tokens = 0
 
         for chunk in stream:
             # Usage comes in the final chunk
             if getattr(chunk, "usage", None):
                 prompt_tokens = chunk.usage.prompt_tokens or 0
                 completion_tokens = chunk.usage.completion_tokens or 0
+                cached_prompt_tokens = _extract_openai_cached_tokens(chunk.usage)
 
             if chunk.choices:
                 delta = chunk.choices[0].delta
@@ -283,5 +312,9 @@ class OpenAIDriver(CostMixin, Driver):
                     full_text += content
                     yield {"type": "delta", "text": content}
 
-        total_cost = self._calculate_cost("openai", model, prompt_tokens, completion_tokens)
-        yield _build_openai_stream_done(model, full_text, prompt_tokens, completion_tokens, total_cost)
+        total_cost = self._calculate_cost(
+            "openai", model, prompt_tokens, completion_tokens, cached_tokens=cached_prompt_tokens
+        )
+        yield _build_openai_stream_done(
+            model, full_text, prompt_tokens, completion_tokens, total_cost, cached_prompt_tokens
+        )

--- a/prompture/infra/cost_mixin.py
+++ b/prompture/infra/cost_mixin.py
@@ -50,21 +50,49 @@ class CostMixin:
         model: str,
         prompt_tokens: int | float,
         completion_tokens: int | float,
+        *,
+        cached_tokens: int | float = 0,
+        cache_creation_tokens: int | float = 0,
     ) -> float:
         """Calculate USD cost for a generation call.
 
         Uses live rates from ``model_rates.get_model_rates()`` (per 1M tokens).
         Returns 0.0 if no rates are available.
+
+        Provider-side prompt-cache tokens are billed at the discounted
+        ``cache_read`` rate (and ``cache_write`` rate for Anthropic-style
+        cache writes) when the rate is available; otherwise they fall back
+        to the full input rate.
+
+        ``prompt_tokens`` is treated as the *total* prompt token count
+        reported by the provider (which already includes any cached tokens
+        — that's how OpenAI and Anthropic both report it). The cached
+        portion is subtracted out before applying the full input rate.
         """
         from .model_rates import get_model_rates
 
         live_rates = get_model_rates(provider, model)
-        if live_rates and (live_rates.get("input") or live_rates.get("output")):
-            prompt_cost = (prompt_tokens / 1_000_000) * live_rates["input"]
-            completion_cost = (completion_tokens / 1_000_000) * live_rates["output"]
-            return round(prompt_cost + completion_cost, 6)
+        if not live_rates or not (live_rates.get("input") or live_rates.get("output")):
+            return 0.0
 
-        return 0.0
+        input_rate = live_rates.get("input", 0.0)
+        output_rate = live_rates.get("output", 0.0)
+        cache_read_rate = live_rates.get("cache_read", input_rate)
+        cache_write_rate = live_rates.get("cache_write", input_rate)
+
+        cached = max(0, cached_tokens)
+        cache_created = max(0, cache_creation_tokens)
+        # Both cached reads and cache-creation tokens are reported inside
+        # prompt_tokens — strip them out so we don't double-bill.
+        non_cached = max(0, prompt_tokens - cached - cache_created)
+
+        cost = (
+            (non_cached / 1_000_000) * input_rate
+            + (cached / 1_000_000) * cache_read_rate
+            + (cache_created / 1_000_000) * cache_write_rate
+            + (completion_tokens / 1_000_000) * output_rate
+        )
+        return round(cost, 6)
 
     def _get_model_config(self, provider: str, model: str) -> dict[str, Any]:
         """Return per-model configuration from capabilities knowledge base.

--- a/prompture/infra/model_rates.py
+++ b/prompture/infra/model_rates.py
@@ -257,29 +257,19 @@ def _lookup_model(provider: str, model_id: str) -> Optional[dict[str, Any]]:
 def get_model_rates(provider: str, model_id: str) -> Optional[dict[str, float]]:
     """Return pricing dict for a model, or ``None`` if unavailable.
 
+    Resolution is delegated to the pluggable :mod:`pricing` registry —
+    by default the curated local KB (``infra/rates/*.json`` ``cost`` blocks)
+    is consulted first, with models.dev as a fallback. The order can be
+    changed via the ``pricing_source`` setting or by registering custom
+    sources at runtime.
+
     Returned keys mirror models.dev cost fields (per 1M tokens):
     ``input``, ``output``, and optionally ``cache_read``, ``cache_write``,
     ``reasoning``.
     """
-    entry = _lookup_model(provider, model_id)
-    if entry is None:
-        return None
+    from .pricing import resolve_rates
 
-    cost = entry.get("cost")
-    if not isinstance(cost, dict):
-        return None
-
-    rates: dict[str, float] = {}
-    for key in ("input", "output", "cache_read", "cache_write", "reasoning"):
-        val = cost.get(key)
-        if val is not None:
-            with contextlib.suppress(TypeError, ValueError):
-                rates[key] = float(val)
-
-    # Must have at least input and output to be useful
-    if "input" in rates and "output" in rates:
-        return rates
-    return None
+    return resolve_rates(provider, model_id)
 
 
 def get_model_info(provider: str, model_id: str) -> Optional[dict[str, Any]]:

--- a/prompture/infra/pricing.py
+++ b/prompture/infra/pricing.py
@@ -26,7 +26,7 @@ import json
 import logging
 import threading
 from pathlib import Path
-from typing import Any, Optional, Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ class PricingSource(Protocol):
     name: str
     priority: int
 
-    def get_rates(self, provider: str, model_id: str) -> Optional[dict[str, float]]:
+    def get_rates(self, provider: str, model_id: str) -> dict[str, float] | None:
         """Return per-1M rates or ``None`` when the source has no data.
 
         Returned dict should include ``input`` and ``output`` keys (per 1M
@@ -118,7 +118,7 @@ def clear_pricing_sources() -> None:
         _initialized = False
 
 
-def resolve_rates(provider: str, model_id: str) -> Optional[dict[str, float]]:
+def resolve_rates(provider: str, model_id: str) -> dict[str, float] | None:
     """Walk the registry and return the first source's rates for ``(provider, model_id)``.
 
     A source's result is accepted only if it includes both ``input`` and
@@ -142,7 +142,7 @@ def resolve_rates(provider: str, model_id: str) -> Optional[dict[str, float]]:
 _RATES_DIR = Path(__file__).resolve().parent / "rates"
 
 
-def _coerce_rate_dict(raw: Any) -> Optional[dict[str, float]]:
+def _coerce_rate_dict(raw: Any) -> dict[str, float] | None:
     """Turn a ``cost`` block into a clean float dict, or ``None`` if invalid."""
     if not isinstance(raw, dict):
         return None
@@ -197,7 +197,7 @@ class LocalKBPricingSource:
         """Rebuild the in-memory KB from disk."""
         self._kb = _load_local_rates_kb()
 
-    def get_rates(self, provider: str, model_id: str) -> Optional[dict[str, float]]:
+    def get_rates(self, provider: str, model_id: str) -> dict[str, float] | None:
         # Resolve the prompture provider name to its models.dev key (so
         # provider aliases like "claude" → "anthropic" work for both
         # storage forms — but the JSON files are keyed by the prompture
@@ -222,7 +222,7 @@ class ModelsDevPricingSource:
     name = "models_dev"
     priority = 100
 
-    def get_rates(self, provider: str, model_id: str) -> Optional[dict[str, float]]:
+    def get_rates(self, provider: str, model_id: str) -> dict[str, float] | None:
         from .model_rates import _lookup_model
 
         entry = _lookup_model(provider, model_id)
@@ -236,7 +236,7 @@ class ModelsDevPricingSource:
 # ---------------------------------------------------------------------------
 
 
-def _initialize_default_sources(mode: Optional[str] = None) -> None:
+def _initialize_default_sources(mode: str | None = None) -> None:
     """Install built-in sources for the requested mode.
 
     If *mode* is ``None``, reads from ``settings.pricing_source``. Recognised

--- a/prompture/infra/pricing.py
+++ b/prompture/infra/pricing.py
@@ -1,0 +1,284 @@
+"""Pluggable pricing-source registry.
+
+Drivers compute cost via :func:`resolve_rates`, which walks a registry of
+:class:`PricingSource` objects in priority order (lowest first) and returns
+the first source's rates that include both ``input`` and ``output``.
+
+Two sources ship by default:
+
+* :class:`LocalKBPricingSource` — reads ``cost`` blocks from the per-provider
+  JSON files in ``prompture/infra/rates/`` (priority 0). Curated locally so
+  Prompture's pricing isn't held hostage by a stale third-party feed.
+* :class:`ModelsDevPricingSource` — reads pricing from the cached models.dev
+  API data (priority 100). Acts as a fallback for models the local KB hasn't
+  curated yet.
+
+The :attr:`Settings.pricing_source` setting selects which built-ins are
+registered at startup (``"local_first"``, ``"local_only"``,
+``"models_dev_only"``). Custom sources can always be added at runtime via
+:func:`register_pricing_source` regardless of that setting.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import threading
+from pathlib import Path
+from typing import Any, Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+# Per-1M-token rate keys we recognise. Sources may return any subset.
+_RATE_KEYS: tuple[str, ...] = ("input", "output", "cache_read", "cache_write", "reasoning")
+
+
+@runtime_checkable
+class PricingSource(Protocol):
+    """A source of per-1M-token pricing for ``(provider, model_id)`` pairs.
+
+    Implementations must define ``name`` (unique identifier used for
+    deduplication / unregister) and ``priority`` (lower = queried first).
+    The convention is:
+
+    * 0–49   — curated, authoritative sources (e.g. local KB)
+    * 50–99  — third-party feeds you trust
+    * 100+   — best-effort fallbacks (e.g. scraped or auto-imported data)
+    """
+
+    name: str
+    priority: int
+
+    def get_rates(self, provider: str, model_id: str) -> Optional[dict[str, float]]:
+        """Return per-1M rates or ``None`` when the source has no data.
+
+        Returned dict should include ``input`` and ``output`` keys (per 1M
+        tokens, USD); ``cache_read``, ``cache_write``, ``reasoning`` are
+        optional. Sources that can't supply at least input+output should
+        return ``None`` so the resolver can fall through.
+        """
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+_sources: list[PricingSource] = []
+_lock = threading.Lock()
+_initialized = False
+
+
+def register_pricing_source(source: PricingSource, *, replace: bool = False) -> None:
+    """Add *source* to the registry, ordered by ``source.priority``.
+
+    If ``replace`` is true and a source with the same ``name`` already
+    exists, it's removed first.
+
+    Calling this function takes the registry under explicit user control:
+    the lazy bootstrap won't install built-in defaults afterwards. Use
+    :func:`clear_pricing_sources` to release control.
+    """
+    global _initialized
+    with _lock:
+        if replace:
+            _sources[:] = [s for s in _sources if s.name != source.name]
+        elif any(s.name == source.name for s in _sources):
+            raise ValueError(
+                f"Pricing source '{source.name}' is already registered. "
+                "Pass replace=True to overwrite."
+            )
+        _sources.append(source)
+        _sources.sort(key=lambda s: (s.priority, s.name))
+        # User explicitly registered something — suppress lazy defaults
+        # for the rest of this process (or until clear_pricing_sources).
+        _initialized = True
+
+
+def unregister_pricing_source(name: str) -> bool:
+    """Remove the named source. Returns True if anything was removed."""
+    with _lock:
+        before = len(_sources)
+        _sources[:] = [s for s in _sources if s.name != name]
+        return len(_sources) < before
+
+
+def get_pricing_sources() -> list[PricingSource]:
+    """Return a snapshot of the currently registered sources, in priority order."""
+    _ensure_initialized()
+    with _lock:
+        return list(_sources)
+
+
+def clear_pricing_sources() -> None:
+    """Remove all sources. Mainly useful in tests."""
+    global _initialized
+    with _lock:
+        _sources.clear()
+        _initialized = False
+
+
+def resolve_rates(provider: str, model_id: str) -> Optional[dict[str, float]]:
+    """Walk the registry and return the first source's rates for ``(provider, model_id)``.
+
+    A source's result is accepted only if it includes both ``input`` and
+    ``output`` (without those, cost calculation is impossible).
+    """
+    for source in get_pricing_sources():
+        try:
+            rates = source.get_rates(provider, model_id)
+        except Exception:
+            logger.debug("Pricing source %r raised; falling through", source.name, exc_info=True)
+            continue
+        if rates and rates.get("input") is not None and rates.get("output") is not None:
+            return rates
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Built-in sources
+# ---------------------------------------------------------------------------
+
+_RATES_DIR = Path(__file__).resolve().parent / "rates"
+
+
+def _coerce_rate_dict(raw: Any) -> Optional[dict[str, float]]:
+    """Turn a ``cost`` block into a clean float dict, or ``None`` if invalid."""
+    if not isinstance(raw, dict):
+        return None
+    out: dict[str, float] = {}
+    for key in _RATE_KEYS:
+        val = raw.get(key)
+        if val is None:
+            continue
+        with contextlib.suppress(TypeError, ValueError):
+            out[key] = float(val)
+    return out or None
+
+
+def _load_local_rates_kb() -> dict[tuple[str, str], dict[str, float]]:
+    """Build the local-KB pricing index from ``infra/rates/*.json`` files.
+
+    Only entries with a ``cost`` object are included.
+    """
+    kb: dict[tuple[str, str], dict[str, float]] = {}
+    for json_file in sorted(_RATES_DIR.glob("*.json")):
+        provider = json_file.stem
+        try:
+            raw: dict[str, Any] = json.loads(json_file.read_text(encoding="utf-8"))
+        except Exception:
+            logger.warning("Failed to parse %s — skipping", json_file)
+            continue
+        for model_id, entry in raw.items():
+            if not isinstance(entry, dict):
+                continue
+            rates = _coerce_rate_dict(entry.get("cost"))
+            if rates is None:
+                continue
+            if "input" in rates and "output" in rates:
+                kb[(provider, model_id)] = rates
+    return kb
+
+
+class LocalKBPricingSource:
+    """Pricing source backed by the curated JSON files in ``infra/rates/``.
+
+    Entries are loaded once at construction. Call :meth:`reload` after
+    editing the JSON files in a long-running process.
+    """
+
+    name = "local_kb"
+    priority = 0
+
+    def __init__(self) -> None:
+        self._kb: dict[tuple[str, str], dict[str, float]] = _load_local_rates_kb()
+
+    def reload(self) -> None:
+        """Rebuild the in-memory KB from disk."""
+        self._kb = _load_local_rates_kb()
+
+    def get_rates(self, provider: str, model_id: str) -> Optional[dict[str, float]]:
+        # Resolve the prompture provider name to its models.dev key (so
+        # provider aliases like "claude" → "anthropic" work for both
+        # storage forms — but the JSON files are keyed by the prompture
+        # name, so we try that first.)
+        from .model_rates import PROVIDER_MAP, _strip_to_base_model
+
+        for prov in (provider, PROVIDER_MAP.get(provider, provider)):
+            hit = self._kb.get((prov, model_id))
+            if hit is not None:
+                return dict(hit)
+            base = _strip_to_base_model(model_id)
+            if base is not None:
+                hit = self._kb.get((prov, base))
+                if hit is not None:
+                    return dict(hit)
+        return None
+
+
+class ModelsDevPricingSource:
+    """Pricing source backed by the cached models.dev API data."""
+
+    name = "models_dev"
+    priority = 100
+
+    def get_rates(self, provider: str, model_id: str) -> Optional[dict[str, float]]:
+        from .model_rates import _lookup_model
+
+        entry = _lookup_model(provider, model_id)
+        if entry is None:
+            return None
+        return _coerce_rate_dict(entry.get("cost"))
+
+
+# ---------------------------------------------------------------------------
+# Default-source bootstrapping
+# ---------------------------------------------------------------------------
+
+
+def _initialize_default_sources(mode: Optional[str] = None) -> None:
+    """Install built-in sources for the requested mode.
+
+    If *mode* is ``None``, reads from ``settings.pricing_source``. Recognised
+    modes: ``"local_first"`` (default), ``"local_only"``, ``"models_dev_only"``.
+    Unknown values fall back to ``"local_first"`` with a warning.
+
+    Idempotent — calling twice without an intervening
+    :func:`clear_pricing_sources` is a no-op.
+    """
+    global _initialized
+    with _lock:
+        if _initialized:
+            return
+
+        if mode is None:
+            try:
+                from .settings import settings as _settings
+
+                mode = getattr(_settings, "pricing_source", "local_first")
+            except Exception:
+                mode = "local_first"
+
+        if mode not in {"local_first", "local_only", "models_dev_only"}:
+            logger.warning("Unknown pricing_source=%r — falling back to local_first", mode)
+            mode = "local_first"
+
+        # Reset to a clean slate so this can be re-bootstrapped after a
+        # clear_pricing_sources() call (used in tests).
+        _sources.clear()
+
+        if mode == "models_dev_only":
+            _sources.append(ModelsDevPricingSource())
+        else:
+            _sources.append(LocalKBPricingSource())
+            if mode == "local_first":
+                _sources.append(ModelsDevPricingSource())
+
+        _sources.sort(key=lambda s: (s.priority, s.name))
+        _initialized = True
+
+
+def _ensure_initialized() -> None:
+    """Lazily install default sources on first registry access."""
+    if not _initialized:
+        _initialize_default_sources()

--- a/prompture/infra/rates/anthropic.json
+++ b/prompture/infra/rates/anthropic.json
@@ -10,7 +10,13 @@
     "modalities_input": ["text", "image"],
     "modalities_output": ["text"],
     "api_type": "anthropic",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 5.00,
+      "output": 25.00,
+      "cache_read": 0.50,
+      "cache_write": 6.25
+    }
   },
   "claude-opus-4-6": {
     "supports_temperature": true,
@@ -23,7 +29,13 @@
     "modalities_input": ["text", "image"],
     "modalities_output": ["text"],
     "api_type": "anthropic",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 5.00,
+      "output": 25.00,
+      "cache_read": 0.50,
+      "cache_write": 6.25
+    }
   },
   "claude-sonnet-4-6": {
     "supports_temperature": true,
@@ -36,7 +48,13 @@
     "modalities_input": ["text", "image"],
     "modalities_output": ["text"],
     "api_type": "anthropic",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 3.00,
+      "output": 15.00,
+      "cache_read": 0.30,
+      "cache_write": 3.75
+    }
   },
   "claude-haiku-4-5": {
     "supports_temperature": true,
@@ -49,6 +67,12 @@
     "modalities_input": ["text", "image"],
     "modalities_output": ["text"],
     "api_type": "anthropic",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 1.00,
+      "output": 5.00,
+      "cache_read": 0.10,
+      "cache_write": 1.25
+    }
   }
 }

--- a/prompture/infra/rates/google.json
+++ b/prompture/infra/rates/google.json
@@ -10,7 +10,12 @@
     "modalities_input": ["text", "image", "audio", "video"],
     "modalities_output": ["text"],
     "api_type": "google",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 2.00,
+      "output": 12.00,
+      "cache_read": 0.20
+    }
   },
   "gemini-3-flash-preview": {
     "supports_temperature": true,
@@ -23,7 +28,12 @@
     "modalities_input": ["text", "image", "audio", "video"],
     "modalities_output": ["text"],
     "api_type": "google",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 0.50,
+      "output": 3.00,
+      "cache_read": 0.05
+    }
   },
   "gemini-3.1-flash-lite": {
     "supports_temperature": true,
@@ -36,7 +46,12 @@
     "modalities_input": ["text", "image", "audio", "video"],
     "modalities_output": ["text"],
     "api_type": "google",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 0.25,
+      "output": 1.50,
+      "cache_read": 0.025
+    }
   },
   "gemini-2.5-flash-lite": {
     "supports_temperature": true,
@@ -49,7 +64,12 @@
     "modalities_input": ["text", "image", "audio", "video"],
     "modalities_output": ["text"],
     "api_type": "google",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 0.10,
+      "output": 0.40,
+      "cache_read": 0.01
+    }
   },
   "gemini-2.5-pro": {
     "supports_temperature": true,
@@ -62,7 +82,12 @@
     "modalities_input": ["text", "image", "audio", "video"],
     "modalities_output": ["text"],
     "api_type": "google",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 1.25,
+      "output": 10.00,
+      "cache_read": 0.125
+    }
   },
   "gemini-2.5-flash": {
     "supports_temperature": true,
@@ -75,7 +100,12 @@
     "modalities_input": ["text", "image", "audio", "video"],
     "modalities_output": ["text"],
     "api_type": "google",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 0.30,
+      "output": 2.50,
+      "cache_read": 0.03
+    }
   },
   "gemini-2.0-flash": {
     "supports_temperature": true,
@@ -88,7 +118,12 @@
     "modalities_input": ["text", "image", "audio", "video"],
     "modalities_output": ["text", "image"],
     "api_type": "google",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 0.10,
+      "output": 0.40,
+      "cache_read": 0.025
+    }
   },
   "gemini-1.5-pro": {
     "supports_temperature": true,

--- a/prompture/infra/rates/groq.json
+++ b/prompture/infra/rates/groq.json
@@ -10,7 +10,11 @@
     "modalities_input": ["text"],
     "modalities_output": ["text"],
     "api_type": "openai-compatible",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 0.59,
+      "output": 0.79
+    }
   },
   "llama-3.1-8b-instant": {
     "supports_temperature": true,
@@ -23,7 +27,11 @@
     "modalities_input": ["text"],
     "modalities_output": ["text"],
     "api_type": "openai-compatible",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 0.05,
+      "output": 0.08
+    }
   },
   "openai/gpt-oss-120b": {
     "supports_temperature": true,
@@ -36,7 +44,12 @@
     "modalities_input": ["text"],
     "modalities_output": ["text"],
     "api_type": "openai-compatible",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 0.15,
+      "output": 0.60,
+      "cache_read": 0.075
+    }
   },
   "openai/gpt-oss-20b": {
     "supports_temperature": true,
@@ -49,7 +62,12 @@
     "modalities_input": ["text"],
     "modalities_output": ["text"],
     "api_type": "openai-compatible",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 0.075,
+      "output": 0.30,
+      "cache_read": 0.0375
+    }
   },
   "openai/gpt-oss-safeguard-20b": {
     "supports_temperature": true,
@@ -62,7 +80,12 @@
     "modalities_input": ["text"],
     "modalities_output": ["text"],
     "api_type": "openai-compatible",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 0.075,
+      "output": 0.30,
+      "cache_read": 0.0375
+    }
   },
   "meta-llama/llama-4-scout-17b-16e-instruct": {
     "supports_temperature": true,
@@ -75,7 +98,11 @@
     "modalities_input": ["text", "image"],
     "modalities_output": ["text"],
     "api_type": "openai-compatible",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 0.11,
+      "output": 0.34
+    }
   },
   "qwen/qwen3-32b": {
     "supports_temperature": true,
@@ -88,7 +115,11 @@
     "modalities_input": ["text"],
     "modalities_output": ["text"],
     "api_type": "openai-compatible",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 0.29,
+      "output": 0.59
+    }
   },
   "moonshotai/kimi-k2-instruct-0905": {
     "supports_temperature": true,
@@ -101,7 +132,12 @@
     "modalities_input": ["text"],
     "modalities_output": ["text"],
     "api_type": "openai-compatible",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 1.00,
+      "output": 3.00,
+      "cache_read": 0.50
+    }
   },
   "qwen-qwq-32b": {
     "supports_temperature": true,

--- a/prompture/infra/rates/moonshot.json
+++ b/prompture/infra/rates/moonshot.json
@@ -36,7 +36,12 @@
     "modalities_input": ["text"],
     "modalities_output": ["text"],
     "api_type": "openai-compatible",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 0.60,
+      "output": 2.50,
+      "cache_read": 0.15
+    }
   },
   "kimi-k2-0711-preview": {
     "supports_temperature": true,
@@ -49,7 +54,12 @@
     "modalities_input": ["text"],
     "modalities_output": ["text"],
     "api_type": "openai-compatible",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 0.60,
+      "output": 2.50,
+      "cache_read": 0.15
+    }
   },
   "kimi-k2-thinking": {
     "supports_temperature": true,
@@ -62,7 +72,12 @@
     "modalities_input": ["text"],
     "modalities_output": ["text"],
     "api_type": "openai-compatible",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 0.60,
+      "output": 2.50,
+      "cache_read": 0.15
+    }
   },
   "kimi-k2-thinking-turbo": {
     "supports_temperature": true,
@@ -75,7 +90,12 @@
     "modalities_input": ["text"],
     "modalities_output": ["text"],
     "api_type": "openai-compatible",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 1.15,
+      "output": 8.00,
+      "cache_read": 0.15
+    }
   },
   "kimi-k2-turbo-preview": {
     "supports_temperature": true,
@@ -88,6 +108,11 @@
     "modalities_input": ["text"],
     "modalities_output": ["text"],
     "api_type": "openai-compatible",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 1.15,
+      "output": 8.00,
+      "cache_read": 0.15
+    }
   }
 }

--- a/prompture/infra/rates/openai.json
+++ b/prompture/infra/rates/openai.json
@@ -10,7 +10,12 @@
     "modalities_input": ["text", "image"],
     "modalities_output": ["text"],
     "api_type": "openai",
-    "tokens_param": "max_completion_tokens"
+    "tokens_param": "max_completion_tokens",
+    "cost": {
+      "input": 5.00,
+      "output": 30.00,
+      "cache_read": 0.50
+    }
   },
   "gpt-5.5-pro": {
     "supports_temperature": false,
@@ -23,7 +28,11 @@
     "modalities_input": ["text", "image"],
     "modalities_output": ["text"],
     "api_type": "openai",
-    "tokens_param": "max_completion_tokens"
+    "tokens_param": "max_completion_tokens",
+    "cost": {
+      "input": 30.00,
+      "output": 180.00
+    }
   },
   "gpt-5-nano": {
     "supports_temperature": false,
@@ -49,7 +58,12 @@
     "modalities_input": ["text", "image"],
     "modalities_output": ["text"],
     "api_type": "openai",
-    "tokens_param": "max_completion_tokens"
+    "tokens_param": "max_completion_tokens",
+    "cost": {
+      "input": 2.50,
+      "output": 15.00,
+      "cache_read": 0.25
+    }
   },
   "gpt-5.2": {
     "supports_temperature": true,

--- a/prompture/infra/rates/xai.json
+++ b/prompture/infra/rates/xai.json
@@ -10,7 +10,12 @@
     "modalities_input": ["text", "image"],
     "modalities_output": ["text"],
     "api_type": "openai-compatible",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 1.25,
+      "output": 2.50,
+      "cache_read": 0.25
+    }
   },
   "grok-4.20-0309-reasoning": {
     "supports_temperature": true,
@@ -23,7 +28,12 @@
     "modalities_input": ["text", "image"],
     "modalities_output": ["text"],
     "api_type": "openai-compatible",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 1.25,
+      "output": 2.50,
+      "cache_read": 0.25
+    }
   },
   "grok-4.20-0309-non-reasoning": {
     "supports_temperature": true,
@@ -36,7 +46,12 @@
     "modalities_input": ["text", "image"],
     "modalities_output": ["text"],
     "api_type": "openai-compatible",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 1.25,
+      "output": 2.50,
+      "cache_read": 0.25
+    }
   },
   "grok-4.20-multi-agent-0309": {
     "supports_temperature": true,
@@ -49,7 +64,12 @@
     "modalities_input": ["text", "image"],
     "modalities_output": ["text"],
     "api_type": "openai-compatible",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 1.25,
+      "output": 2.50,
+      "cache_read": 0.25
+    }
   },
   "grok-4-1-fast-reasoning": {
     "supports_temperature": true,
@@ -62,7 +82,12 @@
     "modalities_input": ["text", "image"],
     "modalities_output": ["text"],
     "api_type": "openai-compatible",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 0.20,
+      "output": 0.50,
+      "cache_read": 0.04
+    }
   },
   "grok-4-1-fast-non-reasoning": {
     "supports_temperature": true,
@@ -75,7 +100,12 @@
     "modalities_input": ["text", "image"],
     "modalities_output": ["text"],
     "api_type": "openai-compatible",
-    "tokens_param": "max_tokens"
+    "tokens_param": "max_tokens",
+    "cost": {
+      "input": 0.20,
+      "output": 0.50,
+      "cache_read": 0.04
+    }
   },
   "grok-3": {
     "supports_temperature": true,

--- a/prompture/infra/settings.py
+++ b/prompture/infra/settings.py
@@ -103,6 +103,15 @@ class Settings(BaseSettings):
     # Model rates cache
     model_rates_ttl_days: int = 7  # How often to refresh models.dev cache
 
+    # Pricing source resolution. Controls which built-in pricing sources are
+    # registered at startup. Custom sources can always be added via
+    # ``prompture.infra.pricing.register_pricing_source(...)`` regardless of
+    # this setting.
+    #   "local_first"      — local KB first, then models.dev fallback (default)
+    #   "local_only"       — only the local KB; missing models report no cost
+    #   "models_dev_only"  — only models.dev (legacy behaviour)
+    pricing_source: str = "local_first"
+
     # Usage tracking
     usage_tracking_enabled: bool = False
     usage_db_path: Optional[str] = None  # default ~/.prompture/usage/usage.db

--- a/prompture/infra/tracker.py
+++ b/prompture/infra/tracker.py
@@ -57,6 +57,7 @@ class UsageEvent:
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
+    cached_prompt_tokens: int = 0
     cost: float = 0.0
     elapsed_ms: float = 0.0
     session_id: str | None = None
@@ -132,6 +133,7 @@ CREATE TABLE IF NOT EXISTS usage_events (
     prompt_tokens     INTEGER DEFAULT 0,
     completion_tokens INTEGER DEFAULT 0,
     total_tokens      INTEGER DEFAULT 0,
+    cached_prompt_tokens INTEGER DEFAULT 0,
     cost              REAL DEFAULT 0.0,
     elapsed_ms        REAL DEFAULT 0.0,
     session_id        TEXT,
@@ -224,11 +226,22 @@ CREATE VIEW IF NOT EXISTS model_usage AS
 _INSERT_SQL = """
 INSERT INTO usage_events (
     id, timestamp, model_name, provider, api_key_hash,
-    prompt_tokens, completion_tokens, total_tokens, cost, elapsed_ms,
+    prompt_tokens, completion_tokens, total_tokens, cached_prompt_tokens,
+    cost, elapsed_ms,
     session_id, conversation_id, agent_id, tool_name, operation,
     cache_hit, status, error_type, tags, metadata
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 """
+
+# Column additions applied to existing databases via ALTER TABLE.
+# Each entry is (column_name, "ALTER TABLE ... ADD COLUMN ..." statement).
+# Failures are ignored (column already exists), so this is idempotent.
+_SCHEMA_MIGRATIONS: list[tuple[str, str]] = [
+    (
+        "cached_prompt_tokens",
+        "ALTER TABLE usage_events ADD COLUMN cached_prompt_tokens INTEGER DEFAULT 0",
+    ),
+]
 
 
 # ---------------------------------------------------------------------------
@@ -288,6 +301,15 @@ class UsageTracker:
                 try:
                     conn.execute("PRAGMA journal_mode=WAL")
                     conn.executescript(_SCHEMA_SQL)
+                    # Apply additive column migrations for older DBs.
+                    for _col, ddl in _SCHEMA_MIGRATIONS:
+                        try:
+                            conn.execute(ddl)
+                        except sqlite3.OperationalError:
+                            # Column already exists on a fresh DB created from
+                            # _SCHEMA_SQL above, or the migration was already
+                            # applied — both fine.
+                            pass
                     conn.commit()
                 finally:
                     conn.close()
@@ -356,6 +378,7 @@ class UsageTracker:
                             e.prompt_tokens,
                             e.completion_tokens,
                             e.total_tokens,
+                            e.cached_prompt_tokens,
                             e.cost,
                             e.elapsed_ms,
                             e.session_id,
@@ -729,6 +752,7 @@ class UsageTracker:
                 prompt_tokens=meta.get("prompt_tokens", 0),
                 completion_tokens=meta.get("completion_tokens", 0),
                 total_tokens=meta.get("total_tokens", 0),
+                cached_prompt_tokens=meta.get("cached_prompt_tokens", 0),
                 cost=meta.get("cost", 0.0),
                 elapsed_ms=info.get("elapsed_ms", 0.0),
                 session_id=ctx.get("session_id"),

--- a/prompture/infra/tracker.py
+++ b/prompture/infra/tracker.py
@@ -308,14 +308,12 @@ class UsageTracker:
                     conn.execute("PRAGMA journal_mode=WAL")
                     conn.executescript(_SCHEMA_SQL)
                     # Apply additive column migrations for older DBs.
+                    # OperationalError means the column already exists on a
+                    # fresh DB created from _SCHEMA_SQL above, or the
+                    # migration was already applied — both fine.
                     for _col, ddl in _SCHEMA_MIGRATIONS:
-                        try:
+                        with contextlib.suppress(sqlite3.OperationalError):
                             conn.execute(ddl)
-                        except sqlite3.OperationalError:
-                            # Column already exists on a fresh DB created from
-                            # _SCHEMA_SQL above, or the migration was already
-                            # applied — both fine.
-                            pass
                     conn.commit()
                 finally:
                     conn.close()

--- a/prompture/infra/tracker.py
+++ b/prompture/infra/tracker.py
@@ -58,6 +58,7 @@ class UsageEvent:
     completion_tokens: int = 0
     total_tokens: int = 0
     cached_prompt_tokens: int = 0
+    cache_creation_tokens: int = 0
     cost: float = 0.0
     elapsed_ms: float = 0.0
     session_id: str | None = None
@@ -134,6 +135,7 @@ CREATE TABLE IF NOT EXISTS usage_events (
     completion_tokens INTEGER DEFAULT 0,
     total_tokens      INTEGER DEFAULT 0,
     cached_prompt_tokens INTEGER DEFAULT 0,
+    cache_creation_tokens INTEGER DEFAULT 0,
     cost              REAL DEFAULT 0.0,
     elapsed_ms        REAL DEFAULT 0.0,
     session_id        TEXT,
@@ -227,10 +229,10 @@ _INSERT_SQL = """
 INSERT INTO usage_events (
     id, timestamp, model_name, provider, api_key_hash,
     prompt_tokens, completion_tokens, total_tokens, cached_prompt_tokens,
-    cost, elapsed_ms,
+    cache_creation_tokens, cost, elapsed_ms,
     session_id, conversation_id, agent_id, tool_name, operation,
     cache_hit, status, error_type, tags, metadata
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 """
 
 # Column additions applied to existing databases via ALTER TABLE.
@@ -240,6 +242,10 @@ _SCHEMA_MIGRATIONS: list[tuple[str, str]] = [
     (
         "cached_prompt_tokens",
         "ALTER TABLE usage_events ADD COLUMN cached_prompt_tokens INTEGER DEFAULT 0",
+    ),
+    (
+        "cache_creation_tokens",
+        "ALTER TABLE usage_events ADD COLUMN cache_creation_tokens INTEGER DEFAULT 0",
     ),
 ]
 
@@ -379,6 +385,7 @@ class UsageTracker:
                             e.completion_tokens,
                             e.total_tokens,
                             e.cached_prompt_tokens,
+                            e.cache_creation_tokens,
                             e.cost,
                             e.elapsed_ms,
                             e.session_id,
@@ -753,6 +760,7 @@ class UsageTracker:
                 completion_tokens=meta.get("completion_tokens", 0),
                 total_tokens=meta.get("total_tokens", 0),
                 cached_prompt_tokens=meta.get("cached_prompt_tokens", 0),
+                cache_creation_tokens=meta.get("cache_creation_tokens", 0),
                 cost=meta.get("cost", 0.0),
                 elapsed_ms=info.get("elapsed_ms", 0.0),
                 session_id=ctx.get("session_id"),

--- a/tests/test_cached_tokens.py
+++ b/tests/test_cached_tokens.py
@@ -1,9 +1,14 @@
-"""Tests for provider-side prompt-cache token tracking (OpenAI).
+"""Tests for provider-side prompt-cache token tracking.
 
 Covers:
-- Cost calculation discounts cached input tokens at the cache_read rate.
+- Cost calculation discounts cached input tokens at the cache_read rate
+  and bills cache-creation tokens at the cache_write rate.
 - The OpenAI driver extracts ``prompt_tokens_details.cached_tokens`` into meta.
-- Cached tokens flow through the meta dict into the SQLite usage tracker.
+- The Anthropic driver extracts ``cache_read_input_tokens`` and
+  ``cache_creation_input_tokens`` into meta and synthesizes a total
+  ``prompt_tokens`` consistent with OpenAI semantics.
+- Cached / cache-creation tokens flow through the meta dict into the
+  SQLite usage tracker.
 """
 
 from __future__ import annotations
@@ -12,6 +17,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from prompture.drivers.claude_driver import (
+    _build_anthropic_meta,
+    _extract_anthropic_cache_tokens,
+)
 from prompture.drivers.openai_driver import (
     OpenAIDriver,
     _extract_openai_cached_tokens,
@@ -206,8 +215,26 @@ class TestTrackerCachedPromptTokens:
 
         rows = tracker.query()
         assert rows[0]["cached_prompt_tokens"] == 0
+        assert rows[0]["cache_creation_tokens"] == 0
 
-    def test_alter_migration_adds_column_to_old_db(self, tmp_path):
+    def test_record_and_query_cache_creation_tokens(self, tmp_path):
+        tracker = UsageTracker(db_path=tmp_path / "usage.db", flush_threshold=1)
+        tracker.record(
+            UsageEvent(
+                model_name="claude/opus-4-7",
+                provider="claude",
+                prompt_tokens=2500,
+                cached_prompt_tokens=1500,
+                cache_creation_tokens=500,
+                completion_tokens=300,
+                total_tokens=2800,
+            )
+        )
+        rows = tracker.query()
+        assert rows[0]["cached_prompt_tokens"] == 1500
+        assert rows[0]["cache_creation_tokens"] == 500
+
+    def test_alter_migration_adds_cached_prompt_tokens_to_old_db(self, tmp_path):
         """A pre-existing DB without cached_prompt_tokens should be migrated."""
         import sqlite3
 
@@ -258,3 +285,87 @@ class TestTrackerCachedPromptTokens:
 
         rows = tracker.query()
         assert rows[0]["cached_prompt_tokens"] == 150
+
+
+# ---------------------------------------------------------------------------
+# Anthropic / Claude
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicCacheExtraction:
+    """Anthropic returns cache reads/writes as separate fields, not folded
+    into ``input_tokens``. The driver must surface them and synthesize a
+    total ``prompt_tokens`` for downstream consistency."""
+
+    def test_extract_returns_zero_when_usage_missing(self):
+        assert _extract_anthropic_cache_tokens(None) == (0, 0)
+
+    def test_extract_returns_zero_when_fields_absent(self):
+        usage = MagicMock(spec=["input_tokens", "output_tokens"])
+        usage.cache_read_input_tokens = None
+        usage.cache_creation_input_tokens = None
+        assert _extract_anthropic_cache_tokens(usage) == (0, 0)
+
+    def test_extract_returns_both_fields_when_present(self):
+        usage = MagicMock()
+        usage.cache_read_input_tokens = 1500
+        usage.cache_creation_input_tokens = 500
+        assert _extract_anthropic_cache_tokens(usage) == (1500, 500)
+
+    def test_meta_synthesises_total_prompt_tokens(self):
+        # input_tokens=200, cache_read=1500, cache_create=500 → prompt_tokens=2200
+        resp = MagicMock()
+        resp.usage.input_tokens = 200
+        resp.usage.output_tokens = 300
+        resp.usage.cache_read_input_tokens = 1500
+        resp.usage.cache_creation_input_tokens = 500
+
+        meta = _build_anthropic_meta(resp, "claude-opus-4-7", 0.0)
+
+        assert meta["prompt_tokens"] == 2200  # base + cache_read + cache_create
+        assert meta["cached_prompt_tokens"] == 1500
+        assert meta["cache_creation_tokens"] == 500
+        assert meta["completion_tokens"] == 300
+        assert meta["total_tokens"] == 2500
+
+    def test_meta_with_no_cache_activity(self):
+        resp = MagicMock()
+        resp.usage.input_tokens = 100
+        resp.usage.output_tokens = 50
+        resp.usage.cache_read_input_tokens = 0
+        resp.usage.cache_creation_input_tokens = 0
+
+        meta = _build_anthropic_meta(resp, "claude-haiku-4-5", 0.0)
+
+        assert meta["prompt_tokens"] == 100
+        assert meta["cached_prompt_tokens"] == 0
+        assert meta["cache_creation_tokens"] == 0
+
+
+class TestAnthropicCostBilling:
+    """Cost should bill input / cache_read / cache_write at the right rates."""
+
+    @patch("prompture.infra.model_rates.get_model_rates")
+    def test_cost_bills_three_buckets_correctly(self, mock_rates):
+        # Claude Opus 4.7 rates (per 1M tokens)
+        mock_rates.return_value = {
+            "input": 5.00,
+            "output": 25.00,
+            "cache_read": 0.50,
+            "cache_write": 6.25,
+        }
+        mixin = CostMixin()
+
+        # Synthetic prompt_tokens = 100 input + 1500 cache_read + 500 cache_create = 2100
+        cost = mixin._calculate_cost(
+            "claude",
+            "claude-opus-4-7",
+            2100,
+            300,
+            cached_tokens=1500,
+            cache_creation_tokens=500,
+        )
+
+        # 100 * 5 + 1500 * 0.5 + 500 * 6.25 + 300 * 25 = 500 + 750 + 3125 + 7500 = 11875
+        # Per 1M → $0.011875
+        assert cost == pytest.approx(0.011875, abs=1e-9)

--- a/tests/test_cached_tokens.py
+++ b/tests/test_cached_tokens.py
@@ -21,6 +21,7 @@ from prompture.drivers.claude_driver import (
     _build_anthropic_meta,
     _extract_anthropic_cache_tokens,
 )
+from prompture.drivers.moonshot_driver import _extract_moonshot_cached_tokens
 from prompture.drivers.openai_driver import (
     OpenAIDriver,
     _extract_openai_cached_tokens,
@@ -369,3 +370,90 @@ class TestAnthropicCostBilling:
         # 100 * 5 + 1500 * 0.5 + 500 * 6.25 + 300 * 25 = 500 + 750 + 3125 + 7500 = 11875
         # Per 1M → $0.011875
         assert cost == pytest.approx(0.011875, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Moonshot / Kimi
+# ---------------------------------------------------------------------------
+
+
+class TestMoonshotCacheExtraction:
+    """Moonshot exposes cached tokens either as ``usage.cached_tokens`` or as
+    OpenAI-shaped ``usage.prompt_tokens_details.cached_tokens``."""
+
+    def test_returns_zero_when_usage_empty(self):
+        assert _extract_moonshot_cached_tokens({}) == 0
+        assert _extract_moonshot_cached_tokens(None) == 0  # type: ignore[arg-type]
+
+    def test_extracts_top_level_cached_tokens(self):
+        usage = {"prompt_tokens": 1000, "completion_tokens": 50, "cached_tokens": 800}
+        assert _extract_moonshot_cached_tokens(usage) == 800
+
+    def test_extracts_openai_shaped_nested_cached_tokens(self):
+        usage = {
+            "prompt_tokens": 1000,
+            "completion_tokens": 50,
+            "prompt_tokens_details": {"cached_tokens": 600},
+        }
+        assert _extract_moonshot_cached_tokens(usage) == 600
+
+    def test_returns_zero_when_neither_field_present(self):
+        usage = {"prompt_tokens": 100, "completion_tokens": 50}
+        assert _extract_moonshot_cached_tokens(usage) == 0
+
+
+# ---------------------------------------------------------------------------
+# Google / Gemini
+# ---------------------------------------------------------------------------
+
+
+class TestGoogleCacheExtraction:
+    """Gemini's ``usage_metadata`` includes cached_content_token_count when
+    implicit/explicit caching is active."""
+
+    def test_extract_usage_metadata_returns_cached(self):
+        from prompture.drivers.google_driver import GoogleDriver
+
+        driver = GoogleDriver.__new__(GoogleDriver)
+        driver.model = "gemini-2.5-flash"
+
+        usage = MagicMock()
+        usage.prompt_token_count = 1000
+        usage.candidates_token_count = 50
+        usage.total_token_count = 1050
+        usage.cached_content_token_count = 700
+
+        response = MagicMock()
+        response.usage_metadata = usage
+        response.text = "ok"
+
+        with patch.object(driver, "_calculate_cost", return_value=0.0123) as mock_cost:
+            meta = driver._extract_usage_metadata(response, [])
+
+        assert meta["prompt_tokens"] == 1000
+        assert meta["cached_prompt_tokens"] == 700
+        # Verify cost was called with the cache discount
+        mock_cost.assert_called_once_with(
+            "google", "gemini-2.5-flash", 1000, 50, cached_tokens=700
+        )
+
+    def test_extract_usage_metadata_with_no_cache(self):
+        from prompture.drivers.google_driver import GoogleDriver
+
+        driver = GoogleDriver.__new__(GoogleDriver)
+        driver.model = "gemini-2.5-pro"
+
+        usage = MagicMock()
+        usage.prompt_token_count = 200
+        usage.candidates_token_count = 100
+        usage.total_token_count = 300
+        usage.cached_content_token_count = 0
+
+        response = MagicMock()
+        response.usage_metadata = usage
+        response.text = "ok"
+
+        with patch.object(driver, "_calculate_cost", return_value=0.0):
+            meta = driver._extract_usage_metadata(response, [])
+
+        assert meta["cached_prompt_tokens"] == 0

--- a/tests/test_cached_tokens.py
+++ b/tests/test_cached_tokens.py
@@ -1,0 +1,260 @@
+"""Tests for provider-side prompt-cache token tracking (OpenAI).
+
+Covers:
+- Cost calculation discounts cached input tokens at the cache_read rate.
+- The OpenAI driver extracts ``prompt_tokens_details.cached_tokens`` into meta.
+- Cached tokens flow through the meta dict into the SQLite usage tracker.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from prompture.drivers.openai_driver import (
+    OpenAIDriver,
+    _extract_openai_cached_tokens,
+    _extract_openai_meta,
+)
+from prompture.infra.cost_mixin import CostMixin
+from prompture.infra.tracker import UsageEvent, UsageTracker
+
+
+# ---------------------------------------------------------------------------
+# CostMixin._calculate_cost — cache_read discount math
+# ---------------------------------------------------------------------------
+
+
+class TestCostCalcWithCachedTokens:
+    """``_calculate_cost`` should bill cached tokens at the cache_read rate."""
+
+    def _bare_mixin(self) -> CostMixin:
+        return CostMixin()
+
+    @patch("prompture.infra.model_rates.get_model_rates")
+    def test_cached_tokens_use_cache_read_rate(self, mock_rates):
+        mock_rates.return_value = {
+            "input": 10.0,    # $10 / 1M
+            "output": 30.0,   # $30 / 1M
+            "cache_read": 1.0,  # $1 / 1M (10% of input)
+        }
+        mixin = self._bare_mixin()
+
+        # 1000 prompt tokens, 800 of them cached; 500 completion
+        cost = mixin._calculate_cost(
+            "openai", "gpt-4o", 1000, 500, cached_tokens=800
+        )
+
+        # non_cached = 200 → 200/1M * 10 = 0.002
+        # cached = 800 → 800/1M * 1 = 0.0008
+        # completion = 500 → 500/1M * 30 = 0.015
+        # total = 0.0178
+        assert cost == pytest.approx(0.0178, abs=1e-9)
+
+    @patch("prompture.infra.model_rates.get_model_rates")
+    def test_no_cached_tokens_matches_old_behavior(self, mock_rates):
+        mock_rates.return_value = {"input": 10.0, "output": 30.0, "cache_read": 1.0}
+        mixin = self._bare_mixin()
+
+        cost_with_zero_cached = mixin._calculate_cost(
+            "openai", "gpt-4o", 1000, 500, cached_tokens=0
+        )
+        cost_default = mixin._calculate_cost("openai", "gpt-4o", 1000, 500)
+
+        assert cost_with_zero_cached == cost_default
+        # 1000/1M * 10 + 500/1M * 30 = 0.01 + 0.015 = 0.025
+        assert cost_default == pytest.approx(0.025, abs=1e-9)
+
+    @patch("prompture.infra.model_rates.get_model_rates")
+    def test_falls_back_to_input_rate_when_no_cache_read_rate(self, mock_rates):
+        # Model has no cache_read rate published → cached tokens billed at full input.
+        mock_rates.return_value = {"input": 10.0, "output": 30.0}
+        mixin = self._bare_mixin()
+
+        cost = mixin._calculate_cost(
+            "openai", "some-model", 1000, 500, cached_tokens=800
+        )
+        # Effectively: 1000/1M * 10 + 500/1M * 30 = 0.025
+        assert cost == pytest.approx(0.025, abs=1e-9)
+
+    @patch("prompture.infra.model_rates.get_model_rates")
+    def test_zero_rates_returns_zero(self, mock_rates):
+        mock_rates.return_value = None
+        mixin = self._bare_mixin()
+        assert mixin._calculate_cost("openai", "x", 1000, 500, cached_tokens=400) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _extract_openai_cached_tokens / _extract_openai_meta
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIMetaExtraction:
+    """The OpenAI driver should pull cached_tokens out of ``prompt_tokens_details``."""
+
+    def test_extract_returns_zero_when_usage_missing(self):
+        assert _extract_openai_cached_tokens(None) == 0
+
+    def test_extract_returns_zero_when_details_missing(self):
+        usage = MagicMock(spec=["prompt_tokens", "completion_tokens", "total_tokens"])
+        # spec excludes prompt_tokens_details → getattr returns the default
+        usage.prompt_tokens_details = None
+        assert _extract_openai_cached_tokens(usage) == 0
+
+    def test_extract_returns_cached_tokens_when_present(self):
+        usage = MagicMock()
+        usage.prompt_tokens_details.cached_tokens = 512
+        assert _extract_openai_cached_tokens(usage) == 512
+
+    def test_meta_includes_cached_prompt_tokens_zero_by_default(self):
+        resp = MagicMock()
+        resp.usage.prompt_tokens = 100
+        resp.usage.completion_tokens = 50
+        resp.usage.total_tokens = 150
+        resp.usage.prompt_tokens_details = None
+        resp.model_dump.return_value = {}
+
+        meta = _extract_openai_meta(resp, "gpt-4o", 0.01)
+        assert meta["cached_prompt_tokens"] == 0
+
+    def test_meta_includes_cached_prompt_tokens_when_set(self):
+        resp = MagicMock()
+        resp.usage.prompt_tokens = 1000
+        resp.usage.completion_tokens = 50
+        resp.usage.total_tokens = 1050
+        resp.usage.prompt_tokens_details.cached_tokens = 800
+        resp.model_dump.return_value = {}
+
+        meta = _extract_openai_meta(resp, "gpt-4o", 0.01)
+        assert meta["cached_prompt_tokens"] == 800
+        assert meta["prompt_tokens"] == 1000
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: OpenAIDriver.generate with mocked client
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIDriverEndToEnd:
+    """Hit the driver with a mocked OpenAI client and verify meta + cost."""
+
+    @patch("prompture.infra.model_rates.get_model_rates")
+    def test_generate_records_cached_prompt_tokens_in_meta(self, mock_rates):
+        mock_rates.return_value = {
+            "input": 10.0, "output": 30.0, "cache_read": 1.0,
+        }
+
+        driver = OpenAIDriver.__new__(OpenAIDriver)
+        driver.api_key = "test"
+        driver.model = "gpt-4o"
+
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock()]
+        mock_resp.choices[0].message.content = "hello"
+        mock_resp.usage.prompt_tokens = 1000
+        mock_resp.usage.completion_tokens = 500
+        mock_resp.usage.total_tokens = 1500
+        mock_resp.usage.prompt_tokens_details.cached_tokens = 800
+        mock_resp.model_dump.return_value = {}
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_resp
+        driver.client = mock_client
+
+        # Bypass models.dev capability validation noise
+        with patch.object(driver, "_validate_model_capabilities"):
+            result = driver.generate("test", {})
+
+        meta = result["meta"]
+        assert meta["cached_prompt_tokens"] == 800
+        assert meta["prompt_tokens"] == 1000
+        # Cost should reflect the cache discount: 0.0178 (see TestCostCalc above)
+        assert meta["cost"] == pytest.approx(0.0178, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Tracker persistence
+# ---------------------------------------------------------------------------
+
+
+class TestTrackerCachedPromptTokens:
+    """``cached_prompt_tokens`` should round-trip through the SQLite tracker."""
+
+    def test_record_and_query_cached_prompt_tokens(self, tmp_path):
+        tracker = UsageTracker(db_path=tmp_path / "usage.db", flush_threshold=1)
+        tracker.record(
+            UsageEvent(
+                model_name="openai/gpt-4o",
+                provider="openai",
+                prompt_tokens=1000,
+                cached_prompt_tokens=800,
+                completion_tokens=500,
+                total_tokens=1500,
+                cost=0.0178,
+            )
+        )
+
+        rows = tracker.query()
+        assert len(rows) == 1
+        assert rows[0]["cached_prompt_tokens"] == 800
+        assert rows[0]["prompt_tokens"] == 1000
+
+    def test_default_cached_prompt_tokens_is_zero(self, tmp_path):
+        tracker = UsageTracker(db_path=tmp_path / "usage.db", flush_threshold=1)
+        tracker.record(UsageEvent(model_name="x", provider="x"))
+
+        rows = tracker.query()
+        assert rows[0]["cached_prompt_tokens"] == 0
+
+    def test_alter_migration_adds_column_to_old_db(self, tmp_path):
+        """A pre-existing DB without cached_prompt_tokens should be migrated."""
+        import sqlite3
+
+        db_path = tmp_path / "old_usage.db"
+        # Build a minimal "old" schema without the cached_prompt_tokens column.
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute(
+                """
+                CREATE TABLE usage_events (
+                    id TEXT PRIMARY KEY,
+                    timestamp TEXT NOT NULL,
+                    model_name TEXT NOT NULL,
+                    provider TEXT NOT NULL,
+                    api_key_hash TEXT DEFAULT '',
+                    prompt_tokens INTEGER DEFAULT 0,
+                    completion_tokens INTEGER DEFAULT 0,
+                    total_tokens INTEGER DEFAULT 0,
+                    cost REAL DEFAULT 0.0,
+                    elapsed_ms REAL DEFAULT 0.0,
+                    session_id TEXT,
+                    conversation_id TEXT,
+                    agent_id TEXT,
+                    tool_name TEXT,
+                    operation TEXT,
+                    cache_hit INTEGER DEFAULT 0,
+                    status TEXT DEFAULT 'success',
+                    error_type TEXT,
+                    tags TEXT,
+                    metadata TEXT
+                )
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        tracker = UsageTracker(db_path=db_path, flush_threshold=1)
+        # Trigger lazy init + migration
+        tracker.record(
+            UsageEvent(
+                model_name="openai/gpt-4o",
+                provider="openai",
+                prompt_tokens=200,
+                cached_prompt_tokens=150,
+            )
+        )
+
+        rows = tracker.query()
+        assert rows[0]["cached_prompt_tokens"] == 150

--- a/tests/test_cached_tokens.py
+++ b/tests/test_cached_tokens.py
@@ -30,7 +30,6 @@ from prompture.drivers.openai_driver import (
 from prompture.infra.cost_mixin import CostMixin
 from prompture.infra.tracker import UsageEvent, UsageTracker
 
-
 # ---------------------------------------------------------------------------
 # CostMixin._calculate_cost — cache_read discount math
 # ---------------------------------------------------------------------------

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,246 @@
+"""Tests for the pluggable pricing-source registry.
+
+Covers:
+- Source ordering (priority-based, lowest first wins).
+- LocalKBPricingSource reads ``cost`` blocks from infra/rates/*.json.
+- ModelsDevPricingSource reads cost from cached models.dev data.
+- Custom user sources can be registered, replacing or stacking with built-ins.
+- Settings ``pricing_source`` flag picks the right built-ins on init.
+- Backwards compat: ``get_model_rates`` keeps the same signature/return shape.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+
+from prompture.infra import pricing
+from prompture.infra.model_rates import get_model_rates
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Force a fresh registry for every test (and restore defaults after)."""
+    pricing.clear_pricing_sources()
+    yield
+    pricing.clear_pricing_sources()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _StubSource:
+    def __init__(
+        self,
+        name: str,
+        priority: int,
+        rates: Optional[dict[str, float]] = None,
+    ) -> None:
+        self.name = name
+        self.priority = priority
+        self._rates = rates
+        self.calls: list[tuple[str, str]] = []
+
+    def get_rates(self, provider: str, model_id: str):
+        self.calls.append((provider, model_id))
+        return self._rates
+
+
+# ---------------------------------------------------------------------------
+# Registry behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_register_and_resolve_returns_first_priority(self):
+        cheap = _StubSource("cheap", priority=10, rates={"input": 1.0, "output": 2.0})
+        expensive = _StubSource("expensive", priority=100, rates={"input": 99.0, "output": 99.0})
+        pricing.register_pricing_source(expensive)
+        pricing.register_pricing_source(cheap)
+
+        result = pricing.resolve_rates("openai", "anything")
+        assert result == {"input": 1.0, "output": 2.0}
+        # Lower priority should not even be queried — short-circuit
+        assert cheap.calls == [("openai", "anything")]
+        assert expensive.calls == []
+
+    def test_falls_through_when_first_returns_none(self):
+        empty = _StubSource("empty", priority=10, rates=None)
+        full = _StubSource("full", priority=100, rates={"input": 1.0, "output": 2.0})
+        pricing.register_pricing_source(empty)
+        pricing.register_pricing_source(full)
+
+        result = pricing.resolve_rates("openai", "x")
+        assert result == {"input": 1.0, "output": 2.0}
+        assert empty.calls == [("openai", "x")]
+        assert full.calls == [("openai", "x")]
+
+    def test_falls_through_when_first_returns_partial_rates(self):
+        # input but no output → not usable, must fall through
+        partial = _StubSource("partial", priority=10, rates={"input": 1.0})
+        full = _StubSource("full", priority=100, rates={"input": 5.0, "output": 10.0})
+        pricing.register_pricing_source(partial)
+        pricing.register_pricing_source(full)
+
+        result = pricing.resolve_rates("openai", "x")
+        assert result == {"input": 5.0, "output": 10.0}
+
+    def test_replace_overwrites_same_name(self):
+        original = _StubSource("foo", 10, rates={"input": 1.0, "output": 1.0})
+        pricing.register_pricing_source(original)
+
+        with pytest.raises(ValueError):
+            pricing.register_pricing_source(_StubSource("foo", 10, rates={"input": 9.0, "output": 9.0}))
+
+        replacement = _StubSource("foo", 10, rates={"input": 9.0, "output": 9.0})
+        pricing.register_pricing_source(replacement, replace=True)
+
+        result = pricing.resolve_rates("any", "any")
+        assert result == {"input": 9.0, "output": 9.0}
+
+    def test_unregister(self):
+        pricing.register_pricing_source(_StubSource("a", 10, rates={"input": 1.0, "output": 1.0}))
+        assert pricing.unregister_pricing_source("a") is True
+        assert pricing.unregister_pricing_source("a") is False
+        assert pricing.resolve_rates("any", "any") is None
+
+    def test_source_exception_is_swallowed(self):
+        class _Boom:
+            name = "boom"
+            priority = 10
+
+            def get_rates(self, provider, model_id):
+                raise RuntimeError("kaboom")
+
+        pricing.register_pricing_source(_Boom())
+        pricing.register_pricing_source(_StubSource("ok", 100, rates={"input": 1.0, "output": 1.0}))
+
+        # Resolver must not raise; the failing source is skipped
+        assert pricing.resolve_rates("any", "any") == {"input": 1.0, "output": 1.0}
+
+
+# ---------------------------------------------------------------------------
+# Built-in: LocalKBPricingSource
+# ---------------------------------------------------------------------------
+
+
+class TestLocalKBPricingSource:
+    def test_loads_seeded_openai_gpt55(self):
+        # gpt-5.5 was seeded with verified pricing in this PR.
+        src = pricing.LocalKBPricingSource()
+        rates = src.get_rates("openai", "gpt-5.5")
+        assert rates == {"input": 5.0, "output": 30.0, "cache_read": 0.5}
+
+    def test_returns_none_for_unknown_model(self):
+        src = pricing.LocalKBPricingSource()
+        assert src.get_rates("openai", "made-up-model-xyz") is None
+
+    def test_returns_none_for_known_model_without_cost_block(self):
+        # gpt-5-nano has capabilities but no cost block in openai.json.
+        src = pricing.LocalKBPricingSource()
+        assert src.get_rates("openai", "gpt-5-nano") is None
+
+    def test_strips_date_suffix_for_lookup(self):
+        src = pricing.LocalKBPricingSource()
+        # gpt-5.5 with a date stamp should resolve to the base model's pricing
+        rates = src.get_rates("openai", "gpt-5.5-2026-01-15")
+        assert rates == {"input": 5.0, "output": 30.0, "cache_read": 0.5}
+
+
+# ---------------------------------------------------------------------------
+# Built-in: ModelsDevPricingSource
+# ---------------------------------------------------------------------------
+
+
+class TestModelsDevPricingSource:
+    def test_returns_rates_when_lookup_finds_entry(self):
+        src = pricing.ModelsDevPricingSource()
+        with patch(
+            "prompture.infra.model_rates._lookup_model",
+            return_value={"cost": {"input": 1.5, "output": 2.5, "cache_read": 0.15}},
+        ):
+            assert src.get_rates("openai", "x") == {
+                "input": 1.5,
+                "output": 2.5,
+                "cache_read": 0.15,
+            }
+
+    def test_returns_none_when_no_entry(self):
+        src = pricing.ModelsDevPricingSource()
+        with patch("prompture.infra.model_rates._lookup_model", return_value=None):
+            assert src.get_rates("openai", "x") is None
+
+    def test_returns_none_when_entry_has_no_cost(self):
+        src = pricing.ModelsDevPricingSource()
+        with patch("prompture.infra.model_rates._lookup_model", return_value={"name": "x"}):
+            assert src.get_rates("openai", "x") is None
+
+
+# ---------------------------------------------------------------------------
+# Default-source bootstrapping by setting
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultBootstrap:
+    def _bootstrap_with_mode(self, mode: str) -> list[str]:
+        pricing.clear_pricing_sources()
+        pricing._initialize_default_sources(mode=mode)
+        return [s.name for s in pricing.get_pricing_sources()]
+
+    def test_local_first_registers_both(self):
+        assert self._bootstrap_with_mode("local_first") == ["local_kb", "models_dev"]
+
+    def test_local_only_registers_only_local(self):
+        assert self._bootstrap_with_mode("local_only") == ["local_kb"]
+
+    def test_models_dev_only_registers_only_models_dev(self):
+        assert self._bootstrap_with_mode("models_dev_only") == ["models_dev"]
+
+    def test_unknown_mode_falls_back_to_local_first(self):
+        assert self._bootstrap_with_mode("nonsense") == ["local_kb", "models_dev"]
+
+
+# ---------------------------------------------------------------------------
+# get_model_rates backwards compatibility & local-first behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestGetModelRatesIntegration:
+    def test_local_kb_wins_over_models_dev(self):
+        """The seeded openai gpt-5.5 entry should be returned even if
+        models.dev would have served different numbers."""
+        pricing.clear_pricing_sources()
+        pricing._initialize_default_sources(mode="local_first")
+        with patch(
+            "prompture.infra.model_rates._lookup_model",
+            return_value={"cost": {"input": 999.0, "output": 999.0}},
+        ):
+            rates = get_model_rates("openai", "gpt-5.5")
+        assert rates is not None
+        assert rates["input"] == 5.0  # from local KB, NOT 999.0 from mocked models.dev
+        assert rates["cache_read"] == 0.5
+
+    def test_falls_through_to_models_dev_when_not_in_local_kb(self):
+        pricing.clear_pricing_sources()
+        pricing._initialize_default_sources(mode="local_first")
+        with patch(
+            "prompture.infra.model_rates._lookup_model",
+            return_value={"cost": {"input": 7.7, "output": 8.8}},
+        ):
+            rates = get_model_rates("openai", "model-not-in-local-kb")
+        assert rates == {"input": 7.7, "output": 8.8}
+
+    def test_local_only_returns_none_when_missing(self):
+        pricing.clear_pricing_sources()
+        pricing._initialize_default_sources(mode="local_only")
+        with patch(
+            "prompture.infra.model_rates._lookup_model",
+            return_value={"cost": {"input": 7.7, "output": 8.8}},
+        ):
+            rates = get_model_rates("openai", "model-not-in-local-kb")
+        # Even though models.dev would return rates, local_only refuses to fall through.
+        assert rates is None

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -11,7 +11,6 @@ Covers:
 
 from __future__ import annotations
 
-from typing import Optional
 from unittest.mock import patch
 
 import pytest
@@ -38,7 +37,7 @@ class _StubSource:
         self,
         name: str,
         priority: int,
-        rates: Optional[dict[str, float]] = None,
+        rates: dict[str, float] | None = None,
     ) -> None:
         self.name = name
         self.priority = priority


### PR DESCRIPTION
Turns out paying full input price for tokens the provider already had warm in cache is a bad deal. This PR teaches every major driver to read prompt-cache hits out of the API response and bills them at the discounted `cache_read` rate, then rewires pricing resolution so a curated local KB is the primary source instead of waiting on a third-party feed to catch up.

### Highlights

- Cached prompt tokens are now billed at provider `cache_read` rates instead of full input rates — across OpenAI, Anthropic, Gemini, Kimi/Moonshot, Groq, and xAI/Grok.
- Anthropic-style cache writes are tracked separately and billed at `cache_write` rates.
- Usage records now expose `cached_prompt_tokens` and `cache_creation_tokens` so dashboards can show real cache hit-rate and savings.
- Pricing now resolves from local curated rate files first, with models.dev as a fallback — so vendor price drops can be picked up immediately by editing one JSON file instead of waiting on a feed refresh.
- Pricing source resolution is configurable: `local_first` (default), `local_only` (offline / locked-down envs), or `models_dev_only` (legacy behavior).
- Custom pricing sources can be plugged in at runtime for internal price feeds or per-environment overrides.

<details>
<summary>Technical changes</summary>

- New `prompture/infra/pricing.py` introduces a `PricingSource` protocol with priority-ordered registry. `resolve_rates()` walks sources lowest-priority first and returns the first dict containing both `input` and `output` rates.
- `LocalKBPricingSource` (priority 0) loads `cost` blocks from `prompture/infra/rates/*.json` once at construction, with provider-name aliasing (`claude` → `anthropic`) and base-model fallback via `_strip_to_base_model`.
- `ModelsDevPricingSource` (priority 100) reuses `_lookup_model` to read pricing from the cached models.dev API data.
- `register_pricing_source` / `unregister_pricing_source` / `clear_pricing_sources` give users explicit registry control; lazy bootstrap is suppressed once any source is registered manually.
- `Settings.pricing_source` (`local_first` | `local_only` | `models_dev_only`) controls which built-ins get installed at startup; unknown values fall back to `local_first` with a warning.
- `get_model_rates` in `prompture/infra/model_rates.py` is now a thin shim delegating to `resolve_rates`.
- `CostMixin._calculate_cost` gains `cached_tokens` and `cache_creation_tokens` kwargs. It subtracts cached + cache-creation portions from `prompt_tokens` (which providers report as the *total*) before applying the input rate, then prices the cached/creation slices at `cache_read` / `cache_write` (each falling back to the input rate when not published).
- `Driver` and `AsyncDriver` base classes propagate `cached_prompt_tokens` and `cache_creation_tokens` from driver meta into `UsageEvent`.
- `UsageEvent` dataclass and `usage_events` SQLite schema gain `cached_prompt_tokens` and `cache_creation_tokens` columns; `_SCHEMA_MIGRATIONS` runs idempotent `ALTER TABLE ... ADD COLUMN` against existing DBs (suppresses `OperationalError` for already-applied migrations).
- `_INSERT_SQL` and the dashboard SELECT in `tracker.py` updated to read/write the new columns.
- `OpenAIDriver` / `AsyncOpenAIDriver` extract `usage.prompt_tokens_details.cached_tokens` via the new `_extract_openai_cached_tokens` helper, including in streaming paths; `_build_openai_stream_done` accepts the new field.
- `ClaudeDriver` / `AsyncClaudeDriver` extract `cache_read_input_tokens` and `cache_creation_input_tokens` via `_extract_anthropic_cache_tokens`. Anthropic reports cache reads/writes *separately* from `input_tokens`, so the driver synthesizes a unified `prompt_tokens = base_input + cache_read + cache_create` to match OpenAI-shaped accounting downstream. Streaming `message_start` events are read for the cache fields too.
- `GoogleDriver` / `AsyncGoogleDriver` read `cached_content_token_count` from `usage_metadata`; Gemini already includes the cached portion in `prompt_token_count`, so the cached count is surfaced for discounting only.
- `MoonshotDriver` / `AsyncMoonshotDriver` introduce `_extract_moonshot_cached_tokens`, which checks both `usage.cached_tokens` (Kimi K2 top-level) and `usage.prompt_tokens_details.cached_tokens` (OpenAI-shaped nested) — both shapes appear depending on model and SDK version. Streaming + JSON-mode-fallback paths both accumulate cached counts.
- `GroqDriver` / `AsyncGroqDriver` reuse `_extract_openai_cached_tokens` since Groq's API mirrors OpenAI's `prompt_tokens_details` shape.
- `GrokDriver` / `AsyncGrokDriver` reuse `_extract_moonshot_cached_tokens` because xAI's response carries `cached_tokens` in either of those positions.
- `cost` blocks seeded into `rates/openai.json`, `rates/anthropic.json` (with `cache_write`), `rates/google.json`, `rates/moonshot.json`, `rates/groq.json`, `rates/xai.json` for current-generation models.
- `update-pricing` skill rewritten end-to-end (v3.0 → v4.0) to document the pluggable resolver, vendor pricing pages, custom-source registration, and reload semantics for long-running processes.
- `VERSION` file removed (project switched to `setuptools_scm`).
- Ruff: `Optional[X]` modernized to `X | None` in `infra/pricing.py`, `infra/tracker.py`, `tests/test_cached_tokens.py`, and `tests/test_pricing.py`; trailing imports tidied.

</details>
