### PR TITLE
Add Grok and Runway multi-modal drivers (video, image, audio)

### DIFF
--- a/.env.copy
+++ b/.env.copy
@@ -90,3 +90,8 @@ AIRLLM_COMPRESSION=
 
 # ─── Stability AI (image generation) ────────────────────────────────────────
 STABILITY_API_KEY=
+
+# ─── Runway (image generation via /v1/text_to_image) ────────────────────────
+# Either RUNWAY_API_KEY or RUNWAYML_API_SECRET is accepted.
+RUNWAY_API_KEY=
+RUNWAY_ENDPOINT=

--- a/.env.copy
+++ b/.env.copy
@@ -91,7 +91,6 @@ AIRLLM_COMPRESSION=
 # ─── Stability AI (image generation) ────────────────────────────────────────
 STABILITY_API_KEY=
 
-# ─── Runway (image generation via /v1/text_to_image) ────────────────────────
+# ─── Runway (image / video / audio) ─────────────────────────────────────────
 # Either RUNWAY_API_KEY or RUNWAYML_API_SECRET is accepted.
 RUNWAY_API_KEY=
-RUNWAY_ENDPOINT=

--- a/.env.copy
+++ b/.env.copy
@@ -53,7 +53,10 @@ OPENROUTER_MODEL=openai/gpt-4o-mini
 
 # ─── Grok (xAI) ─────────────────────────────────────────────────────────────
 GROK_API_KEY=your-grok-api-key
+# XAI_API_KEY is also supported for xAI docs compatibility.
+XAI_API_KEY=
 GROK_MODEL=grok-4-fast-reasoning
+GROK_VIDEO_MODEL=grok-imagine-video
 
 # ─── Moonshot AI (Kimi) ─────────────────────────────────────────────────────
 MOONSHOT_API_KEY=your-moonshot-api-key

--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,4 @@ PROMPTURE_FEATURES.md
 /docs-cacao
 /.agents
 /.claude
+/examples/runway_image_outputs

--- a/.gitignore
+++ b/.gitignore
@@ -231,3 +231,5 @@ PROMPTURE_FEATURES.md
 /.agents
 /.claude
 /examples/runway_image_outputs
+/examples/runway_audio_outputs
+/examples/runway_video_outputs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,15 +61,15 @@ Configuration is in `pyproject.toml` under `[tool.ruff]`.
 ### Module Layout
 
 - **`prompture/core.py`** — Primary business logic. All extraction functions live here: `ask_for_json()` (low-level schema enforcement), `extract_and_jsonify()` / `manual_extract_and_jsonify()` (text-to-JSON), `extract_with_model()` / `stepwise_extract_with_model()` (Pydantic-based), `extract_from_data()` / `extract_from_pandas()` (TOON input), `render_output()` (raw text formatting).
-- **`prompture/drivers/`** — One module per LLM provider (openai, claude, google, groq, grok, azure, ollama, lmstudio, openrouter, local_http, huggingface, airllm). Each driver implements `generate(prompt, options)` returning a standardized response with token/cost metadata.
+- **`prompture/drivers/`** — One module per provider × modality. LLM drivers (openai, claude, google, groq, grok, azure, ollama, lmstudio, openrouter, local_http, huggingface, airllm, moonshot, modelscope, zai, cachibot, …) implement `generate(prompt, options)`; non-LLM drivers implement modality-specific methods (`generate_image`, `generate_video`, `synthesize`, etc.). Each provider also has an `async_*` sibling. Registration is centralized in `provider_descriptors.py` via `ProviderDescriptor` with lazy `DriverSpec.cls_path` resolution.
 - **`prompture/drivers/__init__.py`** — Central `DRIVER_REGISTRY` dict mapping provider name to factory lambda. `get_driver_for_model("provider/model")` parses the string and instantiates the right driver. `get_driver("provider")` is the legacy interface.
 - **`prompture/tools.py`** — Utilities: JSON/TOON text cleanup, type conversion (shorthand numbers, multilingual booleans, datetimes), field schema generation.
 - **`prompture/logging.py`** — Library logging configuration: `JSONFormatter` for structured JSON-lines output, `configure_logging()` for enabling library-level logging via Python stdlib `logging`.
 - **`prompture/callbacks.py`** — `DriverCallbacks` dataclass with `on_request`, `on_response`, `on_error` hooks for driver-level observability.
 - **`prompture/session.py`** — `UsageSession` dataclass for tracking token counts, costs, and errors across multiple driver calls.
 - **`prompture/field_definitions.py`** — Thread-safe global field registry with 50+ predefined fields, template variable substitution (`{{current_year}}`, `{{current_date}}`), and Pydantic Field generation via `field_from_registry()`.
-- **`prompture/settings.py`** — Pydantic-settings `Settings` class loading provider API keys/endpoints from `.env`.
-- **`prompture/discovery.py`** — `get_available_models()` auto-detects models from configured providers (static pricing tables + dynamic Ollama endpoint query).
+- **`prompture/infra/settings.py`** — Pydantic-settings `Settings` class loading provider API keys/endpoints from `.env`.
+- **`prompture/infra/discovery.py`** — `get_available_models()` plus per-modality helpers (`get_available_image_gen_models`, `get_available_video_gen_models`, `get_available_audio_models`). Auto-detects models from configured providers via static `*_PRICING` / `KNOWN_MODELS` tables, dynamic provider listing endpoints (Ollama, ElevenLabs), and models.dev capability fallback.
 - **`prompture/runner.py`** — Spec-driven test suite runner for cross-model comparison.
 - **`prompture/validator.py`** — JSON schema validation via jsonschema with fallback.
 
@@ -79,6 +79,21 @@ Configuration is in `pyproject.toml` under `[tool.ruff]`.
 - **Driver responses** always include metadata: `prompt_tokens`, `completion_tokens`, `total_tokens`, `cost`, `raw_response`.
 - **Output formats**: JSON (default) and TOON (experimental, for compact output). Controlled via `output_format` parameter.
 - **TOON input conversion** uses `python-toon` and `tukuy` packages to reduce token usage by 45-60% when sending structured data to LLMs.
+
+### Multi-Modal Drivers
+
+Beyond LLMs, drivers exist for adjacent modalities. Each modality has its own base class, registry, and factory:
+
+- **Image generation** (`ImageGenDriver` / `img_gen_registry.get_img_gen_driver_for_model`) — OpenAI DALL-E + GPT image, Google Imagen, Grok, Stability AI, Runway.
+- **Video generation** (`VideoGenDriver` / `video_gen_registry.get_video_gen_driver_for_model`) — Grok Imagine Video; Runway (text/image/video → video via a single driver, mode auto-detected from options).
+- **TTS** (`TTSDriver` / `audio_registry.get_tts_driver_for_model`) — OpenAI, ElevenLabs, Runway (TTS + sound effects).
+- **STT** (`STTDriver` / `audio_registry.get_stt_driver_for_model`) — OpenAI Whisper, ElevenLabs.
+- **Embeddings** (`EmbeddingDriver`) — OpenAI, Ollama.
+- **Standalone helpers** (not modality-registered) — `RunwayAudioTransformDriver` for voice dubbing / isolation / speech-to-speech; instantiated directly.
+
+**Runway is the only provider spanning image + video + TTS + sound-effects + voice transforms under one API key** (`RUNWAY_API_KEY` or `RUNWAYML_API_SECRET`). Per-model capabilities live in `prompture/drivers/runway_capabilities.py` (`RUNWAY_MODEL_INFO`, `get_runway_model_info`, `get_runway_models_by_op`, `get_runway_models_by_modality`) — use this when you need to answer "which models support text_to_video?" without instantiating drivers.
+
+Discovery for non-LLM modalities: `infra/discovery.py` exposes `get_available_image_gen_models`, `get_available_video_gen_models`, `get_available_audio_models(modality="tts" | "stt" | None)`.
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ print(person.name)  # Maria
 
 - **Structured output** — JSON schema enforcement and direct Pydantic model population
 - **17+ providers** — OpenAI, Claude, Google, Groq, Grok, Azure, Ollama, LM Studio, OpenRouter, HuggingFace, Moonshot, ModelScope, Z.ai, Vertex AI, AirLLM, CachiBot, and generic HTTP
-- **Multi-modal** — Drivers for embeddings, image generation (DALL-E, Imagen, Grok, Stability), text-to-speech, and speech-to-text (Whisper, ElevenLabs)
+- **Multi-modal** — Drivers for embeddings, image generation (DALL-E, Imagen, Grok, Stability), video generation (Grok Imagine Video), text-to-speech, and speech-to-text (Whisper, ElevenLabs)
 - **Multi-model fallback** — Try a list of models in sequence with per-attempt cost, token, and capability accounting
 - **Strategy cascade** — Auto-selects between provider-native JSON mode, tool-call extraction, and prompted repair so extraction works on any model
 - **TOON input conversion** — 45-60% token savings when sending structured data via [Token-Oriented Object Notation](https://github.com/jhd3197/python-toon)
@@ -77,6 +77,8 @@ ANTHROPIC_API_KEY=sk-ant-...
 GOOGLE_API_KEY=...
 GROQ_API_KEY=...
 GROK_API_KEY=...
+# optional xAI-compatible alias for Grok APIs
+XAI_API_KEY=...
 OPENROUTER_API_KEY=...
 AZURE_OPENAI_ENDPOINT=...
 AZURE_OPENAI_API_KEY=...
@@ -134,6 +136,7 @@ Beyond text LLMs, Prompture exposes drivers for adjacent modalities under the sa
 
 - **Embeddings** — OpenAI (`text-embedding-3-*`) and Ollama (`nomic-embed-text`)
 - **Image generation** — OpenAI DALL-E, Google Imagen, Grok, Stability AI
+- **Video generation** — Grok Imagine Video (`grok-imagine-video`) with text-to-video, image-to-video, reference images, and polling
 - **Text-to-speech** — OpenAI (`tts-1`) and ElevenLabs
 - **Speech-to-text** — OpenAI Whisper and ElevenLabs
 
@@ -147,6 +150,26 @@ result = driver.generate_image(
 )
 print(result["meta"]["cost"], result["meta"]["image_count"])
 ```
+
+Video generation uses the same provider/model routing. Set `GROK_API_KEY` or `XAI_API_KEY`, then request a Grok video model:
+
+```python
+from prompture import get_video_gen_driver_for_model
+
+driver = get_video_gen_driver_for_model("grok/grok-imagine-video")
+result = driver.generate_video(
+    "wide shot of a crystal-powered rocket launching from red desert dunes",
+    {"duration": 8, "aspect_ratio": "16:9", "resolution": "720p"},
+)
+
+video = result["videos"][0]
+print(video.url)
+print(result["meta"]["request_id"], result["meta"]["cost"])
+```
+
+For local smoke tests without waiting on the render, pass `{"poll": False}` to get the provider request ID. The async factory is available as `get_async_video_gen_driver_for_model()`.
+
+Runnable example: `python examples/grok_video_generation_example.py`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ print(person.name)  # Maria
 ## Key Features
 
 - **Structured output** — JSON schema enforcement and direct Pydantic model population
-- **17+ providers** — OpenAI, Claude, Google, Groq, Grok, Azure, Ollama, LM Studio, OpenRouter, HuggingFace, Moonshot, ModelScope, Z.ai, Vertex AI, AirLLM, CachiBot, and generic HTTP
-- **Multi-modal** — Drivers for embeddings, image generation (DALL-E, Imagen, Grok, Stability), video generation (Grok Imagine Video), text-to-speech, and speech-to-text (Whisper, ElevenLabs)
+- **18+ providers** — OpenAI, Claude, Google, Groq, Grok, Azure, Ollama, LM Studio, OpenRouter, HuggingFace, Moonshot, ModelScope, Z.ai, Vertex AI, AirLLM, CachiBot, Runway, and generic HTTP
+- **Multi-modal** — Drivers for embeddings, image generation (DALL-E, Imagen, Grok, Stability, Runway), video generation (Grok Imagine Video, Runway text/image/video → video), text-to-speech (OpenAI, ElevenLabs, Runway), sound effects, voice dubbing / isolation / conversion (Runway), and speech-to-text (Whisper, ElevenLabs)
 - **Multi-model fallback** — Try a list of models in sequence with per-attempt cost, token, and capability accounting
 - **Strategy cascade** — Auto-selects between provider-native JSON mode, tool-call extraction, and prompted repair so extraction works on any model
 - **TOON input conversion** — 45-60% token savings when sending structured data via [Token-Oriented Object Notation](https://github.com/jhd3197/python-toon)
@@ -127,17 +127,20 @@ Model strings use `"provider/model"` format. The provider prefix routes to the c
 | `huggingface` | `hf/model-name` | Free (local) |
 | `airllm` | `airllm/Qwen2-7B` | Free (local) |
 | `local_http` | `local_http/self-hosted` | Free |
+| `runway` | `runway/gen4.5` (video), `runway/gpt_image_2` (image), `runway/eleven_multilingual_v2` (TTS) | Automatic |
 
-Aliases (`anthropic`, `gemini`, `chatgpt`, `xai`, `lm_studio`, `zhipu`, `hf`, `dalle`) route to their canonical providers.
+Aliases (`anthropic`, `gemini`, `chatgpt`, `xai`, `lm_studio`, `zhipu`, `hf`, `dalle`, `runwayml`) route to their canonical providers.
 
 ## Multi-Modal
 
 Beyond text LLMs, Prompture exposes drivers for adjacent modalities under the same `provider/model` routing:
 
 - **Embeddings** — OpenAI (`text-embedding-3-*`) and Ollama (`nomic-embed-text`)
-- **Image generation** — OpenAI DALL-E, Google Imagen, Grok, Stability AI
-- **Video generation** — Grok Imagine Video (`grok-imagine-video`) with text-to-video, image-to-video, reference images, and polling
-- **Text-to-speech** — OpenAI (`tts-1`) and ElevenLabs
+- **Image generation** — OpenAI DALL-E + GPT image, Google Imagen, Grok, Stability AI, Runway (`gen4_image`, `gen4_image_turbo`, `gpt_image_2`, `gemini_image3_pro`, `gemini_2.5_flash`)
+- **Video generation** — Grok Imagine Video; Runway text/image/video → video (`gen4.5`, `gen4_turbo`, `gen3a_turbo`, `gen4_aleph`, `veo3`, `veo3.1`, `veo3.1_fast`)
+- **Text-to-speech** — OpenAI (`tts-1`), ElevenLabs, Runway (`eleven_multilingual_v2`)
+- **Sound effects** — Runway (`eleven_text_to_sound_v2`)
+- **Audio transforms** — Runway voice dubbing, voice isolation, speech-to-speech (`RunwayAudioTransformDriver`)
 - **Speech-to-text** — OpenAI Whisper and ElevenLabs
 
 ```python
@@ -170,6 +173,61 @@ print(result["meta"]["request_id"], result["meta"]["cost"])
 For local smoke tests without waiting on the render, pass `{"poll": False}` to get the provider request ID. The async factory is available as `get_async_video_gen_driver_for_model()`.
 
 Runnable example: `python examples/grok_video_generation_example.py`.
+
+### Runway
+
+Runway is a single API surface covering image, video, and audio. One key (`RUNWAY_API_KEY`, or `RUNWAYML_API_SECRET`) unlocks all of it:
+
+```python
+from prompture.drivers.img_gen_registry import get_img_gen_driver_for_model
+from prompture.drivers.video_gen_registry import get_video_gen_driver_for_model
+from prompture.drivers.audio_registry import get_tts_driver_for_model
+from prompture.drivers import RunwayAudioTransformDriver
+
+# Image — text_to_image, optionally with reference images
+img = get_img_gen_driver_for_model("runway/gpt_image_2").generate_image(
+    "A cinematic wide shot of a neon-lit Tokyo alleyway at night in the rain",
+    {"ratio": "1920:1080", "quality": "high"},
+)
+
+# Video — one driver, three modes (auto-detected from inputs)
+vid = get_video_gen_driver_for_model("runway/gen4.5").generate_video(
+    "wide cinematic shot of a rocket launching from desert dunes",
+    {"ratio": "1280:720", "duration": 5},          # text_to_video
+)
+# Pass `image=...` → image_to_video; `video=...` → video_to_video (gen4_aleph).
+
+# Speech and sound effects
+tts = get_tts_driver_for_model("runway/eleven_multilingual_v2").synthesize(
+    "Hello from Runway via Prompture.", {"voice": "Maya"},
+)
+sfx = get_tts_driver_for_model("runway/eleven_text_to_sound_v2").synthesize(
+    "Heavy tropical rain on a metal roof", {"duration": 5},
+)
+
+# Voice transforms (audio in → audio out, not a registered modality)
+dub = RunwayAudioTransformDriver().dub("https://.../speech.mp3", target_lang="es")
+```
+
+Inspect any model's capabilities (operations, endpoints, cost) as data — no need to instantiate the driver:
+
+```python
+from prompture.drivers import get_runway_model_info, get_runway_models_by_op
+
+get_runway_model_info("gen4.5")
+# {'modality': 'video',
+#  'operations': ['text_to_video', 'image_to_video'],
+#  'endpoints':  ['/v1/text_to_video', '/v1/image_to_video'],
+#  'cost': '$0.12 per second'}
+
+get_runway_models_by_op("text_to_video")
+# ['gen4.5', 'veo3', 'veo3.1', 'veo3.1_fast']
+```
+
+Runnable examples:
+- `python examples/runway_image_generation_example.py`
+- `python examples/runway_video_generation_example.py`
+- `python examples/runway_audio_example.py`
 
 ## Usage
 
@@ -442,6 +500,20 @@ from prompture import get_available_models
 models = get_available_models()
 for model in models:
     print(model)  # "openai/gpt-4", "ollama/llama3:latest", ...
+```
+
+For non-LLM modalities, use the matching helper:
+
+```python
+from prompture.infra.discovery import (
+    get_available_image_gen_models,
+    get_available_video_gen_models,
+    get_available_audio_models,
+)
+
+get_available_image_gen_models()        # ['runway/gpt_image_2', 'openai/dall-e-3', ...]
+get_available_video_gen_models()        # ['runway/gen4.5', 'runway/gen4_aleph', ...]
+get_available_audio_models(modality="tts")  # ['runway/eleven_multilingual_v2', ...]
 ```
 
 ### Logging and Debugging

--- a/examples/grok_video_generation_example.py
+++ b/examples/grok_video_generation_example.py
@@ -1,0 +1,54 @@
+"""
+Example: Grok video generation.
+
+This script demonstrates:
+1. Selecting a video generation driver by provider/model string.
+2. Starting a text-to-video request with xAI Grok Imagine Video.
+3. Running a fast local smoke test by returning the request ID without polling.
+
+Setup:
+    Set GROK_API_KEY or XAI_API_KEY in your environment or .env file.
+    Set PROMPTURE_VIDEO_POLL=true to wait for the finished video URL.
+"""
+
+from __future__ import annotations
+
+import os
+
+from prompture import get_video_gen_driver_for_model
+
+MODEL = "grok/grok-imagine-video"
+PROMPT = "wide cinematic shot of a crystal-powered rocket launching from red desert dunes"
+
+
+def main() -> None:
+    if not (os.getenv("GROK_API_KEY") or os.getenv("XAI_API_KEY")):
+        raise RuntimeError("Set GROK_API_KEY or XAI_API_KEY before running this example.")
+
+    poll = os.getenv("PROMPTURE_VIDEO_POLL", "false").lower() == "true"
+    driver = get_video_gen_driver_for_model(MODEL)
+    result = driver.generate_video(
+        PROMPT,
+        {
+            "duration": 8,
+            "aspect_ratio": "16:9",
+            "resolution": "720p",
+            "poll": poll,
+        },
+    )
+
+    meta = result["meta"]
+    print("Video request metadata:")
+    print(f"Request ID: {meta['request_id']}")
+    print(f"Status: {meta['status']}")
+    print(f"Model: {meta['model_name']}")
+    print(f"Estimated cost: ${meta['cost']:.6f}")
+
+    if result["videos"]:
+        print(f"Video URL: {result['videos'][0].url}")
+    else:
+        print("Polling disabled. Re-run with PROMPTURE_VIDEO_POLL=true to wait for the video URL.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/runway_audio_example.py
+++ b/examples/runway_audio_example.py
@@ -1,0 +1,144 @@
+"""
+Example: Runway audio — TTS, sound effects, and audio-transform endpoints.
+
+Demonstrates four endpoints, each polling to completion:
+
+1. ``POST /v1/text_to_speech``    — Maya voice speaks a line.
+2. ``POST /v1/sound_effect``      — generate a 5-second rain sound effect.
+3. ``POST /v1/voice_dubbing``     — dub the sample clip to Spanish.
+4. ``POST /v1/voice_isolation``   — isolate voice from the sample clip.
+
+Setup:
+    RUNWAY_API_KEY (or RUNWAYML_API_SECRET) must be set.
+
+Override the sample audio used by #3 and #4 with
+``PROMPTURE_RUNWAY_AUDIO_URL=<https-url-to-mp3>``. The default is a public
+~15 s clip; for meaningful dubbing, point this at a speech recording.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from prompture.drivers import RunwayAudioTransformDriver
+from prompture.drivers.audio_registry import get_tts_driver_for_model
+from prompture.drivers.runway_tts_driver import RunwayTTSDriver
+
+OUT_DIR = Path(__file__).parent / "runway_audio_outputs"
+
+# Public sample clip used by voice_dubbing and voice_isolation. Stable URL,
+# small file, well under Runway's input limits.
+AUDIO_URL = os.getenv(
+    "PROMPTURE_RUNWAY_AUDIO_URL",
+    "https://download.samplelib.com/mp3/sample-15s.mp3",
+)
+
+
+def _ts() -> str:
+    return datetime.now().strftime("%Y%m%d-%H%M%S")
+
+
+def _ext_for(media_type: str) -> str:
+    if "wav" in media_type:
+        return "wav"
+    if "ogg" in media_type:
+        return "ogg"
+    if "mp4" in media_type:
+        return "m4a"
+    return "mp3"
+
+
+def _save(audio: bytes, media_type: str, name: str) -> Path:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    path = OUT_DIR / f"{name}-{_ts()}.{_ext_for(media_type)}"
+    path.write_bytes(audio)
+    return path
+
+
+def _print(label: str, result: dict) -> None:
+    meta = result["meta"]
+    print(f"── {label} ──")
+    print(f"  model:    {meta['model_name']}")
+    print(f"  task:     {meta.get('task_id')}")
+    print(f"  status:   {meta.get('status')}")
+    if "cost" in meta:
+        print(f"  cost:     ${meta['cost']:.4f}")
+
+
+def _estimate_tts_cost(model: str, *, characters: int = 0, duration: float = 0.0) -> float:
+    pricing = RunwayTTSDriver.AUDIO_PRICING.get(model, {})
+    cost = characters * pricing.get("per_character", 0.0)
+    cost += duration * pricing.get("per_second", 0.0)
+    return round(cost, 4)
+
+
+def run_text_to_speech() -> None:
+    text = "Hello! This is the Runway text-to-speech demo wired into Prompture."
+    est = _estimate_tts_cost("eleven_multilingual_v2", characters=len(text))
+    print(f"\n• text_to_speech (Maya)  (estimated ${est:.4f} for {len(text)} chars)")
+    driver = get_tts_driver_for_model("runway/eleven_multilingual_v2")
+    result = driver.synthesize(text, {"voice": "Maya"})
+    _print("text_to_speech / Maya", result)
+    if result["audio"]:
+        path = _save(result["audio"], result["media_type"], "tts-maya")
+        print(f"  saved:    {path}")
+
+
+def run_sound_effect() -> None:
+    duration = 5
+    est = _estimate_tts_cost("eleven_text_to_sound_v2", duration=duration)
+    print(f"\n• sound_effect  (estimated ${est:.4f} for {duration}s)")
+    driver = get_tts_driver_for_model("runway/eleven_text_to_sound_v2")
+    result = driver.synthesize(
+        "Heavy tropical rain on a metal roof with distant thunder",
+        {"duration": duration, "loop": False},
+    )
+    _print("sound_effect", result)
+    if result["audio"]:
+        path = _save(result["audio"], result["media_type"], "sfx-rain")
+        print(f"  saved:    {path}")
+
+
+def run_voice_dubbing() -> None:
+    # Voice dubbing is priced per-second of input; the clip duration isn't
+    # known until Runway fetches it, so we just note the input URL.
+    print("\n• voice_dubbing → es")
+    print(f"  input:    {AUDIO_URL}")
+    driver = RunwayAudioTransformDriver()
+    result = driver.dub(AUDIO_URL, target_lang="es", drop_background_audio=False)
+    _print("voice_dubbing → es", result)
+    if result["audio"]:
+        path = _save(result["audio"], result["media_type"], "dub-es")
+        print(f"  saved:    {path}")
+
+
+def run_voice_isolation() -> None:
+    print("\n• voice_isolation")
+    print(f"  input:    {AUDIO_URL}")
+    driver = RunwayAudioTransformDriver()
+    result = driver.isolate(AUDIO_URL)
+    _print("voice_isolation", result)
+    if result["audio"]:
+        path = _save(result["audio"], result["media_type"], "isolated")
+        print(f"  saved:    {path}")
+
+
+def main() -> None:
+    if not (os.getenv("RUNWAY_API_KEY") or os.getenv("RUNWAYML_API_SECRET")):
+        raise RuntimeError("Set RUNWAY_API_KEY (or RUNWAYML_API_SECRET) before running.")
+
+    print(f"Output: {OUT_DIR}")
+    print("Each step polls until SUCCEEDED — total runtime can be a few minutes.")
+
+    for step in (run_text_to_speech, run_sound_effect, run_voice_dubbing, run_voice_isolation):
+        try:
+            step()
+        except Exception as exc:
+            print(f"  {step.__name__} error: {exc}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/runway_image_generation_example.py
+++ b/examples/runway_image_generation_example.py
@@ -1,0 +1,153 @@
+"""
+Example: image generation across providers — Runway (gpt_image_2) and OpenAI (gpt-image-1).
+
+Demonstrates:
+1. Picking an image-gen driver by ``"provider/model"`` string.
+2. Calling Runway ``POST /v1/text_to_image`` with the ``gpt_image_2`` model,
+   ``ratio=1920:1088``, and ``quality=high`` — i.e. the exact contract from the
+   curl example in the Runway docs.
+3. Calling OpenAI's GPT image API (``gpt-image-1`` today; the same code accepts
+   ``gpt-image-2`` automatically when OpenAI ships it).
+4. Saving each result to a PNG next to this script.
+
+Setup:
+    RUNWAY_API_KEY     — Runway API key (RUNWAYML_API_SECRET also accepted).
+    OPENAI_API_KEY     — OpenAI API key.
+
+By default this runs whichever providers are configured. Skip the second
+provider by unsetting its key; the script will tell you what it skipped.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from prompture.drivers.img_gen_registry import get_img_gen_driver_for_model
+
+PROMPT = (
+    "A cinematic wide shot of a neon-lit Tokyo alleyway at night in the rain, "
+    "reflections on wet pavement, moody atmosphere, shot on 35mm film"
+)
+
+OUT_DIR = Path(__file__).parent / "runway_image_outputs"
+
+
+# ── Section: helpers ────────────────────────────────────────────────────────
+
+
+def _timestamp() -> str:
+    return datetime.now().strftime("%Y%m%d-%H%M%S")
+
+
+def _save_image(image, path: Path) -> Path:
+    """Persist an ``ImageContent`` to disk.
+
+    Runway returns URL-backed images; OpenAI returns base64-backed images.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    if image.source_type == "url" and image.url:
+        import urllib.request
+
+        with urllib.request.urlopen(image.url) as resp:
+            path.write_bytes(resp.read())
+    else:
+        path.write_bytes(base64.b64decode(image.data))
+
+    return path
+
+
+def _print_result(label: str, result: dict) -> None:
+    meta = result["meta"]
+    print(f"\n── {label} ──")
+    print(f"  model:    {meta['model_name']}")
+    print(f"  size:     {meta.get('size')}")
+    print(f"  count:    {meta['image_count']}")
+    print(f"  cost:     ${meta['cost']:.4f}")
+    if meta.get("task_id"):
+        print(f"  task_id:  {meta['task_id']}")
+    if meta.get("status"):
+        print(f"  status:   {meta['status']}")
+
+
+# ── Section: Runway (gpt_image_2) ───────────────────────────────────────────
+
+
+def run_runway() -> None:
+    if not (os.getenv("RUNWAY_API_KEY") or os.getenv("RUNWAYML_API_SECRET")):
+        print("• Runway: SKIPPED (set RUNWAY_API_KEY or RUNWAYML_API_SECRET to enable)")
+        return
+
+    print("• Runway: generating with gpt_image_2 (ratio=1920:1088, quality=high)...")
+    driver = get_img_gen_driver_for_model("runway/gpt_image_2")
+    result = driver.generate_image(
+        PROMPT,
+        {
+            "ratio": "1920:1088",
+            "quality": "high",
+            # poll_interval/timeout default to 5s / 600s — fine for this demo.
+        },
+    )
+    _print_result("Runway / gpt_image_2", result)
+
+    for i, image in enumerate(result["images"], start=1):
+        out = OUT_DIR / f"runway-gpt_image_2-{_timestamp()}-{i}.png"
+        saved = _save_image(image, out)
+        print(f"  saved:    {saved}")
+
+
+# ── Section: OpenAI (gpt-image-1, with gpt-image-2 forward-compat) ──────────
+
+
+def run_openai() -> None:
+    if not os.getenv("OPENAI_API_KEY"):
+        print("• OpenAI: SKIPPED (set OPENAI_API_KEY to enable)")
+        return
+
+    # gpt-image-2 is not yet published in OpenAI's public catalog; use
+    # gpt-image-1, which has identical request semantics. Override via
+    # PROMPTURE_OPENAI_IMAGE_MODEL=gpt-image-2 the day OpenAI ships it.
+    model = os.getenv("PROMPTURE_OPENAI_IMAGE_MODEL", "gpt-image-1")
+
+    print(f"• OpenAI: generating with {model} (size=1024x1024, quality=high)...")
+    driver = get_img_gen_driver_for_model(f"openai/{model}")
+    result = driver.generate_image(
+        PROMPT,
+        {
+            "size": "1024x1024",
+            "quality": "high",
+            "n": 1,
+        },
+    )
+    _print_result(f"OpenAI / {model}", result)
+
+    for i, image in enumerate(result["images"], start=1):
+        out = OUT_DIR / f"openai-{model}-{_timestamp()}-{i}.png"
+        saved = _save_image(image, out)
+        print(f"  saved:    {saved}")
+
+
+# ── Section: entry point ────────────────────────────────────────────────────
+
+
+def main() -> None:
+    print(f"Prompt: {PROMPT!r}")
+    print(f"Output directory: {OUT_DIR}")
+
+    try:
+        run_runway()
+    except Exception as exc:
+        print(f"  Runway error: {exc}", file=sys.stderr)
+
+    try:
+        run_openai()
+    except Exception as exc:
+        print(f"  OpenAI error: {exc}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/runway_video_generation_example.py
+++ b/examples/runway_video_generation_example.py
@@ -1,0 +1,163 @@
+"""
+Example: Runway video generation — text/image/video → video.
+
+Demonstrates all three Runway video endpoints through a single driver:
+
+1. ``text_to_video``  with ``gen4.5``         — a cinematic prompt.
+2. ``image_to_video`` with ``gen4_turbo``     — animate a still image.
+3. ``video_to_video`` with ``gen4_aleph``     — restyle a video.
+
+The script chains them: the v2v step uses the t2v output (a Runway-signed
+URL, valid for 24–48 h) as its input, so the whole demo is self-contained.
+
+Setup:
+    RUNWAY_API_KEY (or RUNWAYML_API_SECRET) must be set.
+
+Each scenario waits for the task to finish and downloads the MP4. Set
+``PROMPTURE_RUNWAY_SCENARIO`` to ``t2v``, ``i2v``, or ``v2v`` to run just one.
+If you run ``v2v`` solo, override ``PROMPTURE_RUNWAY_VIDEO_URL`` to point at
+an existing 720p MP4 — there's no prior t2v output to chain from.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+
+from prompture.drivers.runway_video_gen_driver import RunwayVideoGenDriver
+from prompture.drivers.video_gen_registry import get_video_gen_driver_for_model
+
+OUT_DIR = Path(__file__).parent / "runway_video_outputs"
+
+IMAGE_URL = os.getenv(
+    "PROMPTURE_RUNWAY_IMAGE_URL",
+    "https://images.unsplash.com/photo-1518791841217-8f162f1e1131?w=1280",
+)
+# Fallback only — when running v2v in isolation, no chained output exists.
+FALLBACK_VIDEO_URL = os.getenv(
+    "PROMPTURE_RUNWAY_VIDEO_URL",
+    "https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/720/Big_Buck_Bunny_720_10s_1MB.mp4",
+)
+
+
+def _ts() -> str:
+    return datetime.now().strftime("%Y%m%d-%H%M%S")
+
+
+def _save_video(url: str, name: str) -> Path:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    path = OUT_DIR / f"{name}-{_ts()}.mp4"
+    with urllib.request.urlopen(url) as resp:
+        path.write_bytes(resp.read())
+    return path
+
+
+def _estimate_cost(model: str, duration: int | None) -> float:
+    pricing = RunwayVideoGenDriver.VIDEO_PRICING.get(model, {})
+    return round(pricing.get("per_second", 0.0) * (duration or 0), 4)
+
+
+def _print(label: str, result: dict) -> None:
+    meta = result["meta"]
+    print(f"── {label} ──")
+    print(f"  model:    {meta['model_name']}")
+    print(f"  mode:     {meta.get('mode')}")
+    print(f"  duration: {meta.get('duration_seconds')}s")
+    print(f"  ratio:    {meta.get('aspect_ratio')}")
+    print(f"  task:     {meta.get('task_id')}")
+    print(f"  status:   {meta.get('status')}")
+    print(f"  cost:     ${meta['cost']:.4f}")
+
+
+# State that scenarios can pass to each other (e.g. the t2v output URL
+# becomes the v2v input).
+chained: dict[str, str] = {}
+
+
+def run_text_to_video() -> None:
+    model, duration = "gen4.5", 5
+    print(f"\n• {model} / text_to_video  (estimated ${_estimate_cost(model, duration):.4f})")
+    driver = get_video_gen_driver_for_model(f"runway/{model}")
+    result = driver.generate_video(
+        "wide cinematic shot of a crystal-powered rocket launching from red desert dunes, "
+        "slow camera push-in, golden hour light",
+        {"ratio": "1280:720", "duration": duration},
+    )
+    _print("text_to_video / gen4.5", result)
+    if result["videos"]:
+        url = result["videos"][0].url
+        chained["t2v_url"] = url
+        path = _save_video(url, "t2v-gen4.5")
+        print(f"  saved:    {path}")
+
+
+def run_image_to_video() -> None:
+    model, duration = "gen4_turbo", 5
+    print(f"\n• {model} / image_to_video  (estimated ${_estimate_cost(model, duration):.4f})")
+    driver = get_video_gen_driver_for_model(f"runway/{model}")
+    result = driver.generate_video(
+        "slow dolly-in across the scene, soft drifting clouds, cinematic",
+        {"image": IMAGE_URL, "ratio": "1280:720", "duration": duration},
+    )
+    _print("image_to_video / gen4_turbo", result)
+    if result["videos"]:
+        url = result["videos"][0].url
+        chained.setdefault("i2v_url", url)
+        path = _save_video(url, "i2v-gen4_turbo")
+        print(f"  saved:    {path}")
+
+
+def run_video_to_video() -> None:
+    # Prefer the t2v output (Runway → Runway always fetches cleanly), then
+    # i2v output, then the external fallback.
+    source = chained.get("t2v_url") or chained.get("i2v_url") or FALLBACK_VIDEO_URL
+    source_label = (
+        "t2v output" if source == chained.get("t2v_url")
+        else "i2v output" if source == chained.get("i2v_url")
+        else "external URL"
+    )
+
+    per_sec = RunwayVideoGenDriver.VIDEO_PRICING.get("gen4_aleph", {}).get("per_second", 0.0)
+    print(f"\n• gen4_aleph / video_to_video  (≈ ${per_sec:.2f}/sec of input)")
+    print(f"  input:    {source_label}")
+
+    driver = get_video_gen_driver_for_model("runway/gen4_aleph")
+    result = driver.generate_video(
+        "restyle the scene to a snow-covered winter version, soft falling snow",
+        {"video": source},
+    )
+    _print("video_to_video / gen4_aleph", result)
+    if result["videos"]:
+        path = _save_video(result["videos"][0].url, "v2v-gen4_aleph")
+        print(f"  saved:    {path}")
+
+
+SCENARIOS = {
+    "t2v": run_text_to_video,
+    "i2v": run_image_to_video,
+    "v2v": run_video_to_video,
+}
+
+
+def main() -> None:
+    if not (os.getenv("RUNWAY_API_KEY") or os.getenv("RUNWAYML_API_SECRET")):
+        raise RuntimeError("Set RUNWAY_API_KEY (or RUNWAYML_API_SECRET) before running.")
+
+    print(f"Output: {OUT_DIR}")
+    print("Each scenario polls until SUCCEEDED — this can take 30s–3min per video.")
+
+    only = os.getenv("PROMPTURE_RUNWAY_SCENARIO", "").lower()
+    targets = [only] if only in SCENARIOS else list(SCENARIOS)
+
+    for name in targets:
+        try:
+            SCENARIOS[name]()
+        except Exception as exc:
+            print(f"  {name} error: {exc}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/prompture/drivers/__init__.py
+++ b/prompture/drivers/__init__.py
@@ -41,6 +41,7 @@ from .async_google_driver import AsyncGoogleDriver
 from .async_google_img_gen_driver import AsyncGoogleImageGenDriver
 from .async_grok_driver import AsyncGrokDriver
 from .async_grok_img_gen_driver import AsyncGrokImageGenDriver
+from .async_grok_video_gen_driver import AsyncGrokVideoGenDriver
 from .async_groq_driver import AsyncGroqDriver
 from .async_hugging_driver import AsyncHuggingFaceDriver
 from .async_img_gen_base import AsyncImageGenDriver
@@ -59,6 +60,7 @@ from .async_openrouter_driver import AsyncOpenRouterDriver
 from .async_stability_img_gen_driver import AsyncStabilityImageGenDriver
 from .async_stt_base import AsyncSTTDriver
 from .async_tts_base import AsyncTTSDriver
+from .async_video_gen_base import AsyncVideoGenDriver
 from .async_zai_driver import AsyncZaiDriver
 from .azure_config import (
     clear_azure_configs,
@@ -76,6 +78,7 @@ from .google_driver import GoogleDriver
 from .google_img_gen_driver import GoogleImageGenDriver
 from .grok_driver import GrokDriver
 from .grok_img_gen_driver import GrokImageGenDriver
+from .grok_video_gen_driver import GrokVideoGenDriver
 from .groq_driver import GroqDriver
 from .hugging_driver import HuggingFaceDriver
 from .img_gen_base import ImageGenDriver
@@ -104,59 +107,70 @@ from .registry import (
     get_async_img_gen_driver_factory,
     get_async_stt_driver_factory,
     get_async_tts_driver_factory,
+    get_async_video_gen_driver_factory,
     get_driver_factory,
     get_embedding_driver_factory,
     get_img_gen_driver_factory,
     get_stt_driver_factory,
     get_tts_driver_factory,
+    get_video_gen_driver_factory,
     is_async_driver_registered,
     is_async_embedding_driver_registered,
     is_async_img_gen_driver_registered,
     is_async_stt_driver_registered,
     is_async_tts_driver_registered,
+    is_async_video_gen_driver_registered,
     is_driver_registered,
     is_embedding_driver_registered,
     is_img_gen_driver_registered,
     is_stt_driver_registered,
     is_tts_driver_registered,
+    is_video_gen_driver_registered,
     list_registered_async_drivers,
     list_registered_async_embedding_drivers,
     list_registered_async_img_gen_drivers,
     list_registered_async_stt_drivers,
     list_registered_async_tts_drivers,
+    list_registered_async_video_gen_drivers,
     list_registered_drivers,
     list_registered_embedding_drivers,
     list_registered_img_gen_drivers,
     list_registered_stt_drivers,
     list_registered_tts_drivers,
+    list_registered_video_gen_drivers,
     load_entry_point_drivers,
     register_async_driver,
     register_async_embedding_driver,
     register_async_img_gen_driver,
     register_async_stt_driver,
     register_async_tts_driver,
+    register_async_video_gen_driver,
     register_driver,
     register_embedding_driver,
     register_img_gen_driver,
     register_stt_driver,
     register_tts_driver,
+    register_video_gen_driver,
     unregister_async_driver,
     unregister_async_embedding_driver,
     unregister_async_img_gen_driver,
     unregister_async_stt_driver,
     unregister_async_tts_driver,
+    unregister_async_video_gen_driver,
     unregister_driver,
     unregister_embedding_driver,
     unregister_img_gen_driver,
     unregister_stt_driver,
     unregister_tts_driver,
+    unregister_video_gen_driver,
 )
 from .stability_img_gen_driver import StabilityImageGenDriver
 from .stt_base import STTDriver
 from .tts_base import TTSDriver
+from .video_gen_base import VideoGenDriver
 from .zai_driver import ZaiDriver
 
-# Register all built-in drivers (LLM sync/async, STT, TTS, img_gen, embedding)
+# Register all built-in drivers (LLM sync/async, STT, TTS, img_gen, video_gen, embedding)
 # from the unified ProviderDescriptor list — replaces ~200 lines of individual
 # register_*() calls that were previously scattered across this file,
 # async_registry.py, audio_registry.py, embedding_registry.py, and img_gen_registry.py.
@@ -184,6 +198,10 @@ from .embedding_registry import (
 from .img_gen_registry import (
     get_async_img_gen_driver_for_model,
     get_img_gen_driver_for_model,
+)
+from .video_gen_registry import (
+    get_async_video_gen_driver_for_model,
+    get_video_gen_driver_for_model,
 )
 
 # Backwards compatibility: expose registry dict (read-only view recommended)
@@ -449,6 +467,7 @@ __all__ = [
     "AsyncGoogleImageGenDriver",
     "AsyncGrokDriver",
     "AsyncGrokImageGenDriver",
+    "AsyncGrokVideoGenDriver",
     "AsyncGroqDriver",
     "AsyncHuggingFaceDriver",
     "AsyncImageGenDriver",
@@ -467,6 +486,7 @@ __all__ = [
     "AsyncSTTDriver",
     "AsyncStabilityImageGenDriver",
     "AsyncTTSDriver",
+    "AsyncVideoGenDriver",
     "AsyncZaiDriver",
     # Sync LLM drivers
     "AzureDriver",
@@ -482,6 +502,7 @@ __all__ = [
     "GoogleImageGenDriver",
     "GrokDriver",
     "GrokImageGenDriver",
+    "GrokVideoGenDriver",
     "GroqDriver",
     "HuggingFaceDriver",
     # Image gen base class
@@ -502,6 +523,7 @@ __all__ = [
     "STTDriver",
     "StabilityImageGenDriver",
     "TTSDriver",
+    "VideoGenDriver",
     "ZaiDriver",
     # Azure config API
     "clear_azure_configs",
@@ -521,6 +543,10 @@ __all__ = [
     "get_async_stt_driver_for_model",
     "get_async_tts_driver_factory",
     "get_async_tts_driver_for_model",
+    # Video gen registry query functions
+    "get_async_video_gen_driver_factory",
+    # Video gen factory functions
+    "get_async_video_gen_driver_for_model",
     # LLM factory functions
     "get_driver",
     "get_driver_for_model",
@@ -532,27 +558,33 @@ __all__ = [
     "get_stt_driver_for_model",
     "get_tts_driver_factory",
     "get_tts_driver_for_model",
+    "get_video_gen_driver_factory",
+    "get_video_gen_driver_for_model",
     # Other registry query functions
     "is_async_driver_registered",
     "is_async_embedding_driver_registered",
     "is_async_img_gen_driver_registered",
     "is_async_stt_driver_registered",
     "is_async_tts_driver_registered",
+    "is_async_video_gen_driver_registered",
     "is_driver_registered",
     "is_embedding_driver_registered",
     "is_img_gen_driver_registered",
     "is_stt_driver_registered",
     "is_tts_driver_registered",
+    "is_video_gen_driver_registered",
     "list_registered_async_drivers",
     "list_registered_async_embedding_drivers",
     "list_registered_async_img_gen_drivers",
     "list_registered_async_stt_drivers",
     "list_registered_async_tts_drivers",
+    "list_registered_async_video_gen_drivers",
     "list_registered_drivers",
     "list_registered_embedding_drivers",
     "list_registered_img_gen_drivers",
     "list_registered_stt_drivers",
     "list_registered_tts_drivers",
+    "list_registered_video_gen_drivers",
     "load_entry_point_drivers",
     "parse_model_string",
     "provider_for_model",
@@ -562,6 +594,7 @@ __all__ = [
     "register_async_img_gen_driver",
     "register_async_stt_driver",
     "register_async_tts_driver",
+    "register_async_video_gen_driver",
     "register_azure_config",
     # Registry functions (public API)
     "register_driver",
@@ -569,16 +602,19 @@ __all__ = [
     "register_img_gen_driver",
     "register_stt_driver",
     "register_tts_driver",
+    "register_video_gen_driver",
     "set_azure_config_resolver",
     "unregister_async_driver",
     "unregister_async_embedding_driver",
     "unregister_async_img_gen_driver",
     "unregister_async_stt_driver",
     "unregister_async_tts_driver",
+    "unregister_async_video_gen_driver",
     "unregister_azure_config",
     "unregister_driver",
     "unregister_embedding_driver",
     "unregister_img_gen_driver",
     "unregister_stt_driver",
     "unregister_tts_driver",
+    "unregister_video_gen_driver",
 ]

--- a/prompture/drivers/__init__.py
+++ b/prompture/drivers/__init__.py
@@ -58,6 +58,8 @@ from .async_openai_stt_driver import AsyncOpenAISTTDriver
 from .async_openai_tts_driver import AsyncOpenAITTSDriver
 from .async_openrouter_driver import AsyncOpenRouterDriver
 from .async_runway_img_gen_driver import AsyncRunwayImageGenDriver
+from .async_runway_tts_driver import AsyncRunwayTTSDriver
+from .async_runway_video_gen_driver import AsyncRunwayVideoGenDriver
 from .async_stability_img_gen_driver import AsyncStabilityImageGenDriver
 from .async_stt_base import AsyncSTTDriver
 from .async_tts_base import AsyncTTSDriver
@@ -165,7 +167,10 @@ from .registry import (
     unregister_tts_driver,
     unregister_video_gen_driver,
 )
+from .runway_audio_transform_driver import RunwayAudioTransformDriver
 from .runway_img_gen_driver import RunwayImageGenDriver
+from .runway_tts_driver import RunwayTTSDriver
+from .runway_video_gen_driver import RunwayVideoGenDriver
 from .stability_img_gen_driver import StabilityImageGenDriver
 from .stt_base import STTDriver
 from .tts_base import TTSDriver
@@ -486,6 +491,8 @@ __all__ = [
     "AsyncOpenAITTSDriver",
     "AsyncOpenRouterDriver",
     "AsyncRunwayImageGenDriver",
+    "AsyncRunwayTTSDriver",
+    "AsyncRunwayVideoGenDriver",
     "AsyncSTTDriver",
     "AsyncStabilityImageGenDriver",
     "AsyncTTSDriver",
@@ -522,7 +529,10 @@ __all__ = [
     "OpenAISTTDriver",
     "OpenAITTSDriver",
     "OpenRouterDriver",
+    "RunwayAudioTransformDriver",
     "RunwayImageGenDriver",
+    "RunwayTTSDriver",
+    "RunwayVideoGenDriver",
     # STT/TTS base classes
     "STTDriver",
     "StabilityImageGenDriver",

--- a/prompture/drivers/__init__.py
+++ b/prompture/drivers/__init__.py
@@ -57,6 +57,7 @@ from .async_openai_img_gen_driver import AsyncOpenAIImageGenDriver
 from .async_openai_stt_driver import AsyncOpenAISTTDriver
 from .async_openai_tts_driver import AsyncOpenAITTSDriver
 from .async_openrouter_driver import AsyncOpenRouterDriver
+from .async_runway_img_gen_driver import AsyncRunwayImageGenDriver
 from .async_stability_img_gen_driver import AsyncStabilityImageGenDriver
 from .async_stt_base import AsyncSTTDriver
 from .async_tts_base import AsyncTTSDriver
@@ -164,6 +165,7 @@ from .registry import (
     unregister_tts_driver,
     unregister_video_gen_driver,
 )
+from .runway_img_gen_driver import RunwayImageGenDriver
 from .stability_img_gen_driver import StabilityImageGenDriver
 from .stt_base import STTDriver
 from .tts_base import TTSDriver
@@ -483,6 +485,7 @@ __all__ = [
     "AsyncOpenAISTTDriver",
     "AsyncOpenAITTSDriver",
     "AsyncOpenRouterDriver",
+    "AsyncRunwayImageGenDriver",
     "AsyncSTTDriver",
     "AsyncStabilityImageGenDriver",
     "AsyncTTSDriver",
@@ -519,6 +522,7 @@ __all__ = [
     "OpenAISTTDriver",
     "OpenAITTSDriver",
     "OpenRouterDriver",
+    "RunwayImageGenDriver",
     # STT/TTS base classes
     "STTDriver",
     "StabilityImageGenDriver",

--- a/prompture/drivers/__init__.py
+++ b/prompture/drivers/__init__.py
@@ -168,6 +168,18 @@ from .registry import (
     unregister_video_gen_driver,
 )
 from .runway_audio_transform_driver import RunwayAudioTransformDriver
+from .runway_capabilities import (
+    ALL_MODALITIES as RUNWAY_ALL_MODALITIES,
+)
+from .runway_capabilities import (
+    ALL_OPERATIONS as RUNWAY_ALL_OPERATIONS,
+)
+from .runway_capabilities import (
+    RUNWAY_MODEL_INFO,
+    get_runway_model_info,
+    get_runway_models_by_modality,
+    get_runway_models_by_op,
+)
 from .runway_img_gen_driver import RunwayImageGenDriver
 from .runway_tts_driver import RunwayTTSDriver
 from .runway_video_gen_driver import RunwayVideoGenDriver
@@ -455,6 +467,9 @@ __all__ = [
     "PROVIDER_DRIVER_MAP",
     # Provider name mapping
     "PROVIDER_NAME_MAP",
+    "RUNWAY_ALL_MODALITIES",
+    "RUNWAY_ALL_OPERATIONS",
+    "RUNWAY_MODEL_INFO",
     # Sync LLM drivers
     "AirLLMDriver",
     # Async LLM drivers
@@ -568,6 +583,9 @@ __all__ = [
     "get_embedding_driver_for_model",
     "get_img_gen_driver_factory",
     "get_img_gen_driver_for_model",
+    "get_runway_model_info",
+    "get_runway_models_by_modality",
+    "get_runway_models_by_op",
     "get_stt_driver_factory",
     "get_stt_driver_for_model",
     "get_tts_driver_factory",

--- a/prompture/drivers/async_grok_video_gen_driver.py
+++ b/prompture/drivers/async_grok_video_gen_driver.py
@@ -1,0 +1,194 @@
+"""Async xAI Grok Imagine video generation driver."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from typing import Any
+
+import httpx
+
+from ..infra.cost_mixin import VideoCostMixin
+from .async_video_gen_base import AsyncVideoGenDriver
+from .grok_video_gen_driver import (
+    _DEFAULT_ENDPOINT,
+    _duration_from_options,
+    _error_text,
+    _extract_video_content,
+    _get_xai_api_key,
+    _image_payload,
+)
+
+
+class AsyncGrokVideoGenDriver(VideoCostMixin, AsyncVideoGenDriver):
+    """Async video generation via xAI Grok Imagine Video REST API."""
+
+    supports_image_input = True
+    supports_reference_images = True
+    supports_video_input = False
+    supports_audio = True
+    supports_polling = True
+    supported_aspect_ratios = ["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"]
+    supported_resolutions = ["480p", "720p"]
+    max_seconds = 15
+
+    KNOWN_MODELS = ["grok-imagine-video"]
+    VIDEO_PRICING: dict[str, dict[str, Any]] = {
+        "grok-imagine-video": {
+            "per_second": 0.05,
+            "per_second_by_resolution": {
+                "480p": 0.05,
+                "720p": 0.07,
+            },
+        }
+    }
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = "grok-imagine-video",
+        endpoint: str | None = None,
+    ):
+        self.api_key = _get_xai_api_key(api_key)
+        self.model = model
+        self.endpoint = (endpoint or os.getenv("GROK_ENDPOINT") or _DEFAULT_ENDPOINT).rstrip("/")
+
+    @classmethod
+    def list_models(cls, *, api_key: str | None = None, **kw: object) -> list[str] | None:
+        """Return known xAI video models when an API key is configured."""
+        key = _get_xai_api_key(api_key)
+        if not key:
+            return None
+        return list(cls.KNOWN_MODELS)
+
+    async def generate_video(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        """Generate a video using xAI Grok Imagine Video (async)."""
+        if not self.api_key:
+            raise RuntimeError("GROK_API_KEY or XAI_API_KEY environment variable is required")
+        if not prompt:
+            raise ValueError("prompt cannot be empty")
+
+        model = options.get("model", self.model)
+        duration = _duration_from_options(options)
+        aspect_ratio = options.get("aspect_ratio", "16:9")
+        resolution = options.get("resolution", "480p")
+
+        if aspect_ratio not in self.supported_aspect_ratios:
+            raise ValueError(f"Unsupported aspect_ratio '{aspect_ratio}'")
+        if resolution not in self.supported_resolutions:
+            raise ValueError(f"Unsupported resolution '{resolution}'")
+
+        image = options.get("image")
+        reference_images = options.get("reference_images")
+        if image is not None and reference_images:
+            raise ValueError("image and reference_images cannot be used together")
+        if reference_images:
+            if len(reference_images) > 7:
+                raise ValueError("reference_images supports at most 7 images")
+            if duration > 10:
+                raise ValueError("duration must be 10 seconds or less when using reference_images")
+
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": prompt,
+            "duration": duration,
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+        }
+        if image is not None:
+            payload["image"] = _image_payload(image)
+        if reference_images:
+            payload["reference_images"] = [_image_payload(img) for img in reference_images]
+
+        headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self.endpoint}/videos/generations",
+                headers=headers,
+                json=payload,
+                timeout=120.0,
+            )
+            if response.status_code >= 400:
+                raise RuntimeError(
+                    f"Grok video generation failed: HTTP {response.status_code}: {_error_text(response)}"
+                )
+
+            start_data = response.json()
+            request_id = start_data.get("request_id")
+            if not request_id:
+                raise RuntimeError("Grok video generation response did not include request_id")
+
+            if not options.get("poll", True):
+                return {
+                    "videos": [],
+                    "meta": {
+                        "video_count": 0,
+                        "request_id": request_id,
+                        "status": start_data.get("status", "pending"),
+                        "duration_seconds": duration,
+                        "aspect_ratio": aspect_ratio,
+                        "resolution": resolution,
+                        "cost": 0.0,
+                        "model_name": f"grok/{model}",
+                        "raw_response": start_data,
+                    },
+                }
+
+            final_data = await self._poll_until_done(
+                client,
+                request_id,
+                headers=headers,
+                poll_interval=float(options.get("poll_interval", 5)),
+                timeout_seconds=float(options.get("timeout", 600)),
+            )
+
+        video = _extract_video_content(final_data)
+        duration_seconds = video.duration_seconds or float(duration)
+        cost = self._calculate_video_cost(
+            "grok",
+            model,
+            duration_seconds=duration_seconds,
+            n=1,
+            resolution=resolution,
+        )
+
+        return {
+            "videos": [video],
+            "meta": {
+                "video_count": 1,
+                "request_id": request_id,
+                "status": final_data.get("status"),
+                "duration_seconds": duration_seconds,
+                "aspect_ratio": aspect_ratio,
+                "resolution": resolution,
+                "cost": cost,
+                "model_name": f"grok/{model}",
+                "raw_response": {"start": start_data, "final": final_data},
+            },
+        }
+
+    async def _poll_until_done(
+        self,
+        client: httpx.AsyncClient,
+        request_id: str,
+        *,
+        headers: dict[str, str],
+        poll_interval: float,
+        timeout_seconds: float,
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            response = await client.get(f"{self.endpoint}/videos/{request_id}", headers=headers, timeout=30.0)
+            if response.status_code >= 400:
+                raise RuntimeError(f"Grok video status failed: HTTP {response.status_code}: {_error_text(response)}")
+
+            data = response.json()
+            status = data.get("status")
+            if status == "done":
+                return data
+            if status in {"failed", "expired"}:
+                raise RuntimeError(f"Grok video generation {status}: {data}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Grok video generation timed out for request_id={request_id}")
+            await asyncio.sleep(poll_interval)

--- a/prompture/drivers/async_openai_img_gen_driver.py
+++ b/prompture/drivers/async_openai_img_gen_driver.py
@@ -48,15 +48,18 @@ class AsyncOpenAIImageGenDriver(ImageCostMixin, AsyncImageGenDriver):
             raise RuntimeError("openai package (>=1.0.0) is not installed")
 
         model = options.get("model", self.model)
+        is_gpt_image = model.startswith("gpt-image")
+        is_dalle3 = "dall-e-3" in model
+
         size = options.get("size", "1024x1024")
-        quality = options.get("quality", "standard")
+        default_quality = "high" if is_gpt_image else "standard"
+        quality = options.get("quality", default_quality)
         n = options.get("n", 1)
         style = options.get("style", "vivid")
 
         images = []
         revised_prompt = None
 
-        is_dalle3 = "dall-e-3" in model
         batch_size = 1 if is_dalle3 else n
 
         remaining = n
@@ -68,11 +71,14 @@ class AsyncOpenAIImageGenDriver(ImageCostMixin, AsyncImageGenDriver):
                 "prompt": prompt,
                 "n": batch_n,
                 "size": size,
-                "response_format": "b64_json",
             }
-            if is_dalle3:
+            if is_gpt_image:
                 kwargs["quality"] = quality
-                kwargs["style"] = style
+            else:
+                kwargs["response_format"] = "b64_json"
+                if is_dalle3:
+                    kwargs["quality"] = quality
+                    kwargs["style"] = style
 
             resp = await self.client.images.generate(**kwargs)
 

--- a/prompture/drivers/async_runway_img_gen_driver.py
+++ b/prompture/drivers/async_runway_img_gen_driver.py
@@ -1,0 +1,137 @@
+"""Async Runway image generation driver. Mirrors :mod:`runway_img_gen_driver`."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Any
+
+import httpx
+
+from ..infra.cost_mixin import ImageCostMixin
+from .async_img_gen_base import AsyncImageGenDriver
+from .runway_img_gen_driver import (
+    _API_VERSION,
+    _DEFAULT_ENDPOINT,
+    _TERMINAL_FAIL,
+    _TERMINAL_OK,
+    RunwayImageGenDriver,
+    _format_error,
+    _get_runway_api_key,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncRunwayImageGenDriver(ImageCostMixin, AsyncImageGenDriver):
+    """Async image generation via Runway ``POST /v1/text_to_image``."""
+
+    supports_multiple = RunwayImageGenDriver.supports_multiple
+    supports_size_variants = RunwayImageGenDriver.supports_size_variants
+    supported_sizes = RunwayImageGenDriver.supported_sizes
+    max_images = RunwayImageGenDriver.max_images
+
+    KNOWN_MODELS = RunwayImageGenDriver.KNOWN_MODELS
+    IMAGE_PRICING = RunwayImageGenDriver.IMAGE_PRICING
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = "gen4_image",
+        endpoint: str | None = None,
+    ):
+        self.api_key = _get_runway_api_key(api_key)
+        self.model = model
+        self.endpoint = (
+            endpoint or os.getenv("RUNWAY_ENDPOINT") or _DEFAULT_ENDPOINT
+        ).rstrip("/")
+
+    @classmethod
+    def list_models(cls, *, api_key: str | None = None, **kw: object) -> list[str] | None:
+        key = _get_runway_api_key(api_key)
+        if not key:
+            return None
+        return list(cls.KNOWN_MODELS)
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "X-Runway-Version": _API_VERSION,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    async def generate_image(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        if not self.api_key:
+            raise RuntimeError(
+                "RUNWAY_API_KEY (or RUNWAYML_API_SECRET) is not configured"
+            )
+
+        # Reuse the sync driver's body-building logic to avoid duplication.
+        builder = RunwayImageGenDriver.__new__(RunwayImageGenDriver)
+        builder.model = self.model
+        model, body = builder._build_body(prompt, options)
+        headers = self._headers()
+
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            resp = await client.post(
+                f"{self.endpoint}/v1/text_to_image", headers=headers, json=body
+            )
+            if resp.status_code >= 400:
+                raise RuntimeError(
+                    f"Runway text_to_image failed: {_format_error(resp.status_code, resp)}"
+                )
+            task = resp.json()
+            task_id = task.get("id")
+            if not task_id:
+                raise RuntimeError(f"Runway response missing task id: {task}")
+
+            if not options.get("poll", True):
+                return RunwayImageGenDriver._pending_response(
+                    builder, task_id, model, body, task
+                )
+
+            final = await self._poll_until_done(
+                client,
+                task_id,
+                headers=headers,
+                poll_interval=float(options.get("poll_interval", 5)),
+                timeout_seconds=float(options.get("timeout", 600)),
+            )
+
+        return RunwayImageGenDriver._build_success_response(
+            builder, final, model, body, options
+        )
+
+    async def _poll_until_done(
+        self,
+        client: httpx.AsyncClient,
+        task_id: str,
+        *,
+        headers: dict[str, str],
+        poll_interval: float,
+        timeout_seconds: float,
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            r = await client.get(
+                f"{self.endpoint}/v1/tasks/{task_id}", headers=headers
+            )
+            if r.status_code >= 400:
+                raise RuntimeError(
+                    f"Runway task poll failed: {_format_error(r.status_code, r)}"
+                )
+            data = r.json()
+            status = data.get("status")
+            if status in _TERMINAL_OK:
+                return data
+            if status in _TERMINAL_FAIL:
+                failure = data.get("failure") or data.get("failureCode") or status
+                raise RuntimeError(f"Runway task {task_id} {status}: {failure}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Runway task {task_id} timed out (status={status})"
+                )
+            await asyncio.sleep(poll_interval)

--- a/prompture/drivers/async_runway_tts_driver.py
+++ b/prompture/drivers/async_runway_tts_driver.py
@@ -1,0 +1,167 @@
+"""Async Runway TTS driver — mirrors :mod:`runway_tts_driver`."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Any
+
+import httpx
+
+from ..infra.cost_mixin import AudioCostMixin
+from .async_tts_base import AsyncTTSDriver
+from .runway_img_gen_driver import (
+    _API_VERSION,
+    _DEFAULT_ENDPOINT,
+    _TERMINAL_FAIL,
+    _TERMINAL_OK,
+    _format_error,
+    _get_runway_api_key,
+)
+from .runway_tts_driver import (
+    PRESET_VOICES,
+    TTS_MODEL,
+    RunwayTTSDriver,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def _fetch_audio(client: httpx.AsyncClient, url: str) -> tuple[bytes, str]:
+    r = await client.get(url, timeout=120.0)
+    if r.status_code >= 400:
+        raise RuntimeError(f"Failed to download audio ({r.status_code}): {url}")
+    return r.content, r.headers.get("content-type", "audio/mpeg")
+
+
+class AsyncRunwayTTSDriver(AudioCostMixin, AsyncTTSDriver):
+    """Async Runway TTS + sound-effect synthesis."""
+
+    supports_streaming = False
+    supports_ssml = False
+    available_voices = list(PRESET_VOICES)
+
+    KNOWN_MODELS = RunwayTTSDriver.KNOWN_MODELS
+    AUDIO_PRICING = RunwayTTSDriver.AUDIO_PRICING
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = TTS_MODEL,
+        endpoint: str | None = None,
+    ):
+        self.api_key = _get_runway_api_key(api_key)
+        self.model = model
+        self.endpoint = (
+            endpoint or os.getenv("RUNWAY_ENDPOINT") or _DEFAULT_ENDPOINT
+        ).rstrip("/")
+
+    @classmethod
+    def list_models(cls, *, api_key: str | None = None, **kw: object) -> list[str] | None:
+        key = _get_runway_api_key(api_key)
+        if not key:
+            return None
+        return list(cls.KNOWN_MODELS)
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "X-Runway-Version": _API_VERSION,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    async def synthesize(self, text: str, options: dict[str, Any]) -> dict[str, Any]:
+        if not self.api_key:
+            raise RuntimeError("RUNWAY_API_KEY (or RUNWAYML_API_SECRET) is not configured")
+        if not text:
+            raise ValueError("text cannot be empty")
+
+        builder = RunwayTTSDriver.__new__(RunwayTTSDriver)
+        builder.model = self.model
+        model, path, body = builder._build(text, options)
+        headers = self._headers()
+
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            resp = await client.post(f"{self.endpoint}{path}", headers=headers, json=body)
+            if resp.status_code >= 400:
+                raise RuntimeError(f"Runway {path} failed: {_format_error(resp.status_code, resp)}")
+            task = resp.json()
+            task_id = task.get("id")
+            if not task_id:
+                raise RuntimeError(f"Runway response missing task id: {task}")
+
+            if not options.get("poll", True):
+                return {
+                    "audio": b"",
+                    "media_type": "audio/mpeg",
+                    "meta": {
+                        "characters": len(text),
+                        "cost": 0.0,
+                        "model_name": f"runway/{model}",
+                        "task_id": task_id,
+                        "status": task.get("status", "PENDING"),
+                        "raw_response": task,
+                    },
+                }
+
+            final = await self._poll_until_done(
+                client,
+                task_id,
+                headers=headers,
+                poll_interval=float(options.get("poll_interval", 5)),
+                timeout_seconds=float(options.get("timeout", 600)),
+            )
+            outputs = final.get("output") or []
+            if not outputs:
+                raise RuntimeError(f"Runway {path} produced no output URLs: {final}")
+            audio, media_type = await _fetch_audio(client, outputs[0])
+
+        characters = len(text)
+        duration_s = float(body.get("duration") or 0.0)
+        cost = self._calculate_audio_cost(
+            "runway",
+            model,
+            duration_seconds=duration_s,
+            characters=characters if model == TTS_MODEL else 0,
+        )
+
+        return {
+            "audio": audio,
+            "media_type": media_type,
+            "meta": {
+                "characters": characters,
+                "cost": cost,
+                "model_name": f"runway/{model}",
+                "task_id": final.get("id"),
+                "status": final.get("status"),
+                "raw_response": final,
+            },
+        }
+
+    async def _poll_until_done(
+        self,
+        client: httpx.AsyncClient,
+        task_id: str,
+        *,
+        headers: dict[str, str],
+        poll_interval: float,
+        timeout_seconds: float,
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            r = await client.get(f"{self.endpoint}/v1/tasks/{task_id}", headers=headers)
+            if r.status_code >= 400:
+                raise RuntimeError(f"Runway task poll failed: {_format_error(r.status_code, r)}")
+            data = r.json()
+            status = data.get("status")
+            if status in _TERMINAL_OK:
+                return data
+            if status in _TERMINAL_FAIL:
+                failure = data.get("failure") or data.get("failureCode") or status
+                raise RuntimeError(f"Runway task {task_id} {status}: {failure}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Runway task {task_id} timed out (status={status})")
+            await asyncio.sleep(poll_interval)

--- a/prompture/drivers/async_runway_video_gen_driver.py
+++ b/prompture/drivers/async_runway_video_gen_driver.py
@@ -1,0 +1,132 @@
+"""Async Runway video generation driver. Mirrors :mod:`runway_video_gen_driver`."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Any
+
+import httpx
+
+from ..infra.cost_mixin import VideoCostMixin
+from .async_video_gen_base import AsyncVideoGenDriver
+from .runway_img_gen_driver import (
+    _API_VERSION,
+    _DEFAULT_ENDPOINT,
+    _TERMINAL_FAIL,
+    _TERMINAL_OK,
+    _format_error,
+    _get_runway_api_key,
+)
+from .runway_video_gen_driver import RunwayVideoGenDriver
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncRunwayVideoGenDriver(VideoCostMixin, AsyncVideoGenDriver):
+    """Async video generation via Runway text/image/video → video endpoints."""
+
+    supports_image_input = RunwayVideoGenDriver.supports_image_input
+    supports_reference_images = RunwayVideoGenDriver.supports_reference_images
+    supports_video_input = RunwayVideoGenDriver.supports_video_input
+    supports_audio = RunwayVideoGenDriver.supports_audio
+    supports_polling = RunwayVideoGenDriver.supports_polling
+    supported_aspect_ratios = RunwayVideoGenDriver.supported_aspect_ratios
+    supported_resolutions = RunwayVideoGenDriver.supported_resolutions
+    max_seconds = RunwayVideoGenDriver.max_seconds
+
+    KNOWN_MODELS = RunwayVideoGenDriver.KNOWN_MODELS
+    VIDEO_PRICING = RunwayVideoGenDriver.VIDEO_PRICING
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = "gen4.5",
+        endpoint: str | None = None,
+    ):
+        self.api_key = _get_runway_api_key(api_key)
+        self.model = model
+        self.endpoint = (
+            endpoint or os.getenv("RUNWAY_ENDPOINT") or _DEFAULT_ENDPOINT
+        ).rstrip("/")
+
+    @classmethod
+    def list_models(cls, *, api_key: str | None = None, **kw: object) -> list[str] | None:
+        key = _get_runway_api_key(api_key)
+        if not key:
+            return None
+        return list(cls.KNOWN_MODELS)
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "X-Runway-Version": _API_VERSION,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    async def generate_video(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        if not self.api_key:
+            raise RuntimeError(
+                "RUNWAY_API_KEY (or RUNWAYML_API_SECRET) is not configured"
+            )
+        if not prompt:
+            raise ValueError("prompt cannot be empty")
+
+        builder = RunwayVideoGenDriver.__new__(RunwayVideoGenDriver)
+        builder.model = self.model
+        mode, path, body = builder._build(prompt, options)
+        headers = self._headers()
+
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            resp = await client.post(f"{self.endpoint}{path}", headers=headers, json=body)
+            if resp.status_code >= 400:
+                raise RuntimeError(
+                    f"Runway {mode} failed: {_format_error(resp.status_code, resp)}"
+                )
+            task = resp.json()
+            task_id = task.get("id")
+            if not task_id:
+                raise RuntimeError(f"Runway response missing task id: {task}")
+
+            if not options.get("poll", True):
+                return RunwayVideoGenDriver._pending_response(builder, task_id, mode, body, task)
+
+            final = await self._poll_until_done(
+                client,
+                task_id,
+                headers=headers,
+                poll_interval=float(options.get("poll_interval", 5)),
+                timeout_seconds=float(options.get("timeout", 600)),
+            )
+
+        return RunwayVideoGenDriver._success_response(builder, final, mode, body, options)
+
+    async def _poll_until_done(
+        self,
+        client: httpx.AsyncClient,
+        task_id: str,
+        *,
+        headers: dict[str, str],
+        poll_interval: float,
+        timeout_seconds: float,
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            r = await client.get(f"{self.endpoint}/v1/tasks/{task_id}", headers=headers)
+            if r.status_code >= 400:
+                raise RuntimeError(
+                    f"Runway task poll failed: {_format_error(r.status_code, r)}"
+                )
+            data = r.json()
+            status = data.get("status")
+            if status in _TERMINAL_OK:
+                return data
+            if status in _TERMINAL_FAIL:
+                failure = data.get("failure") or data.get("failureCode") or status
+                raise RuntimeError(f"Runway task {task_id} {status}: {failure}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Runway task {task_id} timed out (status={status})")
+            await asyncio.sleep(poll_interval)

--- a/prompture/drivers/async_video_gen_base.py
+++ b/prompture/drivers/async_video_gen_base.py
@@ -1,0 +1,78 @@
+"""Async base class for video generation drivers."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from ..infra.callbacks import DriverCallbacks
+
+logger = logging.getLogger("prompture.async_video_gen_driver")
+
+
+class AsyncVideoGenDriver:
+    """Async adapter base for video generation. Implement ``async generate_video(prompt, options)``."""
+
+    supports_image_input: bool = False
+    supports_reference_images: bool = False
+    supports_video_input: bool = False
+    supports_audio: bool = False
+    supports_polling: bool = True
+    supported_aspect_ratios: list[str] = []
+    supported_resolutions: list[str] = []
+    max_seconds: int | None = None
+
+    callbacks: DriverCallbacks | None = None
+
+    async def generate_video(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        """Generate video(s) from a text prompt (async)."""
+        raise NotImplementedError
+
+    async def generate_video_with_hooks(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        """Wrap :meth:`generate_video` with on_request / on_response / on_error callbacks."""
+        driver_name = getattr(self, "model", self.__class__.__name__)
+        self._fire_callback(
+            "on_request",
+            {"prompt_length": len(prompt), "options": options, "driver": driver_name},
+        )
+        t0 = time.perf_counter()
+        try:
+            resp = await self.generate_video(prompt, options)
+        except Exception as exc:
+            self._fire_callback(
+                "on_error",
+                {"error": exc, "prompt_length": len(prompt), "options": options, "driver": driver_name},
+            )
+            raise
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+        meta = resp.get("meta", {})
+        logger.debug(
+            "[video_gen] async generate driver=%s videos=%d cost=%.6f elapsed=%.0fms",
+            driver_name,
+            meta.get("video_count", 0),
+            meta.get("cost", 0.0),
+            elapsed_ms,
+        )
+        self._fire_callback(
+            "on_response",
+            {
+                "video_count": meta.get("video_count", 0),
+                "meta": meta,
+                "driver": driver_name,
+                "elapsed_ms": elapsed_ms,
+            },
+        )
+        return resp
+
+    def _fire_callback(self, event: str, payload: dict[str, Any]) -> None:
+        """Invoke a single callback, swallowing and logging any exception."""
+        if self.callbacks is None:
+            return
+        cb = getattr(self.callbacks, event, None)
+        if cb is None:
+            return
+        try:
+            cb(payload)
+        except Exception:
+            logger.exception("Callback %s raised an exception", event)

--- a/prompture/drivers/grok_video_gen_driver.py
+++ b/prompture/drivers/grok_video_gen_driver.py
@@ -1,0 +1,241 @@
+"""xAI Grok Imagine video generation driver."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import httpx
+
+from ..infra.cost_mixin import VideoCostMixin
+from ..media.image import ImageContent, ImageInput, make_image
+from ..media.video import VideoContent, video_from_url
+from .video_gen_base import VideoGenDriver
+
+_DEFAULT_ENDPOINT = "https://api.x.ai/v1"
+
+
+def _get_xai_api_key(api_key: str | None = None) -> str | None:
+    return api_key or os.getenv("GROK_API_KEY") or os.getenv("XAI_API_KEY")
+
+
+def _duration_from_options(options: dict[str, Any], default: int = 8) -> int:
+    duration = options.get("duration", options.get("seconds", default))
+    try:
+        value = int(duration)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("duration must be an integer number of seconds") from exc
+    if value < 1 or value > 15:
+        raise ValueError("duration must be between 1 and 15 seconds")
+    return value
+
+
+def _image_payload(image: ImageInput | dict[str, Any]) -> dict[str, str]:
+    if isinstance(image, dict):
+        if "url" in image:
+            return {"url": str(image["url"])}
+        if "data" in image:
+            return {"url": str(image["data"])}
+        raise ValueError("image dictionaries must include 'url' or 'data'")
+
+    content: ImageContent = make_image(image)
+    if content.source_type == "url":
+        if not content.url:
+            raise ValueError("URL image input is missing a URL")
+        return {"url": content.url}
+    return {"url": f"data:{content.media_type};base64,{content.data}"}
+
+
+def _extract_video_content(data: dict[str, Any]) -> VideoContent:
+    video_info = data.get("video") or {}
+    url = video_info.get("url")
+    if not url:
+        raise RuntimeError("Grok video generation completed without a video URL")
+    duration = video_info.get("duration")
+    try:
+        duration_seconds = float(duration) if duration is not None else None
+    except (TypeError, ValueError):
+        duration_seconds = None
+    return video_from_url(url, duration_seconds=duration_seconds)
+
+
+def _error_text(response: httpx.Response) -> str:
+    try:
+        return response.text
+    except Exception:
+        return "<unavailable>"
+
+
+class GrokVideoGenDriver(VideoCostMixin, VideoGenDriver):
+    """Video generation via xAI Grok Imagine Video REST API."""
+
+    supports_image_input = True
+    supports_reference_images = True
+    supports_video_input = False
+    supports_audio = True
+    supports_polling = True
+    supported_aspect_ratios = ["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"]
+    supported_resolutions = ["480p", "720p"]
+    max_seconds = 15
+
+    KNOWN_MODELS = ["grok-imagine-video"]
+    VIDEO_PRICING: dict[str, dict[str, Any]] = {
+        "grok-imagine-video": {
+            "per_second": 0.05,
+            "per_second_by_resolution": {
+                "480p": 0.05,
+                "720p": 0.07,
+            },
+        }
+    }
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = "grok-imagine-video",
+        endpoint: str | None = None,
+    ):
+        self.api_key = _get_xai_api_key(api_key)
+        self.model = model
+        self.endpoint = (endpoint or os.getenv("GROK_ENDPOINT") or _DEFAULT_ENDPOINT).rstrip("/")
+
+    @classmethod
+    def list_models(cls, *, api_key: str | None = None, **kw: object) -> list[str] | None:
+        """Return known xAI video models when an API key is configured."""
+        key = _get_xai_api_key(api_key)
+        if not key:
+            return None
+        return list(cls.KNOWN_MODELS)
+
+    def generate_video(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        """Generate a video using xAI Grok Imagine Video.
+
+        Options:
+            model: Model override. Defaults to ``grok-imagine-video``.
+            duration/seconds: Length in seconds, 1-15. Defaults to 8.
+            aspect_ratio: One of the supported aspect ratios. Defaults to ``16:9``.
+            resolution: ``480p`` or ``720p``. Defaults to ``480p``.
+            image: Optional image URL, data URI, bytes, path, or ImageContent for image-to-video.
+            reference_images: Optional list of image inputs for reference-to-video.
+            poll: Whether to poll until complete. Defaults to True.
+            poll_interval: Seconds between polls. Defaults to 5.
+            timeout: Maximum polling seconds. Defaults to 600.
+        """
+        if not self.api_key:
+            raise RuntimeError("GROK_API_KEY or XAI_API_KEY environment variable is required")
+        if not prompt:
+            raise ValueError("prompt cannot be empty")
+
+        model = options.get("model", self.model)
+        duration = _duration_from_options(options)
+        aspect_ratio = options.get("aspect_ratio", "16:9")
+        resolution = options.get("resolution", "480p")
+
+        if aspect_ratio not in self.supported_aspect_ratios:
+            raise ValueError(f"Unsupported aspect_ratio '{aspect_ratio}'")
+        if resolution not in self.supported_resolutions:
+            raise ValueError(f"Unsupported resolution '{resolution}'")
+
+        image = options.get("image")
+        reference_images = options.get("reference_images")
+        if image is not None and reference_images:
+            raise ValueError("image and reference_images cannot be used together")
+        if reference_images:
+            if len(reference_images) > 7:
+                raise ValueError("reference_images supports at most 7 images")
+            if duration > 10:
+                raise ValueError("duration must be 10 seconds or less when using reference_images")
+
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": prompt,
+            "duration": duration,
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+        }
+        if image is not None:
+            payload["image"] = _image_payload(image)
+        if reference_images:
+            payload["reference_images"] = [_image_payload(img) for img in reference_images]
+
+        headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+        response = httpx.post(f"{self.endpoint}/videos/generations", headers=headers, json=payload, timeout=120.0)
+        if response.status_code >= 400:
+            raise RuntimeError(f"Grok video generation failed: HTTP {response.status_code}: {_error_text(response)}")
+
+        start_data = response.json()
+        request_id = start_data.get("request_id")
+        if not request_id:
+            raise RuntimeError("Grok video generation response did not include request_id")
+
+        if not options.get("poll", True):
+            return {
+                "videos": [],
+                "meta": {
+                    "video_count": 0,
+                    "request_id": request_id,
+                    "status": start_data.get("status", "pending"),
+                    "duration_seconds": duration,
+                    "aspect_ratio": aspect_ratio,
+                    "resolution": resolution,
+                    "cost": 0.0,
+                    "model_name": f"grok/{model}",
+                    "raw_response": start_data,
+                },
+            }
+
+        final_data = self._poll_until_done(
+            request_id,
+            headers=headers,
+            poll_interval=float(options.get("poll_interval", 5)),
+            timeout_seconds=float(options.get("timeout", 600)),
+        )
+        video = _extract_video_content(final_data)
+        duration_seconds = video.duration_seconds or float(duration)
+        cost = self._calculate_video_cost(
+            "grok",
+            model,
+            duration_seconds=duration_seconds,
+            n=1,
+            resolution=resolution,
+        )
+
+        return {
+            "videos": [video],
+            "meta": {
+                "video_count": 1,
+                "request_id": request_id,
+                "status": final_data.get("status"),
+                "duration_seconds": duration_seconds,
+                "aspect_ratio": aspect_ratio,
+                "resolution": resolution,
+                "cost": cost,
+                "model_name": f"grok/{model}",
+                "raw_response": {"start": start_data, "final": final_data},
+            },
+        }
+
+    def _poll_until_done(
+        self,
+        request_id: str,
+        *,
+        headers: dict[str, str],
+        poll_interval: float,
+        timeout_seconds: float,
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            response = httpx.get(f"{self.endpoint}/videos/{request_id}", headers=headers, timeout=30.0)
+            if response.status_code >= 400:
+                raise RuntimeError(f"Grok video status failed: HTTP {response.status_code}: {_error_text(response)}")
+
+            data = response.json()
+            status = data.get("status")
+            if status == "done":
+                return data
+            if status in {"failed", "expired"}:
+                raise RuntimeError(f"Grok video generation {status}: {data}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Grok video generation timed out for request_id={request_id}")
+            time.sleep(poll_interval)

--- a/prompture/drivers/openai_img_gen_driver.py
+++ b/prompture/drivers/openai_img_gen_driver.py
@@ -23,7 +23,15 @@ class OpenAIImageGenDriver(ImageCostMixin, ImageGenDriver):
 
     supports_multiple = True
     supports_size_variants = True
-    supported_sizes = ["256x256", "512x512", "1024x1024", "1792x1024", "1024x1792"]
+    supported_sizes = [
+        "256x256",
+        "512x512",
+        "1024x1024",
+        "1536x1024",
+        "1024x1536",
+        "1792x1024",
+        "1024x1792",
+    ]
     max_images = 10
 
     IMAGE_PRICING = {
@@ -39,6 +47,26 @@ class OpenAIImageGenDriver(ImageCostMixin, ImageGenDriver):
             "256x256": 0.016,
             "512x512": 0.018,
             "1024x1024": 0.020,
+        },
+        # gpt-image-1 (and gpt-image-2 when OpenAI ships it) — token-priced in reality;
+        # values below are per-image USD approximations published by OpenAI.
+        "gpt-image-1": {
+            "1024x1024/low": 0.011,
+            "1024x1024/medium": 0.042,
+            "1024x1024/high": 0.167,
+            "1536x1024/low": 0.016,
+            "1536x1024/medium": 0.063,
+            "1536x1024/high": 0.25,
+            "1024x1536/low": 0.016,
+            "1024x1536/medium": 0.063,
+            "1024x1536/high": 0.25,
+            "default": 0.042,
+        },
+        "gpt-image-2": {
+            "1024x1024/low": 0.011,
+            "1024x1024/medium": 0.042,
+            "1024x1024/high": 0.167,
+            "default": 0.042,
         },
     }
 
@@ -62,8 +90,13 @@ class OpenAIImageGenDriver(ImageCostMixin, ImageGenDriver):
             raise RuntimeError("openai package (>=1.0.0) is not installed")
 
         model = options.get("model", self.model)
+        is_gpt_image = model.startswith("gpt-image")
+        is_dalle3 = "dall-e-3" in model
+
         size = options.get("size", "1024x1024")
-        quality = options.get("quality", "standard")
+        # gpt-image-* uses low/medium/high/auto; DALL-E 3 uses standard/hd; DALL-E 2 ignores quality.
+        default_quality = "high" if is_gpt_image else "standard"
+        quality = options.get("quality", default_quality)
         n = options.get("n", 1)
         style = options.get("style", "vivid")
 
@@ -71,7 +104,6 @@ class OpenAIImageGenDriver(ImageCostMixin, ImageGenDriver):
         revised_prompt = None
 
         # DALL-E 3 only supports n=1, so we loop for multiple images
-        is_dalle3 = "dall-e-3" in model
         batch_size = 1 if is_dalle3 else n
 
         remaining = n
@@ -83,11 +115,15 @@ class OpenAIImageGenDriver(ImageCostMixin, ImageGenDriver):
                 "prompt": prompt,
                 "n": batch_n,
                 "size": size,
-                "response_format": "b64_json",
             }
-            if is_dalle3:
+            if is_gpt_image:
+                # gpt-image-* always returns b64; passing response_format is rejected.
                 kwargs["quality"] = quality
-                kwargs["style"] = style
+            else:
+                kwargs["response_format"] = "b64_json"
+                if is_dalle3:
+                    kwargs["quality"] = quality
+                    kwargs["style"] = style
 
             resp = self.client.images.generate(**kwargs)
 

--- a/prompture/drivers/provider_descriptors.py
+++ b/prompture/drivers/provider_descriptors.py
@@ -491,7 +491,7 @@ def _build_descriptors() -> list[ProviderDescriptor]:
         )
     )
 
-    # ── Runway (image gen via /v1/text_to_image) ─────────────────────
+    # ── Runway (image / video / TTS) ─────────────────────────────────
     _runway_kw = {"api_key": "runway_api_key", "endpoint": "runway_endpoint"}
     descriptors.append(
         ProviderDescriptor(
@@ -501,6 +501,18 @@ def _build_descriptors() -> list[ProviderDescriptor]:
             ),
             img_gen_async=DriverSpec(
                 "async_runway_img_gen_driver.AsyncRunwayImageGenDriver", _runway_kw, "gen4_image"
+            ),
+            video_gen_sync=DriverSpec(
+                "runway_video_gen_driver.RunwayVideoGenDriver", _runway_kw, "gen4.5"
+            ),
+            video_gen_async=DriverSpec(
+                "async_runway_video_gen_driver.AsyncRunwayVideoGenDriver", _runway_kw, "gen4.5"
+            ),
+            tts_sync=DriverSpec(
+                "runway_tts_driver.RunwayTTSDriver", _runway_kw, "eleven_multilingual_v2"
+            ),
+            tts_async=DriverSpec(
+                "async_runway_tts_driver.AsyncRunwayTTSDriver", _runway_kw, "eleven_multilingual_v2"
             ),
             display_name="Runway",
             is_configured_check="runway_api_key",
@@ -522,7 +534,7 @@ def _build_descriptors() -> list[ProviderDescriptor]:
         ("zhipu", "zai", {"llm"}),
         ("hf", "huggingface", {"llm"}),
         ("dalle", "openai", {"img_gen"}),
-        ("runwayml", "runway", {"img_gen"}),
+        ("runwayml", "runway", {"img_gen", "video_gen", "tts"}),
         ("vertex", "google_vertexai", {"llm"}),
         ("vertexai", "google_vertexai", {"llm"}),
     ]

--- a/prompture/drivers/provider_descriptors.py
+++ b/prompture/drivers/provider_descriptors.py
@@ -4,7 +4,7 @@ Each ``ProviderDescriptor`` describes one canonical provider (or an alias for
 one) and carries enough metadata to:
 
 * register sync + async driver factories for every modality (LLM, STT, TTS,
-  image-gen, embedding)
+  image-gen, video-gen, embedding)
 * populate ``PROVIDER_DRIVER_MAP`` / ``ASYNC_PROVIDER_DRIVER_MAP``
 * drive the discovery module's ``is_configured`` / ``list_models_kwargs`` logic
 * generate the ``PROVIDER_MAP`` in ``model_rates.py``
@@ -57,6 +57,9 @@ class ProviderDescriptor:
 
     img_gen_sync: DriverSpec | None = None
     img_gen_async: DriverSpec | None = None
+
+    video_gen_sync: DriverSpec | None = None
+    video_gen_async: DriverSpec | None = None
 
     embedding_sync: DriverSpec | None = None
     embedding_async: DriverSpec | None = None
@@ -248,6 +251,12 @@ def _build_descriptors() -> list[ProviderDescriptor]:
             **_llm("grok_driver", "GrokDriver", "async_grok_driver", "AsyncGrokDriver", _grok_kw, "grok_model"),
             img_gen_sync=DriverSpec("grok_img_gen_driver.GrokImageGenDriver", _grok_kw, "grok-2-image"),
             img_gen_async=DriverSpec("async_grok_img_gen_driver.AsyncGrokImageGenDriver", _grok_kw, "grok-2-image"),
+            video_gen_sync=DriverSpec(
+                "grok_video_gen_driver.GrokVideoGenDriver", _grok_kw, "grok_video_model"
+            ),
+            video_gen_async=DriverSpec(
+                "async_grok_video_gen_driver.AsyncGrokVideoGenDriver", _grok_kw, "grok_video_model"
+            ),
             display_name="xAI Grok",
             is_configured_check="grok_api_key",
             list_models_kwargs=[("api_key", "grok_api_key", "GROK_API_KEY")],
@@ -491,7 +500,7 @@ def _build_descriptors() -> list[ProviderDescriptor]:
         ("anthropic", "claude", {"llm"}),
         ("gemini", "google", {"llm", "img_gen"}),
         ("chatgpt", "openai", {"llm", "embedding"}),
-        ("xai", "grok", {"llm", "img_gen"}),
+        ("xai", "grok", {"llm", "img_gen", "video_gen"}),
         ("lm_studio", "lmstudio", {"llm"}),
         ("lm-studio", "lmstudio", {"llm"}),
         ("zhipu", "zai", {"llm"}),
@@ -517,6 +526,8 @@ def _build_descriptors() -> list[ProviderDescriptor]:
             tts_async=canon.tts_async if "tts" in modalities else None,
             img_gen_sync=canon.img_gen_sync if "img_gen" in modalities else None,
             img_gen_async=canon.img_gen_async if "img_gen" in modalities else None,
+            video_gen_sync=canon.video_gen_sync if "video_gen" in modalities else None,
+            video_gen_async=canon.video_gen_async if "video_gen" in modalities else None,
             embedding_sync=canon.embedding_sync if "embedding" in modalities else None,
             embedding_async=canon.embedding_async if "embedding" in modalities else None,
             is_configured_check=canon.is_configured_check,
@@ -596,11 +607,13 @@ def register_all_builtin_drivers() -> None:
         register_async_img_gen_driver,
         register_async_stt_driver,
         register_async_tts_driver,
+        register_async_video_gen_driver,
         register_driver,
         register_embedding_driver,
         register_img_gen_driver,
         register_stt_driver,
         register_tts_driver,
+        register_video_gen_driver,
     )
 
     _MODALITY_REGISTRARS = {
@@ -612,6 +625,8 @@ def register_all_builtin_drivers() -> None:
         "tts_async": register_async_tts_driver,
         "img_gen_sync": register_img_gen_driver,
         "img_gen_async": register_async_img_gen_driver,
+        "video_gen_sync": register_video_gen_driver,
+        "video_gen_async": register_async_video_gen_driver,
         "embedding_sync": register_embedding_driver,
         "embedding_async": register_async_embedding_driver,
     }

--- a/prompture/drivers/provider_descriptors.py
+++ b/prompture/drivers/provider_descriptors.py
@@ -491,6 +491,22 @@ def _build_descriptors() -> list[ProviderDescriptor]:
         )
     )
 
+    # ── Runway (image gen via /v1/text_to_image) ─────────────────────
+    _runway_kw = {"api_key": "runway_api_key", "endpoint": "runway_endpoint"}
+    descriptors.append(
+        ProviderDescriptor(
+            name="runway",
+            img_gen_sync=DriverSpec(
+                "runway_img_gen_driver.RunwayImageGenDriver", _runway_kw, "gen4_image"
+            ),
+            img_gen_async=DriverSpec(
+                "async_runway_img_gen_driver.AsyncRunwayImageGenDriver", _runway_kw, "gen4_image"
+            ),
+            display_name="Runway",
+            is_configured_check="runway_api_key",
+        )
+    )
+
     # ── Aliases ───────────────────────────────────────────────────────
     # Each alias specifies exactly which modalities it covers, matching
     # the original per-file registrations.  Format:
@@ -506,6 +522,7 @@ def _build_descriptors() -> list[ProviderDescriptor]:
         ("zhipu", "zai", {"llm"}),
         ("hf", "huggingface", {"llm"}),
         ("dalle", "openai", {"img_gen"}),
+        ("runwayml", "runway", {"img_gen"}),
         ("vertex", "google_vertexai", {"llm"}),
         ("vertexai", "google_vertexai", {"llm"}),
     ]

--- a/prompture/drivers/registry.py
+++ b/prompture/drivers/registry.py
@@ -43,6 +43,11 @@ _tts_async = DriverRegistry("TTS async", "prompture.async_tts_drivers", error_pr
 _img_gen_sync = DriverRegistry("image gen sync", "prompture.img_gen_drivers", error_prefix="image gen ")
 _img_gen_async = DriverRegistry("image gen async", "prompture.async_img_gen_drivers", error_prefix="async image gen ")
 
+_video_gen_sync = DriverRegistry("video gen sync", "prompture.video_gen_drivers", error_prefix="video gen ")
+_video_gen_async = DriverRegistry(
+    "video gen async", "prompture.async_video_gen_drivers", error_prefix="async video gen "
+)
+
 _embedding_sync = DriverRegistry("embedding sync", "prompture.embedding_drivers", error_prefix="embedding ")
 _embedding_async = DriverRegistry(
     "embedding async", "prompture.async_embedding_drivers", error_prefix="async embedding "
@@ -368,6 +373,68 @@ def load_img_gen_entry_point_drivers() -> tuple[int, int]:
     return (_img_gen_sync.load_entry_points(), _img_gen_async.load_entry_points())
 
 
+# ── Video Gen ─────────────────────────────────────────────────────────────
+
+
+def register_video_gen_driver(name: str, factory: DriverFactory, *, overwrite: bool = False) -> None:
+    """Register a sync video generation driver factory for a provider name."""
+    _video_gen_sync.register(name, factory, overwrite=overwrite)
+
+
+def register_async_video_gen_driver(name: str, factory: DriverFactory, *, overwrite: bool = False) -> None:
+    """Register an async video generation driver factory for a provider name."""
+    _video_gen_async.register(name, factory, overwrite=overwrite)
+
+
+def unregister_video_gen_driver(name: str) -> bool:
+    """Unregister a sync video gen driver by name."""
+    return _video_gen_sync.unregister(name)
+
+
+def unregister_async_video_gen_driver(name: str) -> bool:
+    """Unregister an async video gen driver by name."""
+    return _video_gen_async.unregister(name)
+
+
+def list_registered_video_gen_drivers() -> list[str]:
+    """Return a sorted list of registered sync video gen driver names."""
+    return _video_gen_sync.list_names()
+
+
+def list_registered_async_video_gen_drivers() -> list[str]:
+    """Return a sorted list of registered async video gen driver names."""
+    return _video_gen_async.list_names()
+
+
+def is_video_gen_driver_registered(name: str) -> bool:
+    """Check if a sync video gen driver is registered."""
+    return _video_gen_sync.is_registered(name)
+
+
+def is_async_video_gen_driver_registered(name: str) -> bool:
+    """Check if an async video gen driver is registered."""
+    return _video_gen_async.is_registered(name)
+
+
+def get_video_gen_driver_factory(name: str) -> DriverFactory:
+    """Get a registered sync video gen driver factory by name."""
+    return _video_gen_sync.get_factory(name)
+
+
+def get_async_video_gen_driver_factory(name: str) -> DriverFactory:
+    """Get a registered async video gen driver factory by name."""
+    return _video_gen_async.get_factory(name)
+
+
+def load_video_gen_entry_point_drivers() -> tuple[int, int]:
+    """Load video gen drivers from installed packages via entry points.
+
+    Returns:
+        A tuple of (sync_count, async_count) counts.
+    """
+    return (_video_gen_sync.load_entry_points(), _video_gen_async.load_entry_points())
+
+
 # ── Embedding ──────────────────────────────────────────────────────────────
 
 
@@ -467,6 +534,14 @@ def _get_async_img_gen_registry() -> dict[str, DriverFactory]:
     return _img_gen_async.dict
 
 
+def _get_video_gen_registry() -> dict[str, DriverFactory]:
+    return _video_gen_sync.dict
+
+
+def _get_async_video_gen_registry() -> dict[str, DriverFactory]:
+    return _video_gen_async.dict
+
+
 def _get_embedding_registry() -> dict[str, DriverFactory]:
     return _embedding_sync.dict
 
@@ -485,6 +560,8 @@ def _reset_registries() -> None:
     _tts_async.reset()
     _img_gen_sync.reset()
     _img_gen_async.reset()
+    _video_gen_sync.reset()
+    _video_gen_async.reset()
     _embedding_sync.reset()
     _embedding_async.reset()
 
@@ -501,5 +578,7 @@ _TTS_REGISTRY = _tts_sync._registry
 _ASYNC_TTS_REGISTRY = _tts_async._registry
 _IMG_GEN_REGISTRY = _img_gen_sync._registry
 _ASYNC_IMG_GEN_REGISTRY = _img_gen_async._registry
+_VIDEO_GEN_REGISTRY = _video_gen_sync._registry
+_ASYNC_VIDEO_GEN_REGISTRY = _video_gen_async._registry
 _EMBEDDING_REGISTRY = _embedding_sync._registry
 _ASYNC_EMBEDDING_REGISTRY = _embedding_async._registry

--- a/prompture/drivers/runway_audio_transform_driver.py
+++ b/prompture/drivers/runway_audio_transform_driver.py
@@ -1,0 +1,251 @@
+"""Runway audio-transform driver — voice dubbing, voice isolation, and speech-to-speech.
+
+These three endpoints take audio (or video) as input and emit audio as output,
+which doesn't fit Prompture's STT (audio → text) or TTS (text → audio) modality
+contracts. The driver lives outside the modality registry; import it directly:
+
+    from prompture.drivers import RunwayAudioTransformDriver
+    driver = RunwayAudioTransformDriver()
+    result = driver.dub("https://.../audio.mp3", target_lang="es")
+
+All three methods submit a task, poll until terminal, download the resulting
+audio, and return ``{"audio": bytes, "media_type": str, "meta": {...}}``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any
+
+import httpx
+
+from .runway_img_gen_driver import (
+    _API_VERSION,
+    _DEFAULT_ENDPOINT,
+    _TERMINAL_FAIL,
+    _TERMINAL_OK,
+    _format_error,
+    _get_runway_api_key,
+)
+
+logger = logging.getLogger(__name__)
+
+VOICE_DUBBING_MODEL = "eleven_voice_dubbing"
+VOICE_ISOLATION_MODEL = "eleven_voice_isolation"
+SPEECH_TO_SPEECH_MODEL = "eleven_multilingual_sts_v2"
+
+DUBBING_LANGUAGES: set[str] = {
+    "en", "hi", "pt", "zh", "es", "fr", "de", "ja", "ar", "ru", "ko", "id",
+    "it", "nl", "tr", "pl", "sv", "fil", "ms", "ro", "uk", "el", "cs", "da",
+    "fi", "bg", "hr", "sk", "ta",
+}
+
+
+def _normalize_media_input(media: Any, *, kind: str = "audio") -> dict[str, str]:
+    """Return a ``{type, uri}`` block for a media argument."""
+    if isinstance(media, str):
+        return {"type": kind, "uri": media}
+    if isinstance(media, dict):
+        uri = media.get("uri") or media.get("url")
+        if not uri:
+            raise ValueError(f"{kind} dict must include 'uri'")
+        return {"type": media.get("type", kind), "uri": str(uri)}
+    raise ValueError(f"unsupported {kind} input type: {type(media).__name__}")
+
+
+def _fetch_audio(client: httpx.Client, url: str) -> tuple[bytes, str]:
+    r = client.get(url, timeout=120.0)
+    if r.status_code >= 400:
+        raise RuntimeError(f"Failed to download audio ({r.status_code}): {url}")
+    return r.content, r.headers.get("content-type", "audio/mpeg")
+
+
+class RunwayAudioTransformDriver:
+    """Runway audio-transform operations (dub / isolate / convert voice)."""
+
+    KNOWN_MODELS = [
+        VOICE_DUBBING_MODEL,
+        VOICE_ISOLATION_MODEL,
+        SPEECH_TO_SPEECH_MODEL,
+    ]
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        endpoint: str | None = None,
+    ):
+        self.api_key = _get_runway_api_key(api_key)
+        self.endpoint = (
+            endpoint or os.getenv("RUNWAY_ENDPOINT") or _DEFAULT_ENDPOINT
+        ).rstrip("/")
+
+    # ── public API ──────────────────────────────────────────────────────
+
+    def dub(
+        self,
+        audio: str | dict[str, Any],
+        target_lang: str,
+        *,
+        disable_voice_cloning: bool | None = None,
+        drop_background_audio: bool | None = None,
+        num_speakers: int | None = None,
+        poll: bool = True,
+        poll_interval: float = 5.0,
+        timeout: float = 600.0,
+    ) -> dict[str, Any]:
+        """Dub the input audio to ``target_lang`` (ISO 639-1 code)."""
+        if target_lang not in DUBBING_LANGUAGES:
+            raise ValueError(
+                f"Unsupported targetLang {target_lang!r}. Accepted: {sorted(DUBBING_LANGUAGES)}"
+            )
+        audio_norm = _normalize_media_input(audio, kind="audio")
+        body: dict[str, Any] = {
+            "model": VOICE_DUBBING_MODEL,
+            "audioUri": audio_norm["uri"],
+            "targetLang": target_lang,
+        }
+        if disable_voice_cloning is not None:
+            body["disableVoiceCloning"] = bool(disable_voice_cloning)
+        if drop_background_audio is not None:
+            body["dropBackgroundAudio"] = bool(drop_background_audio)
+        if num_speakers is not None:
+            body["numSpeakers"] = int(num_speakers)
+        return self._submit_and_collect(
+            "/v1/voice_dubbing", body, poll=poll, poll_interval=poll_interval, timeout=timeout
+        )
+
+    def isolate(
+        self,
+        audio: str | dict[str, Any],
+        *,
+        poll: bool = True,
+        poll_interval: float = 5.0,
+        timeout: float = 600.0,
+    ) -> dict[str, Any]:
+        """Isolate voice from background audio (4.6 s ≤ duration < 3600 s)."""
+        audio_norm = _normalize_media_input(audio, kind="audio")
+        body = {
+            "model": VOICE_ISOLATION_MODEL,
+            "audioUri": audio_norm["uri"],
+        }
+        return self._submit_and_collect(
+            "/v1/voice_isolation", body, poll=poll, poll_interval=poll_interval, timeout=timeout
+        )
+
+    def convert_voice(
+        self,
+        media: str | dict[str, Any],
+        voice_preset_id: str,
+        *,
+        media_kind: str = "audio",
+        remove_background_noise: bool | None = None,
+        poll: bool = True,
+        poll_interval: float = 5.0,
+        timeout: float = 600.0,
+    ) -> dict[str, Any]:
+        """Re-voice ``media`` (audio or video) with the given Runway voice preset."""
+        if media_kind not in {"audio", "video"}:
+            raise ValueError("media_kind must be 'audio' or 'video'")
+        media_norm = _normalize_media_input(media, kind=media_kind)
+        body: dict[str, Any] = {
+            "model": SPEECH_TO_SPEECH_MODEL,
+            "media": media_norm,
+            "voice": {"type": "runway-preset", "presetId": voice_preset_id},
+        }
+        if remove_background_noise is not None:
+            body["removeBackgroundNoise"] = bool(remove_background_noise)
+        return self._submit_and_collect(
+            "/v1/speech_to_speech", body, poll=poll, poll_interval=poll_interval, timeout=timeout
+        )
+
+    # ── internals ───────────────────────────────────────────────────────
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "X-Runway-Version": _API_VERSION,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def _submit_and_collect(
+        self,
+        path: str,
+        body: dict[str, Any],
+        *,
+        poll: bool,
+        poll_interval: float,
+        timeout: float,
+    ) -> dict[str, Any]:
+        if not self.api_key:
+            raise RuntimeError("RUNWAY_API_KEY (or RUNWAYML_API_SECRET) is not configured")
+        headers = self._headers()
+
+        with httpx.Client(timeout=120.0) as client:
+            resp = client.post(f"{self.endpoint}{path}", headers=headers, json=body)
+            if resp.status_code >= 400:
+                raise RuntimeError(f"Runway {path} failed: {_format_error(resp.status_code, resp)}")
+            task = resp.json()
+            task_id = task.get("id")
+            if not task_id:
+                raise RuntimeError(f"Runway response missing task id: {task}")
+
+            if not poll:
+                return {
+                    "audio": b"",
+                    "media_type": "audio/mpeg",
+                    "meta": {
+                        "model_name": f"runway/{body['model']}",
+                        "endpoint": path,
+                        "task_id": task_id,
+                        "status": task.get("status", "PENDING"),
+                        "raw_response": task,
+                    },
+                }
+
+            final = self._poll_until_done(
+                client, task_id, headers=headers, poll_interval=poll_interval, timeout_seconds=timeout
+            )
+            outputs = final.get("output") or []
+            if not outputs:
+                raise RuntimeError(f"Runway {path} produced no output URLs: {final}")
+            audio, media_type = _fetch_audio(client, outputs[0])
+
+        return {
+            "audio": audio,
+            "media_type": media_type,
+            "meta": {
+                "model_name": f"runway/{body['model']}",
+                "endpoint": path,
+                "task_id": final.get("id"),
+                "status": final.get("status"),
+                "raw_response": final,
+            },
+        }
+
+    def _poll_until_done(
+        self,
+        client: httpx.Client,
+        task_id: str,
+        *,
+        headers: dict[str, str],
+        poll_interval: float,
+        timeout_seconds: float,
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            r = client.get(f"{self.endpoint}/v1/tasks/{task_id}", headers=headers)
+            if r.status_code >= 400:
+                raise RuntimeError(f"Runway task poll failed: {_format_error(r.status_code, r)}")
+            data = r.json()
+            status = data.get("status")
+            if status in _TERMINAL_OK:
+                return data
+            if status in _TERMINAL_FAIL:
+                failure = data.get("failure") or data.get("failureCode") or status
+                raise RuntimeError(f"Runway task {task_id} {status}: {failure}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Runway task {task_id} timed out (status={status})")
+            time.sleep(poll_interval)

--- a/prompture/drivers/runway_capabilities.py
+++ b/prompture/drivers/runway_capabilities.py
@@ -1,0 +1,190 @@
+"""Per-model capability registry for Runway models.
+
+Runway's endpoints are operation-shaped: each path (``/v1/text_to_image``,
+``/v1/image_to_video``, ``/v1/voice_dubbing`` …) is what a model can *do*.
+The same model often supports multiple operations (``gen4.5`` does both
+``text_to_video`` and ``image_to_video``) or is locked to one
+(``gen4_aleph`` is video_to_video only).
+
+This module exposes that mapping as data so callers can answer:
+
+- *What operations does model X support?* → :func:`get_runway_model_info`
+- *Which models can do text_to_video?*    → :func:`get_runway_models_by_op`
+- *Give me everything I know about Runway* → :data:`RUNWAY_MODEL_INFO`
+
+Driver classes still own the request shape; this is metadata only.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class RunwayModelInfo(TypedDict):
+    """Capability metadata for a single Runway model."""
+
+    modality: str  # "image" | "video" | "audio"
+    operations: list[str]  # e.g. ["text_to_video", "image_to_video"]
+    endpoints: list[str]  # POST paths, one per operation
+    cost: str  # human-readable cost note
+
+
+# Operation names mirror Runway's endpoint slugs.
+RUNWAY_MODEL_INFO: dict[str, RunwayModelInfo] = {
+    # ── Image (POST /v1/text_to_image) ───────────────────────────────
+    "gen4_image": {
+        "modality": "image",
+        "operations": ["text_to_image"],
+        "endpoints": ["/v1/text_to_image"],
+        "cost": "$0.05 (720p) / $0.08 (1080p) per image",
+    },
+    "gen4_image_turbo": {
+        "modality": "image",
+        "operations": ["text_to_image"],
+        "endpoints": ["/v1/text_to_image"],
+        "cost": "$0.02 per image (reference image required)",
+    },
+    "gpt_image_2": {
+        "modality": "image",
+        "operations": ["text_to_image"],
+        "endpoints": ["/v1/text_to_image"],
+        "cost": "$0.04 (low) / $0.06 (medium) / $0.08 (high) per image",
+    },
+    "gemini_image3_pro": {
+        "modality": "image",
+        "operations": ["text_to_image"],
+        "endpoints": ["/v1/text_to_image"],
+        "cost": "$0.08 per image",
+    },
+    "gemini_2.5_flash": {
+        "modality": "image",
+        "operations": ["text_to_image"],
+        "endpoints": ["/v1/text_to_image"],
+        "cost": "$0.05 per image",
+    },
+
+    # ── Video ───────────────────────────────────────────────────────
+    "gen4.5": {
+        "modality": "video",
+        "operations": ["text_to_video", "image_to_video"],
+        "endpoints": ["/v1/text_to_video", "/v1/image_to_video"],
+        "cost": "$0.12 per second",
+    },
+    "gen4_turbo": {
+        "modality": "video",
+        "operations": ["image_to_video"],
+        "endpoints": ["/v1/image_to_video"],
+        "cost": "$0.05 per second",
+    },
+    "gen3a_turbo": {
+        "modality": "video",
+        "operations": ["image_to_video"],
+        "endpoints": ["/v1/image_to_video"],
+        "cost": "$0.05 per second",
+    },
+    "gen4_aleph": {
+        "modality": "video",
+        "operations": ["video_to_video"],
+        "endpoints": ["/v1/video_to_video"],
+        "cost": "$0.15 per second of input",
+    },
+    "veo3": {
+        "modality": "video",
+        "operations": ["text_to_video", "image_to_video"],
+        "endpoints": ["/v1/text_to_video", "/v1/image_to_video"],
+        "cost": "$0.40 per second",
+    },
+    "veo3.1": {
+        "modality": "video",
+        "operations": ["text_to_video", "image_to_video"],
+        "endpoints": ["/v1/text_to_video", "/v1/image_to_video"],
+        "cost": "$0.30 per second",
+    },
+    "veo3.1_fast": {
+        "modality": "video",
+        "operations": ["text_to_video", "image_to_video"],
+        "endpoints": ["/v1/text_to_video", "/v1/image_to_video"],
+        "cost": "$0.12 per second",
+    },
+
+    # ── Audio ───────────────────────────────────────────────────────
+    "eleven_multilingual_v2": {
+        "modality": "audio",
+        "operations": ["text_to_speech"],
+        "endpoints": ["/v1/text_to_speech"],
+        "cost": "~$0.000030 per character",
+    },
+    "eleven_text_to_sound_v2": {
+        "modality": "audio",
+        "operations": ["sound_effect"],
+        "endpoints": ["/v1/sound_effect"],
+        "cost": "~$0.04 per second of generated sound",
+    },
+    "eleven_voice_dubbing": {
+        "modality": "audio",
+        "operations": ["voice_dubbing"],
+        "endpoints": ["/v1/voice_dubbing"],
+        "cost": "per-second of input audio (Runway billing)",
+    },
+    "eleven_voice_isolation": {
+        "modality": "audio",
+        "operations": ["voice_isolation"],
+        "endpoints": ["/v1/voice_isolation"],
+        "cost": "per-second of input audio (Runway billing)",
+    },
+    "eleven_multilingual_sts_v2": {
+        "modality": "audio",
+        "operations": ["speech_to_speech"],
+        "endpoints": ["/v1/speech_to_speech"],
+        "cost": "per-second of input audio (Runway billing)",
+    },
+}
+
+
+ALL_OPERATIONS: list[str] = sorted(
+    {op for info in RUNWAY_MODEL_INFO.values() for op in info["operations"]}
+)
+ALL_MODALITIES: list[str] = sorted({info["modality"] for info in RUNWAY_MODEL_INFO.values()})
+
+
+def get_runway_model_info(model_id: str) -> RunwayModelInfo | None:
+    """Return capability info for a Runway model, or ``None`` if unknown.
+
+    Accepts a bare model id (``"gen4.5"``) or a ``provider/model`` string
+    (``"runway/gen4.5"``, ``"runwayml/gen4.5"``).
+    """
+    if "/" in model_id:
+        model_id = model_id.split("/", 1)[1]
+    return RUNWAY_MODEL_INFO.get(model_id)
+
+
+def get_runway_models_by_op(operation: str) -> list[str]:
+    """Return Runway model ids that support the given operation.
+
+    Example::
+
+        >>> get_runway_models_by_op("text_to_video")
+        ['gen4.5', 'veo3', 'veo3.1', 'veo3.1_fast']
+    """
+    if operation not in ALL_OPERATIONS:
+        raise ValueError(
+            f"Unknown operation {operation!r}. Known: {ALL_OPERATIONS}"
+        )
+    return sorted(
+        model_id
+        for model_id, info in RUNWAY_MODEL_INFO.items()
+        if operation in info["operations"]
+    )
+
+
+def get_runway_models_by_modality(modality: str) -> list[str]:
+    """Return Runway model ids in the given modality (``image``/``video``/``audio``)."""
+    if modality not in ALL_MODALITIES:
+        raise ValueError(
+            f"Unknown modality {modality!r}. Known: {ALL_MODALITIES}"
+        )
+    return sorted(
+        model_id
+        for model_id, info in RUNWAY_MODEL_INFO.items()
+        if info["modality"] == modality
+    )

--- a/prompture/drivers/runway_img_gen_driver.py
+++ b/prompture/drivers/runway_img_gen_driver.py
@@ -1,0 +1,331 @@
+"""Runway image generation driver (``POST /v1/text_to_image``).
+
+Submits a generation task to the Runway public API, polls
+``GET /v1/tasks/{id}`` until terminal, and returns the resulting image as an
+:class:`ImageContent`. Reference images are passed through as
+``{"uri": ..., "tag": ...}`` records.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any
+
+import httpx
+
+from ..infra.cost_mixin import ImageCostMixin
+from ..media.image import ImageContent, image_from_url
+from .img_gen_base import ImageGenDriver
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_ENDPOINT = "https://api.dev.runwayml.com"
+_API_VERSION = "2024-11-06"
+
+_TERMINAL_OK = {"SUCCEEDED"}
+_TERMINAL_FAIL = {"FAILED", "CANCELLED"}
+
+# Default ratios per model — used when caller does not supply one.
+_DEFAULT_RATIOS: dict[str, str] = {
+    "gen4_image": "1280:720",
+    "gen4_image_turbo": "1280:720",
+    "gemini_2.5_flash": "1344:768",
+    "gpt_image_2": "1920:1088",
+}
+
+
+def _get_runway_api_key(api_key: str | None = None) -> str | None:
+    return (
+        api_key
+        or os.getenv("RUNWAY_API_KEY")
+        or os.getenv("RUNWAYML_API_SECRET")
+    )
+
+
+def _normalize_reference_images(refs: Any) -> list[dict[str, str]]:
+    if not refs:
+        return []
+    if not isinstance(refs, list):
+        raise ValueError("reference_images must be a list of {uri, tag} dicts")
+    out: list[dict[str, str]] = []
+    for item in refs:
+        if not isinstance(item, dict):
+            raise ValueError("each reference image must be a dict with 'uri' and 'tag'")
+        uri = item.get("uri") or item.get("url")
+        tag = item.get("tag")
+        if not uri or not tag:
+            raise ValueError("reference image entries require both 'uri' and 'tag'")
+        out.append({"uri": str(uri), "tag": str(tag)})
+    return out
+
+
+def _format_error(status_code: int, response: httpx.Response) -> str:
+    try:
+        body = response.json()
+    except Exception:
+        return f"HTTP {status_code}: {response.text[:500]}"
+    detail = body.get("error") or body.get("message") or ""
+    issues = body.get("issues") or []
+    if issues:
+        parts = [
+            f"{(iss.get('path') or ['?'])[-1]}: {iss.get('message', '')}"
+            for iss in issues
+        ]
+        detail = f"{detail} [{'; '.join(parts)}]"
+    return f"HTTP {status_code}: {detail}".strip()
+
+
+class RunwayImageGenDriver(ImageCostMixin, ImageGenDriver):
+    """Image generation via Runway ``POST /v1/text_to_image``."""
+
+    supports_multiple = False
+    supports_size_variants = True
+    # Ratio strings accepted by Runway; this list is informational, not exhaustive.
+    supported_sizes = [
+        "1920:1080",
+        "1080:1920",
+        "1024:1024",
+        "1360:768",
+        "1080:1080",
+        "1168:880",
+        "1440:1080",
+        "1080:1440",
+        "1808:768",
+        "2112:912",
+        "1280:720",
+        "720:1280",
+        "1344:768",
+        "768:1344",
+        "1920:1088",
+        "1088:1920",
+    ]
+    max_images = 1
+
+    KNOWN_MODELS = [
+        "gen4_image",
+        "gen4_image_turbo",
+        "gemini_2.5_flash",
+        "gpt_image_2",
+    ]
+
+    # USD per image. Credits → USD assumed at $0.01/credit; refine when Runway
+    # publishes authoritative dollar pricing.
+    IMAGE_PRICING: dict[str, dict[str, float]] = {
+        "gen4_image": {"720p": 0.05, "1080p": 0.08, "default": 0.05},
+        "gen4_image_turbo": {"default": 0.02},
+        "gemini_2.5_flash": {"default": 0.05},
+        "gpt_image_2": {
+            "low": 0.04,
+            "medium": 0.06,
+            "high": 0.08,
+            "default": 0.08,
+        },
+    }
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = "gen4_image",
+        endpoint: str | None = None,
+    ):
+        self.api_key = _get_runway_api_key(api_key)
+        self.model = model
+        self.endpoint = (
+            endpoint or os.getenv("RUNWAY_ENDPOINT") or _DEFAULT_ENDPOINT
+        ).rstrip("/")
+
+    @classmethod
+    def list_models(cls, *, api_key: str | None = None, **kw: object) -> list[str] | None:
+        key = _get_runway_api_key(api_key)
+        if not key:
+            return None
+        return list(cls.KNOWN_MODELS)
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "X-Runway-Version": _API_VERSION,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def _build_body(self, prompt: str, options: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+        if not prompt:
+            raise ValueError("prompt cannot be empty")
+
+        model = options.get("model", self.model)
+        ratio = (
+            options.get("ratio")
+            or options.get("aspect_ratio")
+            or _DEFAULT_RATIOS.get(model, "1280:720")
+        )
+
+        body: dict[str, Any] = {
+            "model": model,
+            "promptText": prompt,
+            "ratio": ratio,
+        }
+
+        if model == "gpt_image_2":
+            body["quality"] = options.get("quality", "high")
+        elif options.get("quality") is not None:
+            raise ValueError(
+                f"'quality' is only supported by gpt_image_2 (got model={model!r})"
+            )
+
+        refs = _normalize_reference_images(options.get("reference_images"))
+        if refs:
+            body["referenceImages"] = refs
+        elif model == "gen4_image_turbo":
+            raise ValueError("gen4_image_turbo requires reference_images")
+
+        seed = options.get("seed")
+        if seed is not None:
+            body["seed"] = int(seed)
+
+        return model, body
+
+    def generate_image(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        """Generate an image via Runway ``POST /v1/text_to_image``.
+
+        Options:
+            model: Override the default model.
+            ratio / aspect_ratio: Ratio string like ``"1920:1088"``.
+            quality: ``low`` | ``medium`` | ``high`` — gpt_image_2 only.
+            reference_images: List of ``{"uri": ..., "tag": ...}`` records.
+            seed: Optional integer seed.
+            poll: Whether to poll the task to completion. Defaults to True.
+            poll_interval: Seconds between polls. Defaults to 5.
+            timeout: Max polling seconds. Defaults to 600.
+        """
+        if not self.api_key:
+            raise RuntimeError(
+                "RUNWAY_API_KEY (or RUNWAYML_API_SECRET) is not configured"
+            )
+
+        model, body = self._build_body(prompt, options)
+        headers = self._headers()
+
+        with httpx.Client(timeout=120.0) as client:
+            resp = client.post(f"{self.endpoint}/v1/text_to_image", headers=headers, json=body)
+            if resp.status_code >= 400:
+                raise RuntimeError(f"Runway text_to_image failed: {_format_error(resp.status_code, resp)}")
+            task = resp.json()
+            task_id = task.get("id")
+            if not task_id:
+                raise RuntimeError(f"Runway response missing task id: {task}")
+
+            if not options.get("poll", True):
+                return self._pending_response(task_id, model, body, task)
+
+            final = self._poll_until_done(
+                client,
+                task_id,
+                headers=headers,
+                poll_interval=float(options.get("poll_interval", 5)),
+                timeout_seconds=float(options.get("timeout", 600)),
+            )
+
+        return self._build_success_response(final, model, body, options)
+
+    # ------------------------------------------------------------------
+
+    def _poll_until_done(
+        self,
+        client: httpx.Client,
+        task_id: str,
+        *,
+        headers: dict[str, str],
+        poll_interval: float,
+        timeout_seconds: float,
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            r = client.get(f"{self.endpoint}/v1/tasks/{task_id}", headers=headers)
+            if r.status_code >= 400:
+                raise RuntimeError(f"Runway task poll failed: {_format_error(r.status_code, r)}")
+            data = r.json()
+            status = data.get("status")
+            if status in _TERMINAL_OK:
+                return data
+            if status in _TERMINAL_FAIL:
+                failure = data.get("failure") or data.get("failureCode") or status
+                raise RuntimeError(f"Runway task {task_id} {status}: {failure}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Runway task {task_id} timed out (status={status})")
+            time.sleep(poll_interval)
+
+    def _pending_response(
+        self,
+        task_id: str,
+        model: str,
+        body: dict[str, Any],
+        task: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "images": [],
+            "meta": {
+                "image_count": 0,
+                "size": body.get("ratio"),
+                "revised_prompt": None,
+                "cost": 0.0,
+                "model_name": f"runway/{model}",
+                "task_id": task_id,
+                "status": task.get("status", "PENDING"),
+                "raw_response": task,
+            },
+        }
+
+    def _build_success_response(
+        self,
+        final: dict[str, Any],
+        model: str,
+        body: dict[str, Any],
+        options: dict[str, Any],
+    ) -> dict[str, Any]:
+        outputs = final.get("output") or []
+        images: list[ImageContent] = [image_from_url(url, media_type="image/png") for url in outputs]
+
+        ratio = body.get("ratio", "")
+        size_key = self._cost_size_key(model, ratio, body.get("quality"))
+        cost = self._calculate_image_cost(
+            "runway",
+            model,
+            size=size_key,
+            quality=body.get("quality", "standard"),
+            n=max(len(images), 1),
+        )
+
+        return {
+            "images": images,
+            "meta": {
+                "image_count": len(images),
+                "size": ratio,
+                "revised_prompt": None,
+                "cost": cost,
+                "model_name": f"runway/{model}",
+                "task_id": final.get("id"),
+                "status": final.get("status"),
+                "raw_response": final,
+            },
+        }
+
+    @staticmethod
+    def _cost_size_key(model: str, ratio: str, quality: str | None) -> str:
+        """Map a Runway ratio to a key in IMAGE_PRICING.
+
+        gen4_image charges 5 credits at 720p tier and 8 at 1080p tier; we
+        approximate the tier by the larger dimension in the ratio.
+        """
+        if model == "gpt_image_2":
+            return quality or "high"
+        try:
+            w, h = (int(part) for part in ratio.split(":"))
+        except (ValueError, AttributeError):
+            return "default"
+        long_side = max(w, h)
+        if long_side >= 1600:
+            return "1080p"
+        return "720p"

--- a/prompture/drivers/runway_img_gen_driver.py
+++ b/prompture/drivers/runway_img_gen_driver.py
@@ -31,8 +31,29 @@ _TERMINAL_FAIL = {"FAILED", "CANCELLED"}
 _DEFAULT_RATIOS: dict[str, str] = {
     "gen4_image": "1280:720",
     "gen4_image_turbo": "1280:720",
-    "gemini_2.5_flash": "1344:768",
-    "gpt_image_2": "1920:1088",
+    "gemini_2.5_flash": "1024:1024",
+    "gemini_image3_pro": "1024:1024",
+    "gpt_image_2": "1920:1080",
+}
+
+# Per-docs accepted ratios for POST /v1/text_to_image.
+_TEXT_TO_IMAGE_RATIOS: set[str] = {
+    "1024:1024",
+    "1080:1080",
+    "1168:880",
+    "1360:768",
+    "1440:1080",
+    "1080:1440",
+    "1808:768",
+    "1920:1080",
+    "1080:1920",
+    "2112:912",
+    "1280:720",
+    "720:1280",
+    "720:720",
+    "960:720",
+    "720:960",
+    "1680:720",
 }
 
 
@@ -82,32 +103,15 @@ class RunwayImageGenDriver(ImageCostMixin, ImageGenDriver):
 
     supports_multiple = False
     supports_size_variants = True
-    # Ratio strings accepted by Runway; this list is informational, not exhaustive.
-    supported_sizes = [
-        "1920:1080",
-        "1080:1920",
-        "1024:1024",
-        "1360:768",
-        "1080:1080",
-        "1168:880",
-        "1440:1080",
-        "1080:1440",
-        "1808:768",
-        "2112:912",
-        "1280:720",
-        "720:1280",
-        "1344:768",
-        "768:1344",
-        "1920:1088",
-        "1088:1920",
-    ]
+    supported_sizes = sorted(_TEXT_TO_IMAGE_RATIOS)
     max_images = 1
 
     KNOWN_MODELS = [
         "gen4_image",
         "gen4_image_turbo",
-        "gemini_2.5_flash",
         "gpt_image_2",
+        "gemini_image3_pro",
+        "gemini_2.5_flash",
     ]
 
     # USD per image. Credits → USD assumed at $0.01/credit; refine when Runway
@@ -116,6 +120,7 @@ class RunwayImageGenDriver(ImageCostMixin, ImageGenDriver):
         "gen4_image": {"720p": 0.05, "1080p": 0.08, "default": 0.05},
         "gen4_image_turbo": {"default": 0.02},
         "gemini_2.5_flash": {"default": 0.05},
+        "gemini_image3_pro": {"default": 0.08},
         "gpt_image_2": {
             "low": 0.04,
             "medium": 0.06,
@@ -161,6 +166,11 @@ class RunwayImageGenDriver(ImageCostMixin, ImageGenDriver):
             or options.get("aspect_ratio")
             or _DEFAULT_RATIOS.get(model, "1280:720")
         )
+        if ratio not in _TEXT_TO_IMAGE_RATIOS:
+            raise ValueError(
+                f"Unsupported ratio {ratio!r} for text_to_image. "
+                f"Accepted values: {sorted(_TEXT_TO_IMAGE_RATIOS)}"
+            )
 
         body: dict[str, Any] = {
             "model": model,
@@ -184,6 +194,10 @@ class RunwayImageGenDriver(ImageCostMixin, ImageGenDriver):
         seed = options.get("seed")
         if seed is not None:
             body["seed"] = int(seed)
+
+        content_mod = options.get("content_moderation") or options.get("contentModeration")
+        if content_mod is not None:
+            body["contentModeration"] = content_mod
 
         return model, body
 

--- a/prompture/drivers/runway_tts_driver.py
+++ b/prompture/drivers/runway_tts_driver.py
@@ -1,0 +1,225 @@
+"""Runway TTS driver — text-to-speech and sound-effect generation.
+
+Two endpoints share this driver:
+
+- ``POST /v1/text_to_speech`` with ``eleven_multilingual_v2`` — turn text into speech.
+- ``POST /v1/sound_effect``    with ``eleven_text_to_sound_v2`` — turn a prompt into a sound effect.
+
+Both submit a task and return audio bytes once the task completes.
+The endpoint is picked from the model: any ``eleven_text_to_sound_v2`` model
+goes to ``/v1/sound_effect``; anything else goes to ``/v1/text_to_speech``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any
+
+import httpx
+
+from ..infra.cost_mixin import AudioCostMixin
+from .runway_img_gen_driver import (
+    _API_VERSION,
+    _DEFAULT_ENDPOINT,
+    _TERMINAL_FAIL,
+    _TERMINAL_OK,
+    _format_error,
+    _get_runway_api_key,
+)
+from .tts_base import TTSDriver
+
+logger = logging.getLogger(__name__)
+
+SOUND_EFFECT_MODEL = "eleven_text_to_sound_v2"
+TTS_MODEL = "eleven_multilingual_v2"
+
+PRESET_VOICES: list[str] = [
+    "Maya", "Arjun", "Serene", "Bernard", "Billy", "Mark", "Clint", "Mabel",
+    "Chad", "Leslie", "Eleanor", "Elias", "Elliot", "Grungle", "Brodie",
+    "Sandra", "Kirk", "Kylie", "Lara", "Lisa", "Malachi", "Marlene", "Martin",
+    "Miriam", "Monster", "Paula", "Pip", "Rusty", "Ragnar", "Xylar", "Maggie",
+    "Jack", "Katie", "Noah", "James", "Rina", "Ella", "Mariah", "Frank",
+    "Claudia", "Niki", "Vincent", "Kendrick", "Myrna", "Tom", "Wanda",
+    "Benjamin", "Kiana", "Rachel",
+]
+
+
+def _endpoint_for_model(model: str) -> str:
+    return "/v1/sound_effect" if model == SOUND_EFFECT_MODEL else "/v1/text_to_speech"
+
+
+def _fetch_audio(client: httpx.Client, url: str) -> tuple[bytes, str]:
+    r = client.get(url, timeout=120.0)
+    if r.status_code >= 400:
+        raise RuntimeError(f"Failed to download audio ({r.status_code}): {url}")
+    return r.content, r.headers.get("content-type", "audio/mpeg")
+
+
+class RunwayTTSDriver(AudioCostMixin, TTSDriver):
+    """Runway TTS + sound-effect synthesis."""
+
+    supports_streaming = False
+    supports_ssml = False
+    available_voices = list(PRESET_VOICES)
+
+    KNOWN_MODELS = [TTS_MODEL, SOUND_EFFECT_MODEL]
+
+    # USD per character / per second. ElevenLabs-style pricing applies.
+    AUDIO_PRICING = {
+        TTS_MODEL: {"per_character": 0.000030},
+        SOUND_EFFECT_MODEL: {"per_second": 0.04},
+    }
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = TTS_MODEL,
+        endpoint: str | None = None,
+    ):
+        self.api_key = _get_runway_api_key(api_key)
+        self.model = model
+        self.endpoint = (
+            endpoint or os.getenv("RUNWAY_ENDPOINT") or _DEFAULT_ENDPOINT
+        ).rstrip("/")
+
+    @classmethod
+    def list_models(cls, *, api_key: str | None = None, **kw: object) -> list[str] | None:
+        key = _get_runway_api_key(api_key)
+        if not key:
+            return None
+        return list(cls.KNOWN_MODELS)
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "X-Runway-Version": _API_VERSION,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def _build(self, text: str, options: dict[str, Any]) -> tuple[str, str, dict[str, Any]]:
+        model = options.get("model", self.model)
+        body: dict[str, Any] = {"model": model, "promptText": text}
+
+        if model == SOUND_EFFECT_MODEL:
+            if "duration" in options:
+                duration = float(options["duration"])
+                if not 0.5 <= duration <= 30:
+                    raise ValueError("sound_effect duration must be in [0.5, 30]")
+                body["duration"] = duration
+            if "loop" in options:
+                body["loop"] = bool(options["loop"])
+        else:
+            # text_to_speech requires a preset voice.
+            voice = options.get("voice")
+            if voice is None:
+                preset_id = options.get("preset_id") or options.get("presetId") or "Maya"
+                voice = {"type": "runway-preset", "presetId": preset_id}
+            elif isinstance(voice, str):
+                voice = {"type": "runway-preset", "presetId": voice}
+            body["voice"] = voice
+
+        return model, _endpoint_for_model(model), body
+
+    def synthesize(self, text: str, options: dict[str, Any]) -> dict[str, Any]:
+        """Synthesize audio.
+
+        Options:
+            model: ``eleven_multilingual_v2`` (TTS) or ``eleven_text_to_sound_v2``
+                (sound effect). Defaults to instance model.
+            voice: For TTS — preset voice name (string) or full ``{type,presetId}``
+                dict. Defaults to ``Maya``.
+            duration / loop: Sound-effect only (duration 0.5–30 s).
+            poll, poll_interval, timeout: Control task polling.
+        """
+        if not self.api_key:
+            raise RuntimeError("RUNWAY_API_KEY (or RUNWAYML_API_SECRET) is not configured")
+        if not text:
+            raise ValueError("text cannot be empty")
+
+        model, path, body = self._build(text, options)
+        headers = self._headers()
+
+        with httpx.Client(timeout=120.0) as client:
+            resp = client.post(f"{self.endpoint}{path}", headers=headers, json=body)
+            if resp.status_code >= 400:
+                raise RuntimeError(f"Runway {path} failed: {_format_error(resp.status_code, resp)}")
+            task = resp.json()
+            task_id = task.get("id")
+            if not task_id:
+                raise RuntimeError(f"Runway response missing task id: {task}")
+
+            if not options.get("poll", True):
+                return {
+                    "audio": b"",
+                    "media_type": "audio/mpeg",
+                    "meta": {
+                        "characters": len(text),
+                        "cost": 0.0,
+                        "model_name": f"runway/{model}",
+                        "task_id": task_id,
+                        "status": task.get("status", "PENDING"),
+                        "raw_response": task,
+                    },
+                }
+
+            final = self._poll_until_done(
+                client,
+                task_id,
+                headers=headers,
+                poll_interval=float(options.get("poll_interval", 5)),
+                timeout_seconds=float(options.get("timeout", 600)),
+            )
+            outputs = final.get("output") or []
+            if not outputs:
+                raise RuntimeError(f"Runway {path} produced no output URLs: {final}")
+            audio, media_type = _fetch_audio(client, outputs[0])
+
+        characters = len(text)
+        duration_s = float(body.get("duration") or 0.0)
+        cost = self._calculate_audio_cost(
+            "runway",
+            model,
+            duration_seconds=duration_s,
+            characters=characters if model == TTS_MODEL else 0,
+        )
+
+        return {
+            "audio": audio,
+            "media_type": media_type,
+            "meta": {
+                "characters": characters,
+                "cost": cost,
+                "model_name": f"runway/{model}",
+                "task_id": final.get("id"),
+                "status": final.get("status"),
+                "raw_response": final,
+            },
+        }
+
+    def _poll_until_done(
+        self,
+        client: httpx.Client,
+        task_id: str,
+        *,
+        headers: dict[str, str],
+        poll_interval: float,
+        timeout_seconds: float,
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            r = client.get(f"{self.endpoint}/v1/tasks/{task_id}", headers=headers)
+            if r.status_code >= 400:
+                raise RuntimeError(f"Runway task poll failed: {_format_error(r.status_code, r)}")
+            data = r.json()
+            status = data.get("status")
+            if status in _TERMINAL_OK:
+                return data
+            if status in _TERMINAL_FAIL:
+                failure = data.get("failure") or data.get("failureCode") or status
+                raise RuntimeError(f"Runway task {task_id} {status}: {failure}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Runway task {task_id} timed out (status={status})")
+            time.sleep(poll_interval)

--- a/prompture/drivers/runway_video_gen_driver.py
+++ b/prompture/drivers/runway_video_gen_driver.py
@@ -1,0 +1,386 @@
+"""Runway video generation driver.
+
+A single driver covers the three Runway video endpoints:
+
+- ``POST /v1/text_to_video``   — text-only generation
+- ``POST /v1/image_to_video``  — text + image(s) with optional ``first``/``last`` keyframes
+- ``POST /v1/video_to_video``  — video + text (gen4_aleph)
+
+The endpoint is chosen from the ``mode`` option, or auto-detected from the
+inputs: ``video`` ⇒ video_to_video, ``image`` ⇒ image_to_video, else
+text_to_video. Each call returns a Runway task ID; the driver polls
+``GET /v1/tasks/{id}`` until terminal and returns the first output video URL
+as a :class:`VideoContent`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any
+
+import httpx
+
+from ..infra.cost_mixin import VideoCostMixin
+from ..media.video import VideoContent, video_from_url
+from .runway_img_gen_driver import (
+    _API_VERSION,
+    _DEFAULT_ENDPOINT,
+    _TERMINAL_FAIL,
+    _TERMINAL_OK,
+    _format_error,
+    _get_runway_api_key,
+)
+from .video_gen_base import VideoGenDriver
+
+logger = logging.getLogger(__name__)
+
+# Ratios accepted per endpoint, per the official docs.
+_T2V_RATIOS: set[str] = {"1280:720", "720:1280"}
+_I2V_RATIOS: set[str] = {
+    "1280:720",
+    "720:1280",
+    "1104:832",
+    "960:960",
+    "832:1104",
+    "1584:672",
+}
+
+_MODE_ENDPOINTS = {
+    "text_to_video": "/v1/text_to_video",
+    "image_to_video": "/v1/image_to_video",
+    "video_to_video": "/v1/video_to_video",
+}
+
+_KNOWN_MODELS_BY_MODE: dict[str, set[str]] = {
+    "text_to_video": {"gen4.5", "veo3", "veo3.1", "veo3.1_fast"},
+    "image_to_video": {
+        "gen4.5",
+        "gen4_turbo",
+        "gen3a_turbo",
+        "veo3",
+        "veo3.1",
+        "veo3.1_fast",
+    },
+    "video_to_video": {"gen4_aleph"},
+}
+
+
+def _detect_mode(options: dict[str, Any]) -> str:
+    if options.get("mode"):
+        mode = options["mode"]
+        if mode not in _MODE_ENDPOINTS:
+            raise ValueError(
+                f"Unknown mode {mode!r}. Expected one of {sorted(_MODE_ENDPOINTS)}."
+            )
+        return mode
+    if options.get("video") or options.get("videoUri") or options.get("video_uri"):
+        return "video_to_video"
+    if options.get("image") or options.get("promptImage") or options.get("prompt_image"):
+        return "image_to_video"
+    return "text_to_video"
+
+
+def _normalize_prompt_image(image: Any) -> Any:
+    """Return a value valid for ``promptImage``: a string URI or a list of keyframe dicts."""
+    if isinstance(image, str):
+        return image
+    if isinstance(image, dict):
+        uri = image.get("uri") or image.get("url")
+        if not uri:
+            raise ValueError("image dict must include 'uri'")
+        position = image.get("position", "first")
+        return [{"uri": uri, "position": position}]
+    if isinstance(image, list):
+        out: list[dict[str, str]] = []
+        for item in image:
+            if isinstance(item, str):
+                out.append({"uri": item, "position": "first"})
+            elif isinstance(item, dict):
+                uri = item.get("uri") or item.get("url")
+                if not uri:
+                    raise ValueError("image entries must include 'uri'")
+                out.append({"uri": uri, "position": item.get("position", "first")})
+            else:
+                raise ValueError(f"unsupported image entry type: {type(item).__name__}")
+        return out
+    raise ValueError(f"unsupported image input type: {type(image).__name__}")
+
+
+def _normalize_references(refs: Any) -> list[dict[str, str]]:
+    if not refs:
+        return []
+    if not isinstance(refs, list):
+        raise ValueError("references must be a list of {type, uri} dicts")
+    out: list[dict[str, str]] = []
+    for ref in refs:
+        if not isinstance(ref, dict):
+            raise ValueError("each reference must be a dict")
+        uri = ref.get("uri") or ref.get("url")
+        if not uri:
+            raise ValueError("reference entries require 'uri'")
+        out.append({"type": ref.get("type", "image"), "uri": str(uri)})
+    return out
+
+
+class RunwayVideoGenDriver(VideoCostMixin, VideoGenDriver):
+    """Video generation via Runway text/image/video → video endpoints."""
+
+    supports_image_input = True
+    supports_reference_images = True
+    supports_video_input = True
+    supports_audio = False
+    supports_polling = True
+    supported_aspect_ratios = sorted(_T2V_RATIOS | _I2V_RATIOS)
+    supported_resolutions = ["720p", "1080p"]
+    max_seconds = 10
+
+    KNOWN_MODELS = sorted(
+        {m for s in _KNOWN_MODELS_BY_MODE.values() for m in s}
+    )
+
+    # USD per second of output. Credits → USD at $0.01/credit per Runway docs.
+    VIDEO_PRICING: dict[str, dict[str, Any]] = {
+        "gen4.5": {"per_second": 0.12},
+        "gen4_turbo": {"per_second": 0.05},
+        "gen3a_turbo": {"per_second": 0.05},
+        "gen4_aleph": {"per_second": 0.15},
+        "veo3": {"per_second": 0.40},
+        "veo3.1": {"per_second": 0.30},
+        "veo3.1_fast": {"per_second": 0.12},
+    }
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = "gen4.5",
+        endpoint: str | None = None,
+    ):
+        self.api_key = _get_runway_api_key(api_key)
+        self.model = model
+        self.endpoint = (
+            endpoint or os.getenv("RUNWAY_ENDPOINT") or _DEFAULT_ENDPOINT
+        ).rstrip("/")
+
+    @classmethod
+    def list_models(cls, *, api_key: str | None = None, **kw: object) -> list[str] | None:
+        key = _get_runway_api_key(api_key)
+        if not key:
+            return None
+        return list(cls.KNOWN_MODELS)
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "X-Runway-Version": _API_VERSION,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def _build(self, prompt: str, options: dict[str, Any]) -> tuple[str, str, dict[str, Any]]:
+        """Return (mode, path, body) for the request."""
+        mode = _detect_mode(options)
+        model = options.get("model", self.model)
+
+        if model not in _KNOWN_MODELS_BY_MODE[mode]:
+            logger.warning(
+                "model %r is not in the known list for %s: %s",
+                model,
+                mode,
+                sorted(_KNOWN_MODELS_BY_MODE[mode]),
+            )
+
+        body: dict[str, Any] = {"model": model, "promptText": prompt}
+
+        # ── ratio ───────────────────────────────────────────────────
+        if mode != "video_to_video":
+            ratio = options.get("ratio") or options.get("aspect_ratio")
+            if mode == "text_to_video":
+                ratio = ratio or "1280:720"
+                if ratio not in _T2V_RATIOS:
+                    raise ValueError(
+                        f"text_to_video ratio must be one of {sorted(_T2V_RATIOS)}, got {ratio!r}"
+                    )
+            else:  # image_to_video
+                ratio = ratio or "1280:720"
+                if ratio not in _I2V_RATIOS:
+                    raise ValueError(
+                        f"image_to_video ratio must be one of {sorted(_I2V_RATIOS)}, got {ratio!r}"
+                    )
+            body["ratio"] = ratio
+
+        # ── duration ────────────────────────────────────────────────
+        if mode in {"text_to_video", "image_to_video"}:
+            duration = int(options.get("duration", options.get("seconds", 5)))
+            if not 2 <= duration <= 10:
+                raise ValueError("duration must be an integer in [2, 10]")
+            body["duration"] = duration
+
+        # ── inputs per mode ─────────────────────────────────────────
+        if mode == "image_to_video":
+            image = options.get("image") or options.get("promptImage") or options.get("prompt_image")
+            if not image:
+                raise ValueError("image_to_video requires 'image' (URL/runway://uri/data URI or list of keyframes)")
+            body["promptImage"] = _normalize_prompt_image(image)
+
+        elif mode == "video_to_video":
+            video_uri = (
+                options.get("video")
+                or options.get("videoUri")
+                or options.get("video_uri")
+            )
+            if not video_uri or not isinstance(video_uri, str):
+                raise ValueError("video_to_video requires 'video' as a URI string")
+            body["videoUri"] = video_uri
+            refs = _normalize_references(
+                options.get("references") or options.get("reference_images")
+            )
+            if refs:
+                if len(refs) > 1:
+                    raise ValueError("video_to_video supports at most 1 reference image")
+                body["references"] = refs
+
+        # ── shared optional fields ──────────────────────────────────
+        seed = options.get("seed")
+        if seed is not None:
+            body["seed"] = int(seed)
+
+        content_mod = options.get("content_moderation") or options.get("contentModeration")
+        if content_mod is not None:
+            body["contentModeration"] = content_mod
+
+        return mode, _MODE_ENDPOINTS[mode], body
+
+    def generate_video(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        """Generate a video. See module docstring for endpoint selection rules.
+
+        Options:
+            mode: ``text_to_video`` | ``image_to_video`` | ``video_to_video``.
+                  Auto-detected if omitted.
+            model: Model override (default: instance ``model``, e.g. ``gen4.5``).
+            ratio / aspect_ratio: Endpoint-specific ratio string.
+            duration / seconds: 2–10 (T2V, I2V). Ignored for V2V.
+            image / promptImage: Required for I2V. String URI, dict with
+                ``uri``/``position``, or list of keyframe dicts.
+            video / videoUri: Required for V2V. URI string.
+            references: Optional V2V references — ``[{"type":"image","uri":...}]``.
+            seed, content_moderation: passthrough.
+            poll, poll_interval, timeout: Control task polling.
+        """
+        if not self.api_key:
+            raise RuntimeError(
+                "RUNWAY_API_KEY (or RUNWAYML_API_SECRET) is not configured"
+            )
+        if not prompt:
+            raise ValueError("prompt cannot be empty")
+
+        mode, path, body = self._build(prompt, options)
+        headers = self._headers()
+
+        with httpx.Client(timeout=120.0) as client:
+            resp = client.post(f"{self.endpoint}{path}", headers=headers, json=body)
+            if resp.status_code >= 400:
+                raise RuntimeError(f"Runway {mode} failed: {_format_error(resp.status_code, resp)}")
+            task = resp.json()
+            task_id = task.get("id")
+            if not task_id:
+                raise RuntimeError(f"Runway response missing task id: {task}")
+
+            if not options.get("poll", True):
+                return self._pending_response(task_id, mode, body, task)
+
+            final = self._poll_until_done(
+                client,
+                task_id,
+                headers=headers,
+                poll_interval=float(options.get("poll_interval", 5)),
+                timeout_seconds=float(options.get("timeout", 600)),
+            )
+
+        return self._success_response(final, mode, body, options)
+
+    # ------------------------------------------------------------------
+
+    def _poll_until_done(
+        self,
+        client: httpx.Client,
+        task_id: str,
+        *,
+        headers: dict[str, str],
+        poll_interval: float,
+        timeout_seconds: float,
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            r = client.get(f"{self.endpoint}/v1/tasks/{task_id}", headers=headers)
+            if r.status_code >= 400:
+                raise RuntimeError(f"Runway task poll failed: {_format_error(r.status_code, r)}")
+            data = r.json()
+            status = data.get("status")
+            if status in _TERMINAL_OK:
+                return data
+            if status in _TERMINAL_FAIL:
+                failure = data.get("failure") or data.get("failureCode") or status
+                raise RuntimeError(f"Runway task {task_id} {status}: {failure}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Runway task {task_id} timed out (status={status})")
+            time.sleep(poll_interval)
+
+    def _pending_response(
+        self,
+        task_id: str,
+        mode: str,
+        body: dict[str, Any],
+        task: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "videos": [],
+            "meta": {
+                "video_count": 0,
+                "duration_seconds": body.get("duration"),
+                "aspect_ratio": body.get("ratio"),
+                "resolution": None,
+                "cost": 0.0,
+                "model_name": f"runway/{body['model']}",
+                "mode": mode,
+                "task_id": task_id,
+                "status": task.get("status", "PENDING"),
+                "raw_response": task,
+            },
+        }
+
+    def _success_response(
+        self,
+        final: dict[str, Any],
+        mode: str,
+        body: dict[str, Any],
+        options: dict[str, Any],
+    ) -> dict[str, Any]:
+        outputs = final.get("output") or []
+        videos: list[VideoContent] = [video_from_url(url) for url in outputs]
+
+        duration = body.get("duration") or 0
+        model = body["model"]
+        cost = self._calculate_video_cost(
+            "runway",
+            model,
+            duration_seconds=float(duration) if duration else 0.0,
+            n=max(len(videos), 1),
+        )
+
+        return {
+            "videos": videos,
+            "meta": {
+                "video_count": len(videos),
+                "duration_seconds": float(duration) if duration else None,
+                "aspect_ratio": body.get("ratio"),
+                "resolution": None,
+                "cost": cost,
+                "model_name": f"runway/{model}",
+                "mode": mode,
+                "task_id": final.get("id"),
+                "status": final.get("status"),
+                "raw_response": final,
+            },
+        }

--- a/prompture/drivers/video_gen_base.py
+++ b/prompture/drivers/video_gen_base.py
@@ -1,0 +1,94 @@
+"""Base class for video generation drivers."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from ..infra.callbacks import DriverCallbacks
+
+logger = logging.getLogger("prompture.video_gen_driver")
+
+
+class VideoGenDriver:
+    """Adapter base for video generation. Implement ``generate_video(prompt, options)``.
+
+    Response contract::
+
+        {
+            "videos": list[VideoContent],
+            "meta": {
+                "video_count": int,
+                "duration_seconds": float | None,
+                "aspect_ratio": str | None,
+                "resolution": str | None,
+                "cost": float,
+                "model_name": str,
+                "raw_response": dict,
+            },
+        }
+    """
+
+    supports_image_input: bool = False
+    supports_reference_images: bool = False
+    supports_video_input: bool = False
+    supports_audio: bool = False
+    supports_polling: bool = True
+    supported_aspect_ratios: list[str] = []
+    supported_resolutions: list[str] = []
+    max_seconds: int | None = None
+
+    callbacks: DriverCallbacks | None = None
+
+    def generate_video(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        """Generate video(s) from a text prompt."""
+        raise NotImplementedError
+
+    def generate_video_with_hooks(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        """Wrap :meth:`generate_video` with on_request / on_response / on_error callbacks."""
+        driver_name = getattr(self, "model", self.__class__.__name__)
+        self._fire_callback(
+            "on_request",
+            {"prompt_length": len(prompt), "options": options, "driver": driver_name},
+        )
+        t0 = time.perf_counter()
+        try:
+            resp = self.generate_video(prompt, options)
+        except Exception as exc:
+            self._fire_callback(
+                "on_error",
+                {"error": exc, "prompt_length": len(prompt), "options": options, "driver": driver_name},
+            )
+            raise
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+        meta = resp.get("meta", {})
+        logger.debug(
+            "[video_gen] generate driver=%s videos=%d cost=%.6f elapsed=%.0fms",
+            driver_name,
+            meta.get("video_count", 0),
+            meta.get("cost", 0.0),
+            elapsed_ms,
+        )
+        self._fire_callback(
+            "on_response",
+            {
+                "video_count": meta.get("video_count", 0),
+                "meta": meta,
+                "driver": driver_name,
+                "elapsed_ms": elapsed_ms,
+            },
+        )
+        return resp
+
+    def _fire_callback(self, event: str, payload: dict[str, Any]) -> None:
+        """Invoke a single callback, swallowing and logging any exception."""
+        if self.callbacks is None:
+            return
+        cb = getattr(self.callbacks, event, None)
+        if cb is None:
+            return
+        try:
+            cb(payload)
+        except Exception:
+            logger.exception("Callback %s raised an exception", event)

--- a/prompture/drivers/video_gen_registry.py
+++ b/prompture/drivers/video_gen_registry.py
@@ -1,0 +1,33 @@
+"""Video generation driver factory functions.
+
+Provides high-level factory functions for instantiating video generation
+drivers by model string. Built-in driver registration is handled centrally by
+``provider_descriptors.register_all_builtin_drivers()``.
+"""
+
+from typing import cast
+
+from .async_video_gen_base import AsyncVideoGenDriver
+from .registry import (
+    get_async_video_gen_driver_factory,
+    get_video_gen_driver_factory,
+)
+from .video_gen_base import VideoGenDriver
+
+
+def get_video_gen_driver_for_model(model_str: str) -> VideoGenDriver:
+    """Instantiate a sync video generation driver from a ``"provider/model"`` string."""
+    parts = model_str.split("/", 1)
+    provider = parts[0].lower()
+    model_id = parts[1] if len(parts) > 1 else None
+    factory = get_video_gen_driver_factory(provider)
+    return cast(VideoGenDriver, factory(model_id))
+
+
+def get_async_video_gen_driver_for_model(model_str: str) -> AsyncVideoGenDriver:
+    """Instantiate an async video generation driver from a ``"provider/model"`` string."""
+    parts = model_str.split("/", 1)
+    provider = parts[0].lower()
+    model_id = parts[1] if len(parts) > 1 else None
+    factory = get_async_video_gen_driver_factory(provider)
+    return cast(AsyncVideoGenDriver, factory(model_id))

--- a/prompture/infra/__init__.py
+++ b/prompture/infra/__init__.py
@@ -27,7 +27,7 @@ from .capabilities import (
     register_model,
     register_provider,
 )
-from .cost_mixin import AudioCostMixin, EmbeddingCostMixin
+from .cost_mixin import AudioCostMixin, EmbeddingCostMixin, VideoCostMixin
 from .discovery import (
     clear_discovery_cache,
     display_available_models,
@@ -35,6 +35,7 @@ from .discovery import (
     get_available_embedding_models,
     get_available_image_gen_models,
     get_available_models,
+    get_available_video_gen_models,
 )
 from .ledger import ModelUsageLedger, get_recently_used_models
 from .logging import JSONFormatter, configure_logging
@@ -75,6 +76,7 @@ __all__ = [
     "SQLiteCacheBackend",
     "TukuyLLMBackend",
     "UsageSession",
+    "VideoCostMixin",
     "clear_discovery_cache",
     "clear_overrides",
     "configure_cache",
@@ -89,6 +91,7 @@ __all__ = [
     "get_available_embedding_models",
     "get_available_image_gen_models",
     "get_available_models",
+    "get_available_video_gen_models",
     "get_cache",
     "get_capabilities",
     "get_compatibility_matrix",

--- a/prompture/infra/cost_mixin.py
+++ b/prompture/infra/cost_mixin.py
@@ -253,3 +253,45 @@ class ImageCostMixin:
         per_image = pricing.get(f"{size}/{quality}") or pricing.get(size) or pricing.get("default", 0.0)
 
         return round(per_image * n, 6)
+
+
+class VideoCostMixin:
+    """Mixin that provides ``_calculate_video_cost`` to video generation drivers.
+
+    Video generation pricing is typically per-second or per-video. Subclasses
+    can define ``VIDEO_PRICING`` with any of these keys:
+
+    ``{"model_id": {"per_second": 0.1, "per_video": 1.0, "default": 1.0}}``.
+    Resolution-specific pricing can use
+    ``{"per_second_by_resolution": {"720p": 0.07}}``.
+    """
+
+    VIDEO_PRICING: dict[str, dict[str, Any]] = {}
+
+    def _calculate_video_cost(
+        self,
+        provider: str,
+        model: str,
+        *,
+        duration_seconds: float = 0,
+        n: int = 1,
+        resolution: str | None = None,
+    ) -> float:
+        """Calculate USD cost for a video generation call.
+
+        Lookup order: resolution-specific ``per_second`` × duration →
+        generic ``per_second`` × duration → ``per_video`` → ``default`` → 0.
+        """
+        pricing = self.VIDEO_PRICING.get(model, {})
+
+        per_second_by_resolution = pricing.get("per_second_by_resolution")
+        if duration_seconds > 0 and resolution and isinstance(per_second_by_resolution, dict):
+            rate = per_second_by_resolution.get(resolution)
+            if rate is not None:
+                return round(float(rate) * duration_seconds * n, 6)
+
+        if duration_seconds > 0 and "per_second" in pricing:
+            return round(float(pricing["per_second"]) * duration_seconds * n, 6)
+
+        per_video = pricing.get("per_video", pricing.get("default", 0.0))
+        return round(float(per_video) * n, 6)

--- a/prompture/infra/discovery.py
+++ b/prompture/infra/discovery.py
@@ -593,6 +593,44 @@ def get_available_image_gen_models(
     return sorted(available)
 
 
+def get_available_video_gen_models(
+    *,
+    env: ProviderEnvironment | None = None,
+) -> list[str]:
+    """Auto-detect available video generation models based on configured API keys.
+
+    Args:
+        env: Optional per-consumer environment for isolated API keys.
+            When ``None``, uses the global settings singleton (current behavior).
+
+    Returns:
+        A sorted list of unique model strings (e.g. ``"grok/grok-imagine-video"``).
+    """
+    from ..drivers.grok_video_gen_driver import GrokVideoGenDriver
+
+    available: set[str] = set()
+
+    grok_video_key = _cfg_value(env, "grok_api_key", "GROK_API_KEY") or _cfg_value(env, "xai_api_key", "XAI_API_KEY")
+    if grok_video_key:
+        for model_id in GrokVideoGenDriver.KNOWN_MODELS:
+            available.add(f"grok/{model_id}")
+
+    # Dynamic discovery: check modalities_output from models.dev capabilities
+    # for any models that the built-in video drivers don't know about yet.
+    from .model_rates import get_model_capabilities
+
+    for model_str in get_available_models(env=env):
+        parts = model_str.split("/", 1)
+        if len(parts) != 2:
+            continue
+        provider, model_id = parts
+        caps = get_model_capabilities(provider, model_id)
+        if caps and "video" in caps.modalities_output:
+            available.add(model_str)
+
+    return sorted(available)
+
+
 def get_available_embedding_models(
     *,
     env: ProviderEnvironment | None = None,

--- a/prompture/infra/discovery.py
+++ b/prompture/infra/discovery.py
@@ -518,6 +518,16 @@ def get_available_audio_models(
                 for model_id in ElevenLabsTTSDriver.AUDIO_PRICING:
                     available.add(f"elevenlabs/{model_id}")
 
+    # Runway TTS + sound-effect models (no STT)
+    runway_key = _cfg_value(env, "runway_api_key", "RUNWAY_API_KEY") or _cfg_value(
+        env, "runwayml_api_secret", "RUNWAYML_API_SECRET"
+    )
+    if runway_key and (modality is None or modality == "tts"):
+        from ..drivers.runway_tts_driver import RunwayTTSDriver
+
+        for model_id in RunwayTTSDriver.KNOWN_MODELS:
+            available.add(f"runway/{model_id}")
+
     # Dynamic discovery: check modalities_output from models.dev capabilities
     # for any models that the pricing dicts don't know about yet.
     from .model_rates import get_model_capabilities
@@ -577,6 +587,16 @@ def get_available_image_gen_models(
         for model_id in GrokImageGenDriver.IMAGE_PRICING:
             available.add(f"grok/{model_id}")
 
+    # Runway image gen models (requires runway_api_key or RUNWAYML_API_SECRET)
+    runway_key = _cfg_value(env, "runway_api_key", "RUNWAY_API_KEY") or _cfg_value(
+        env, "runwayml_api_secret", "RUNWAYML_API_SECRET"
+    )
+    if runway_key:
+        from ..drivers.runway_img_gen_driver import RunwayImageGenDriver
+
+        for model_id in RunwayImageGenDriver.KNOWN_MODELS:
+            available.add(f"runway/{model_id}")
+
     # Dynamic discovery: check modalities_output from models.dev capabilities
     # for any models that the pricing dicts don't know about yet.
     from .model_rates import get_model_capabilities
@@ -614,6 +634,16 @@ def get_available_video_gen_models(
     if grok_video_key:
         for model_id in GrokVideoGenDriver.KNOWN_MODELS:
             available.add(f"grok/{model_id}")
+
+    # Runway video gen models (text/image/video → video)
+    runway_key = _cfg_value(env, "runway_api_key", "RUNWAY_API_KEY") or _cfg_value(
+        env, "runwayml_api_secret", "RUNWAYML_API_SECRET"
+    )
+    if runway_key:
+        from ..drivers.runway_video_gen_driver import RunwayVideoGenDriver
+
+        for model_id in RunwayVideoGenDriver.KNOWN_MODELS:
+            available.add(f"runway/{model_id}")
 
     # Dynamic discovery: check modalities_output from models.dev capabilities
     # for any models that the built-in video drivers don't know about yet.

--- a/prompture/infra/provider_env.py
+++ b/prompture/infra/provider_env.py
@@ -18,6 +18,7 @@ class ProviderEnvironment:
     google_api_key: str | None = None
     groq_api_key: str | None = None
     grok_api_key: str | None = None
+    xai_api_key: str | None = None
     openrouter_api_key: str | None = None
     moonshot_api_key: str | None = None
     moonshot_endpoint: str | None = None

--- a/prompture/infra/settings.py
+++ b/prompture/infra/settings.py
@@ -97,6 +97,10 @@ class Settings(BaseSettings):
     stability_api_key: Optional[str] = None
     stability_endpoint: Optional[str] = None
 
+    # Runway (image generation via /v1/text_to_image)
+    runway_api_key: Optional[str] = None
+    runway_endpoint: Optional[str] = None
+
     # ElevenLabs (audio)
     elevenlabs_api_key: Optional[str] = None
     elevenlabs_tts_model: str = "eleven_multilingual_v2"

--- a/prompture/infra/settings.py
+++ b/prompture/infra/settings.py
@@ -66,7 +66,9 @@ class Settings(BaseSettings):
 
     # Grok
     grok_api_key: Optional[str] = None
+    xai_api_key: Optional[str] = None
     grok_model: str = "grok-4-fast-reasoning"
+    grok_video_model: str = "grok-imagine-video"
 
     # Moonshot AI (Kimi)
     moonshot_api_key: Optional[str] = None

--- a/prompture/media/__init__.py
+++ b/prompture/media/__init__.py
@@ -1,4 +1,4 @@
-"""Media handling: images and audio."""
+"""Media handling: images, audio, and video."""
 
 from .audio import (
     AudioContent,
@@ -18,12 +18,23 @@ from .image import (
     image_from_url,
     make_image,
 )
+from .video import (
+    VideoContent,
+    VideoInput,
+    make_video,
+    video_from_base64,
+    video_from_bytes,
+    video_from_file,
+    video_from_url,
+)
 
 __all__ = [
     "AudioContent",
     "AudioInput",
     "ImageContent",
     "ImageInput",
+    "VideoContent",
+    "VideoInput",
     "audio_from_base64",
     "audio_from_bytes",
     "audio_from_file",
@@ -34,4 +45,9 @@ __all__ = [
     "image_from_url",
     "make_audio",
     "make_image",
+    "make_video",
+    "video_from_base64",
+    "video_from_bytes",
+    "video_from_file",
+    "video_from_url",
 ]

--- a/prompture/media/video.py
+++ b/prompture/media/video.py
@@ -1,0 +1,191 @@
+"""Video handling utilities for video generation drivers."""
+
+from __future__ import annotations
+
+import base64
+import mimetypes
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Union
+
+
+@dataclass(frozen=True)
+class VideoContent:
+    """Normalized video representation for video generation drivers.
+
+    Attributes:
+        data: Base64-encoded video data.
+        media_type: MIME type (e.g. ``"video/mp4"``, ``"video/webm"``).
+        source_type: How the video is delivered, either ``"base64"`` or ``"url"``.
+        url: Original URL when ``source_type`` is ``"url"``.
+        duration_seconds: Duration in seconds, if known.
+        width: Video width in pixels, if known.
+        height: Video height in pixels, if known.
+    """
+
+    data: str
+    media_type: str
+    source_type: str = "base64"
+    url: str | None = None
+    duration_seconds: float | None = None
+    width: int | None = None
+    height: int | None = None
+
+
+# Public type alias accepted by video-aware APIs.
+VideoInput = Union[bytes, str, Path, VideoContent]
+
+_DATA_URI_RE = re.compile(r"^data:(video/[a-zA-Z0-9.+-]+);base64,(.+)$", re.DOTALL)
+
+_MIME_FROM_EXT: dict[str, str] = {
+    ".mp4": "video/mp4",
+    ".m4v": "video/mp4",
+    ".mov": "video/quicktime",
+    ".webm": "video/webm",
+    ".avi": "video/x-msvideo",
+    ".mkv": "video/x-matroska",
+    ".mpeg": "video/mpeg",
+    ".mpg": "video/mpeg",
+}
+
+_MAGIC_BYTES: list[tuple[bytes, str]] = [
+    (b"\x1aE\xdf\xa3", "video/webm"),  # EBML: WebM / Matroska
+]
+
+
+def _guess_media_type_from_bytes(data: bytes) -> str:
+    """Guess MIME type from the first few bytes of video data."""
+    for magic, mime in _MAGIC_BYTES:
+        if data[: len(magic)] == magic:
+            return mime
+
+    # MP4/MOV: ftyp box at byte offset 4.
+    if len(data) >= 12 and data[4:8] == b"ftyp":
+        brand = data[8:12]
+        if brand in {b"qt  "}:
+            return "video/quicktime"
+        return "video/mp4"
+
+    return "video/mp4"
+
+
+def _guess_media_type(path: str) -> str:
+    """Guess MIME type from a file path or URL."""
+    clean = path.split("?")[0].split("#")[0]
+    ext = Path(clean).suffix.lower()
+    if ext in _MIME_FROM_EXT:
+        return _MIME_FROM_EXT[ext]
+    guessed = mimetypes.guess_type(clean)[0]
+    if guessed and guessed.startswith("video/"):
+        return guessed
+    return "video/mp4"
+
+
+def video_from_bytes(
+    data: bytes,
+    media_type: str | None = None,
+    *,
+    duration_seconds: float | None = None,
+    width: int | None = None,
+    height: int | None = None,
+) -> VideoContent:
+    """Create a :class:`VideoContent` from raw bytes."""
+    if not data:
+        raise ValueError("Video data cannot be empty")
+    b64 = base64.b64encode(data).decode("ascii")
+    mt = media_type or _guess_media_type_from_bytes(data)
+    return VideoContent(data=b64, media_type=mt, duration_seconds=duration_seconds, width=width, height=height)
+
+
+def video_from_base64(
+    b64: str,
+    media_type: str = "video/mp4",
+    *,
+    duration_seconds: float | None = None,
+    width: int | None = None,
+    height: int | None = None,
+) -> VideoContent:
+    """Create a :class:`VideoContent` from a base64-encoded string or data URI."""
+    m = _DATA_URI_RE.match(b64)
+    if m:
+        return VideoContent(
+            data=m.group(2),
+            media_type=m.group(1),
+            duration_seconds=duration_seconds,
+            width=width,
+            height=height,
+        )
+    return VideoContent(data=b64, media_type=media_type, duration_seconds=duration_seconds, width=width, height=height)
+
+
+def video_from_file(
+    path: str | Path,
+    media_type: str | None = None,
+    *,
+    duration_seconds: float | None = None,
+    width: int | None = None,
+    height: int | None = None,
+) -> VideoContent:
+    """Create a :class:`VideoContent` by reading a local file."""
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Video file not found: {p}")
+    raw = p.read_bytes()
+    mt = media_type or _guess_media_type(str(p))
+    return video_from_bytes(raw, mt, duration_seconds=duration_seconds, width=width, height=height)
+
+
+def video_from_url(
+    url: str,
+    media_type: str | None = None,
+    *,
+    duration_seconds: float | None = None,
+    width: int | None = None,
+    height: int | None = None,
+) -> VideoContent:
+    """Create a :class:`VideoContent` referencing a remote URL."""
+    mt = media_type or _guess_media_type(url)
+    return VideoContent(
+        data="",
+        media_type=mt,
+        source_type="url",
+        url=url,
+        duration_seconds=duration_seconds,
+        width=width,
+        height=height,
+    )
+
+
+def make_video(source: VideoInput) -> VideoContent:
+    """Auto-detect the source type and return a :class:`VideoContent`.
+
+    Accepts:
+    - ``VideoContent``: returned as-is.
+    - ``bytes``: base64-encoded with auto-detected MIME.
+    - ``str``: tries (in order): data URI, URL, file path, raw base64.
+    - ``pathlib.Path``: read from disk.
+    """
+    if isinstance(source, VideoContent):
+        return source
+
+    if isinstance(source, bytes):
+        return video_from_bytes(source)
+
+    if isinstance(source, Path):
+        return video_from_file(source)
+
+    if isinstance(source, str):
+        if source.startswith("data:"):
+            return video_from_base64(source)
+
+        if source.startswith(("http://", "https://")):
+            return video_from_url(source)
+
+        p = Path(source)
+        if p.exists():
+            return video_from_file(p)
+
+        return video_from_base64(source)
+
+    raise TypeError(f"Unsupported video source type: {type(source).__name__}")

--- a/tests/test_video_content.py
+++ b/tests/test_video_content.py
@@ -1,0 +1,129 @@
+"""Tests for prompture.media.video."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+
+from prompture.media.video import (
+    VideoContent,
+    _guess_media_type,
+    _guess_media_type_from_bytes,
+    make_video,
+    video_from_base64,
+    video_from_bytes,
+    video_from_file,
+    video_from_url,
+)
+
+
+class TestVideoContent:
+    """Tests for VideoContent."""
+
+    def test_frozen(self):
+        video = VideoContent(data="abc", media_type="video/mp4")
+        with pytest.raises(AttributeError):
+            video.data = "xyz"  # type: ignore[misc]
+
+    def test_defaults(self):
+        video = VideoContent(data="abc", media_type="video/mp4")
+        assert video.source_type == "base64"
+        assert video.url is None
+        assert video.duration_seconds is None
+        assert video.width is None
+        assert video.height is None
+
+    def test_url_source(self):
+        video = VideoContent(data="", media_type="video/mp4", source_type="url", url="https://example.com/v.mp4")
+        assert video.source_type == "url"
+        assert video.url == "https://example.com/v.mp4"
+
+
+class TestVideoMediaDetection:
+    """Tests for MIME detection."""
+
+    def test_mp4_magic(self):
+        data = b"\x00\x00\x00\x18ftypmp42" + b"\x00" * 50
+        assert _guess_media_type_from_bytes(data) == "video/mp4"
+
+    def test_mov_magic(self):
+        data = b"\x00\x00\x00\x18ftypqt  " + b"\x00" * 50
+        assert _guess_media_type_from_bytes(data) == "video/quicktime"
+
+    def test_webm_magic(self):
+        data = b"\x1aE\xdf\xa3" + b"\x00" * 50
+        assert _guess_media_type_from_bytes(data) == "video/webm"
+
+    def test_extension(self):
+        assert _guess_media_type("movie.webm") == "video/webm"
+        assert _guess_media_type("clip.mov") == "video/quicktime"
+
+    def test_url_with_query(self):
+        assert _guess_media_type("https://cdn.example.com/clip.mp4?token=abc") == "video/mp4"
+
+
+class TestVideoConstructors:
+    """Tests for video constructor helpers."""
+
+    def test_video_from_bytes(self):
+        raw = b"\x00\x00\x00\x18ftypmp42" + b"\x00" * 50
+        video = video_from_bytes(raw, duration_seconds=2.5, width=1280, height=720)
+        assert video.media_type == "video/mp4"
+        assert base64.b64decode(video.data) == raw
+        assert video.duration_seconds == 2.5
+        assert video.width == 1280
+        assert video.height == 720
+
+    def test_empty_bytes_raise(self):
+        with pytest.raises(ValueError, match="empty"):
+            video_from_bytes(b"")
+
+    def test_video_from_base64_data_uri(self):
+        raw_b64 = base64.b64encode(b"video bytes").decode()
+        video = video_from_base64(f"data:video/webm;base64,{raw_b64}")
+        assert video.data == raw_b64
+        assert video.media_type == "video/webm"
+
+    def test_video_from_file(self, tmp_path: Path):
+        path = tmp_path / "clip.mp4"
+        raw = b"\x00\x00\x00\x18ftypmp42" + b"\x00" * 50
+        path.write_bytes(raw)
+        video = video_from_file(path)
+        assert video.media_type == "video/mp4"
+        assert base64.b64decode(video.data) == raw
+
+    def test_missing_file(self):
+        with pytest.raises(FileNotFoundError):
+            video_from_file("/nonexistent/video.mp4")
+
+    def test_video_from_url(self):
+        video = video_from_url("https://example.com/clip.mp4", duration_seconds=8)
+        assert video.source_type == "url"
+        assert video.url == "https://example.com/clip.mp4"
+        assert video.media_type == "video/mp4"
+        assert video.duration_seconds == 8
+
+
+class TestMakeVideo:
+    """Tests for make_video."""
+
+    def test_passthrough(self):
+        video = VideoContent(data="abc", media_type="video/mp4")
+        assert make_video(video) is video
+
+    def test_url_string(self):
+        video = make_video("https://example.com/clip.webm")
+        assert video.source_type == "url"
+        assert video.media_type == "video/webm"
+
+    def test_file_path_string(self, tmp_path: Path):
+        path = tmp_path / "clip.mp4"
+        path.write_bytes(b"\x00\x00\x00\x18ftypmp42" + b"\x00" * 50)
+        video = make_video(str(path))
+        assert video.media_type == "video/mp4"
+
+    def test_unsupported_type(self):
+        with pytest.raises(TypeError, match="Unsupported"):
+            make_video(42)  # type: ignore[arg-type]

--- a/tests/test_video_gen.py
+++ b/tests/test_video_gen.py
@@ -1,0 +1,363 @@
+"""Tests for video generation registry, base classes, costs, and Grok driver."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from prompture.drivers.registry import (
+    _ASYNC_VIDEO_GEN_REGISTRY,
+    _VIDEO_GEN_REGISTRY,
+    get_async_video_gen_driver_factory,
+    get_video_gen_driver_factory,
+    is_async_video_gen_driver_registered,
+    is_video_gen_driver_registered,
+    list_registered_async_video_gen_drivers,
+    list_registered_video_gen_drivers,
+    register_async_video_gen_driver,
+    register_video_gen_driver,
+    unregister_async_video_gen_driver,
+    unregister_video_gen_driver,
+)
+
+
+class DummyVideoGen:
+    """Dummy video gen driver for registry tests."""
+
+    def __init__(self, model=None):
+        self.model = model
+
+
+@pytest.fixture(autouse=True)
+def _clean_video_gen_registries():
+    """Reset only video gen registries before each test, restore after."""
+    saved = (
+        dict(_VIDEO_GEN_REGISTRY),
+        dict(_ASYNC_VIDEO_GEN_REGISTRY),
+    )
+    _VIDEO_GEN_REGISTRY.clear()
+    _ASYNC_VIDEO_GEN_REGISTRY.clear()
+    yield
+    _VIDEO_GEN_REGISTRY.clear()
+    _ASYNC_VIDEO_GEN_REGISTRY.clear()
+    _VIDEO_GEN_REGISTRY.update(saved[0])
+    _ASYNC_VIDEO_GEN_REGISTRY.update(saved[1])
+
+
+class TestVideoGenRegistration:
+    """Tests for sync video generation registration."""
+
+    def test_register_and_lookup(self):
+        register_video_gen_driver("test_video", lambda model=None: DummyVideoGen(model))
+        assert is_video_gen_driver_registered("test_video")
+        factory = get_video_gen_driver_factory("test_video")
+        driver = factory("grok-imagine-video")
+        assert isinstance(driver, DummyVideoGen)
+        assert driver.model == "grok-imagine-video"
+
+    def test_case_insensitive(self):
+        register_video_gen_driver("TestVideo", lambda model=None: DummyVideoGen(model))
+        assert is_video_gen_driver_registered("testvideo")
+        assert is_video_gen_driver_registered("TESTVIDEO")
+
+    def test_duplicate_raises(self):
+        register_video_gen_driver("dup", lambda model=None: DummyVideoGen())
+        with pytest.raises(ValueError, match="already registered"):
+            register_video_gen_driver("dup", lambda model=None: DummyVideoGen())
+
+    def test_overwrite(self):
+        register_video_gen_driver("dup", lambda model=None: DummyVideoGen("old"))
+        register_video_gen_driver("dup", lambda model=None: DummyVideoGen("new"), overwrite=True)
+        driver = get_video_gen_driver_factory("dup")()
+        assert driver.model == "new"
+
+    def test_unregister(self):
+        register_video_gen_driver("temp", lambda model=None: DummyVideoGen())
+        assert unregister_video_gen_driver("temp")
+        assert not is_video_gen_driver_registered("temp")
+        assert not unregister_video_gen_driver("temp")
+
+    def test_list(self):
+        register_video_gen_driver("b_video", lambda model=None: DummyVideoGen())
+        register_video_gen_driver("a_video", lambda model=None: DummyVideoGen())
+        assert list_registered_video_gen_drivers() == ["a_video", "b_video"]
+
+    def test_lookup_missing_raises(self):
+        with pytest.raises(ValueError, match="Unsupported video gen"):
+            get_video_gen_driver_factory("nonexistent")
+
+
+class TestAsyncVideoGenRegistration:
+    """Tests for async video generation registration."""
+
+    def test_register_and_lookup(self):
+        register_async_video_gen_driver("test_async", lambda model=None: DummyVideoGen(model))
+        assert is_async_video_gen_driver_registered("test_async")
+        factory = get_async_video_gen_driver_factory("test_async")
+        driver = factory("grok-imagine-video")
+        assert driver.model == "grok-imagine-video"
+
+    def test_unregister(self):
+        register_async_video_gen_driver("temp", lambda model=None: DummyVideoGen())
+        assert unregister_async_video_gen_driver("temp")
+        assert not is_async_video_gen_driver_registered("temp")
+
+    def test_list(self):
+        register_async_video_gen_driver("z_async", lambda model=None: DummyVideoGen())
+        register_async_video_gen_driver("a_async", lambda model=None: DummyVideoGen())
+        assert list_registered_async_video_gen_drivers() == ["a_async", "z_async"]
+
+
+class TestVideoCostMixin:
+    """Tests for VideoCostMixin."""
+
+    def test_per_second_cost(self):
+        from prompture.infra.cost_mixin import VideoCostMixin
+
+        class TestDriver(VideoCostMixin):
+            VIDEO_PRICING = {"model": {"per_second": 0.05}}
+
+        driver = TestDriver()
+        assert driver._calculate_video_cost("test", "model", duration_seconds=10) == pytest.approx(0.5)
+
+    def test_resolution_specific_per_second_cost(self):
+        from prompture.infra.cost_mixin import VideoCostMixin
+
+        class TestDriver(VideoCostMixin):
+            VIDEO_PRICING = {"model": {"per_second": 0.05, "per_second_by_resolution": {"720p": 0.07}}}
+
+        driver = TestDriver()
+        cost = driver._calculate_video_cost("test", "model", duration_seconds=10, resolution="720p")
+        assert cost == pytest.approx(0.7)
+
+    def test_per_video_cost(self):
+        from prompture.infra.cost_mixin import VideoCostMixin
+
+        class TestDriver(VideoCostMixin):
+            VIDEO_PRICING = {"model": {"per_video": 1.25}}
+
+        driver = TestDriver()
+        assert driver._calculate_video_cost("test", "model", n=2) == pytest.approx(2.5)
+
+    def test_unknown_model_zero_cost(self):
+        from prompture.infra.cost_mixin import VideoCostMixin
+
+        class TestDriver(VideoCostMixin):
+            VIDEO_PRICING = {}
+
+        driver = TestDriver()
+        assert driver._calculate_video_cost("test", "unknown", duration_seconds=10) == 0.0
+
+
+class TestVideoGenBaseContract:
+    """Tests for video generation base contracts."""
+
+    def test_sync_generate_video_raises(self):
+        from prompture.drivers.video_gen_base import VideoGenDriver
+
+        driver = VideoGenDriver()
+        with pytest.raises(NotImplementedError):
+            driver.generate_video("a cat", {})
+
+    def test_async_generate_video_raises(self):
+        from prompture.drivers.async_video_gen_base import AsyncVideoGenDriver
+
+        driver = AsyncVideoGenDriver()
+        with pytest.raises(NotImplementedError):
+            asyncio.run(driver.generate_video("a cat", {}))
+
+    def test_sync_class_attributes(self):
+        from prompture.drivers.video_gen_base import VideoGenDriver
+
+        driver = VideoGenDriver()
+        assert driver.supports_polling is True
+        assert driver.supports_image_input is False
+        assert driver.callbacks is None
+
+
+class TestVideoGenHooks:
+    """Tests for video generation hook wrappers."""
+
+    def test_sync_generate_with_hooks_fires_callbacks(self):
+        from prompture.drivers.video_gen_base import VideoGenDriver
+        from prompture.infra.callbacks import DriverCallbacks
+        from prompture.media.video import video_from_url
+
+        calls = []
+
+        class TestVideo(VideoGenDriver):
+            def generate_video(self, prompt, options):
+                return {
+                    "videos": [video_from_url("https://example.com/video.mp4")],
+                    "meta": {"video_count": 1, "cost": 0.0},
+                }
+
+        driver = TestVideo()
+        driver.callbacks = DriverCallbacks(
+            on_request=lambda p: calls.append(("request", p)),
+            on_response=lambda p: calls.append(("response", p)),
+        )
+
+        result = driver.generate_video_with_hooks("a cat", {})
+        assert result["meta"]["video_count"] == 1
+        assert len(calls) == 2
+        assert calls[0][1]["prompt_length"] == 5
+        assert calls[1][1]["video_count"] == 1
+
+    def test_async_generate_with_hooks_fires_callbacks(self):
+        from prompture.drivers.async_video_gen_base import AsyncVideoGenDriver
+        from prompture.infra.callbacks import DriverCallbacks
+        from prompture.media.video import video_from_url
+
+        calls = []
+
+        class TestAsyncVideo(AsyncVideoGenDriver):
+            async def generate_video(self, prompt, options):
+                return {
+                    "videos": [video_from_url("https://example.com/video.mp4")],
+                    "meta": {"video_count": 1, "cost": 0.0},
+                }
+
+        driver = TestAsyncVideo()
+        driver.callbacks = DriverCallbacks(
+            on_request=lambda p: calls.append(("request", p)),
+            on_response=lambda p: calls.append(("response", p)),
+        )
+
+        result = asyncio.run(driver.generate_video_with_hooks("a cat", {}))
+        assert result["meta"]["video_count"] == 1
+        assert len(calls) == 2
+
+
+class _Response:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class TestGrokVideoGenDriver:
+    """Tests for Grok video generation driver."""
+
+    def test_attributes(self):
+        from prompture.drivers.grok_video_gen_driver import GrokVideoGenDriver
+
+        assert "grok-imagine-video" in GrokVideoGenDriver.KNOWN_MODELS
+        assert "16:9" in GrokVideoGenDriver.supported_aspect_ratios
+        assert "720p" in GrokVideoGenDriver.supported_resolutions
+        assert GrokVideoGenDriver.supports_image_input is True
+        assert GrokVideoGenDriver.supports_audio is True
+
+    @patch("prompture.drivers.grok_video_gen_driver.httpx.get")
+    @patch("prompture.drivers.grok_video_gen_driver.httpx.post")
+    def test_generate_video_polls_and_returns_url(self, mock_post, mock_get):
+        from prompture.drivers.grok_video_gen_driver import GrokVideoGenDriver
+
+        mock_post.return_value = _Response(200, {"request_id": "req_123"})
+        mock_get.return_value = _Response(
+            200,
+            {"status": "done", "video": {"url": "https://vidgen.x.ai/video.mp4", "duration": 8}},
+        )
+
+        driver = GrokVideoGenDriver(api_key="xai-test")
+        result = driver.generate_video(
+            "cinematic launch",
+            {"duration": 8, "resolution": "720p", "poll_interval": 0, "timeout": 1},
+        )
+
+        assert result["videos"][0].url == "https://vidgen.x.ai/video.mp4"
+        assert result["meta"]["video_count"] == 1
+        assert result["meta"]["request_id"] == "req_123"
+        assert result["meta"]["resolution"] == "720p"
+        assert result["meta"]["cost"] == pytest.approx(0.56)
+        mock_post.assert_called_once()
+        mock_get.assert_called_once()
+
+    @patch("prompture.drivers.grok_video_gen_driver.httpx.post")
+    def test_generate_video_without_poll_returns_request_id(self, mock_post):
+        from prompture.drivers.grok_video_gen_driver import GrokVideoGenDriver
+
+        mock_post.return_value = _Response(200, {"request_id": "req_123", "status": "pending"})
+        driver = GrokVideoGenDriver(api_key="xai-test")
+        result = driver.generate_video("cinematic launch", {"poll": False})
+
+        assert result["videos"] == []
+        assert result["meta"]["request_id"] == "req_123"
+        assert result["meta"]["status"] == "pending"
+
+    def test_missing_key_raises(self):
+        from prompture.drivers.grok_video_gen_driver import GrokVideoGenDriver
+
+        with patch.dict("os.environ", {}, clear=True):
+            driver = GrokVideoGenDriver(api_key=None)
+            with pytest.raises(RuntimeError, match="GROK_API_KEY or XAI_API_KEY"):
+                driver.generate_video("test", {})
+
+    def test_xai_api_key_alias_is_supported(self):
+        from prompture.drivers.grok_video_gen_driver import GrokVideoGenDriver
+
+        with patch.dict("os.environ", {"XAI_API_KEY": "xai-test"}, clear=True):
+            driver = GrokVideoGenDriver(api_key=None)
+            assert driver.api_key == "xai-test"
+
+    def test_image_and_reference_images_conflict(self):
+        from prompture.drivers.grok_video_gen_driver import GrokVideoGenDriver
+
+        driver = GrokVideoGenDriver(api_key="xai-test")
+        with pytest.raises(ValueError, match="cannot be used together"):
+            driver.generate_video(
+                "test",
+                {
+                    "image": "https://example.com/a.png",
+                    "reference_images": ["https://example.com/b.png"],
+                },
+            )
+
+    def test_reference_images_limit(self):
+        from prompture.drivers.grok_video_gen_driver import GrokVideoGenDriver
+
+        driver = GrokVideoGenDriver(api_key="xai-test")
+        with pytest.raises(ValueError, match="at most 7"):
+            driver.generate_video("test", {"reference_images": ["https://example.com/a.png"] * 8})
+
+    def test_reference_images_duration_limit(self):
+        from prompture.drivers.grok_video_gen_driver import GrokVideoGenDriver
+
+        driver = GrokVideoGenDriver(api_key="xai-test")
+        with pytest.raises(ValueError, match="10 seconds or less"):
+            driver.generate_video("test", {"reference_images": ["https://example.com/a.png"], "duration": 11})
+
+    def test_factory_resolves_builtin_driver(self):
+        from prompture.drivers import get_video_gen_driver_for_model
+        from prompture.drivers.grok_video_gen_driver import GrokVideoGenDriver
+        from prompture.drivers.provider_descriptors import register_all_builtin_drivers
+
+        register_all_builtin_drivers()
+        driver = get_video_gen_driver_for_model("grok/grok-imagine-video")
+        assert isinstance(driver, GrokVideoGenDriver)
+        assert driver.model == "grok-imagine-video"
+
+
+class TestVideoDiscovery:
+    """Tests for video generation model discovery."""
+
+    @patch("prompture.infra.discovery.get_available_models", return_value=[])
+    @patch.dict("os.environ", {"GROK_API_KEY": "xai-test"})
+    def test_grok_video_model_discovered(self, mock_models):
+        from prompture.infra.discovery import get_available_video_gen_models
+
+        models = get_available_video_gen_models()
+        assert "grok/grok-imagine-video" in models
+
+    @patch("prompture.infra.discovery.get_available_models", return_value=[])
+    @patch.dict("os.environ", {"XAI_API_KEY": "xai-test"}, clear=True)
+    def test_grok_video_model_discovered_with_xai_key_alias(self, mock_models):
+        from prompture.infra.discovery import get_available_video_gen_models
+
+        models = get_available_video_gen_models()
+        assert "grok/grok-imagine-video" in models


### PR DESCRIPTION
Prompture has been quietly competent at text and image generation for a while — this PR drags it the rest of the way into the multi-modal world. It adds a brand-new video generation modality (with Grok Imagine and seven Runway video models behind it) and rounds out the Runway surface across image, TTS, sound effects, and voice transforms, all under a single API key.

### Highlights

- Generate videos from text or image inputs via `get_video_gen_driver_for_model("grok/grok-imagine-video")` or `get_video_gen_driver_for_model("runway/gen4.5")`, with polling, cost reporting, and the same `provider/model` routing as the rest of the library.
- One Runway key (`RUNWAY_API_KEY` or `RUNWAYML_API_SECRET`) now unlocks image generation (`gen4_image`, `gen4_image_turbo`, `gpt_image_2`, `gemini_image3_pro`, `gemini_2.5_flash`), video (`gen4.5`, `gen4_turbo`, `gen3a_turbo`, `gen4_aleph`, `veo3`, `veo3.1`, `veo3.1_fast`), TTS (`eleven_multilingual_v2` with 49 preset voices), and sound effects (`eleven_text_to_sound_v2`).
- New `RunwayAudioTransformDriver` covers voice dubbing across 29 languages, voice isolation, and speech-to-speech voice conversion — operations that don't fit STT/TTS shape and so live as a standalone helper.
- A capability registry (`get_runway_model_info`, `get_runway_models_by_op`, `get_runway_models_by_modality`) lets callers ask "which Runway models do text_to_video?" as data, without instantiating drivers.
- `get_available_video_gen_models()` joins the existing image / audio / embedding discovery helpers, and auto-detects video-capable models from configured provider keys plus the models.dev fallback.
- Three runnable examples in `examples/` for video, image, and audio Runway flows, plus a Grok video example.

<details>
<summary>Technical changes</summary>

- New video generation modality:
  - `prompture/drivers/video_gen_base.py` adds `VideoGenDriver` with the response contract (`videos`, `meta.video_count`, `duration_seconds`, `aspect_ratio`, `resolution`, `cost`, `model_name`, `raw_response`), capability flags (`supports_image_input`, `supports_reference_images`, `supports_video_input`, `supports_audio`, `supports_polling`, `supported_aspect_ratios`, `supported_resolutions`, `max_seconds`), and `generate_video_with_hooks` for `on_request` / `on_response` / `on_error` callbacks.
  - `async_video_gen_base.py` mirrors it for async.
  - `prompture/drivers/registry.py` gains `_video_gen_sync` / `_video_gen_async` `DriverRegistry` instances plus the full set of public functions (`register_video_gen_driver`, `unregister_video_gen_driver`, `list_registered_video_gen_drivers`, `is_video_gen_driver_registered`, `get_video_gen_driver_factory`, `load_video_gen_entry_point_drivers`, async siblings, and `_get_video_gen_registry` / `_get_async_video_gen_registry`). Both registries are reset by `_reset_registries`.
  - `prompture/drivers/video_gen_registry.py` exposes the `get_video_gen_driver_for_model` / `get_async_video_gen_driver_for_model` factories that parse `"provider/model"` strings.
- `VideoCostMixin` added to `prompture/infra/cost_mixin.py`. `_calculate_video_cost` resolves cost in this order: resolution-specific `per_second_by_resolution[resolution] × duration_seconds`, then generic `per_second × duration_seconds`, then `per_video`, then `default`.
- `prompture/media/video.py` introduces `VideoContent` (frozen dataclass with `data`, `media_type`, `source_type`, `url`, `duration_seconds`, `width`, `height`), the `VideoInput` type alias, and constructors `video_from_bytes`, `video_from_base64`, `video_from_file`, `video_from_url`, and `make_video`. MIME detection covers MP4 / MOV / WebM / MKV / AVI / MPEG via extension lookup, magic-byte sniffing (EBML for WebM, `ftyp` box for MP4/MOV), and a `_DATA_URI_RE` matcher for `data:video/...` URIs.
- New Grok video generation driver `prompture/drivers/grok_video_gen_driver.py` (sync) and `async_grok_video_gen_driver.py` (async) targeting the xAI `POST /videos/generations` + `GET /videos/{id}` endpoints. Validates duration (1-15 s, max 10 s when reference images are used), aspect ratio (`1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `3:2`, `2:3`), resolution (`480p` / `720p`), and rejects `image` + `reference_images` combinations. Reference images limited to seven. `VIDEO_PRICING` uses `per_second_by_resolution`: `$0.05/s` at 480p, `$0.07/s` at 720p. Accepts `GROK_API_KEY` or `XAI_API_KEY`, polls the task with configurable `poll_interval` / `timeout`, returns request_id-only response when `poll=False`. Supports `ImageInput` / `dict` / data-URI inputs through `make_image`.
- New Runway image driver `runway_img_gen_driver.py` (+ async) hits `POST /v1/text_to_image` then polls `GET /v1/tasks/{id}` until `SUCCEEDED` / `FAILED` / `CANCELLED`. Enforces the 16 documented `text_to_image` ratios, requires `reference_images` for `gen4_image_turbo`, rejects `quality` on models other than `gpt_image_2`, normalizes reference image dicts to `{uri, tag}`, and parses Runway's structured `error` / `issues` body into a single error string via `_format_error`. Pricing covers all five models with size/quality buckets where Runway differentiates. Default ratios per model live in `_DEFAULT_RATIOS`. Header `X-Runway-Version: 2024-11-06`.
- New Runway video driver `runway_video_gen_driver.py` (+ async) handles all three video endpoints (`/v1/text_to_video`, `/v1/image_to_video`, `/v1/video_to_video`) in one class. `_detect_mode` picks the endpoint from an explicit `mode` option or auto-detects from `video` / `image` presence in options. Per-mode model allow-lists (`_KNOWN_MODELS_BY_MODE`) and per-endpoint ratio sets (`_T2V_RATIOS`, `_I2V_RATIOS`). `_normalize_prompt_image` accepts strings, dicts, or lists of keyframe dicts and emits the right `promptImage` shape. `VIDEO_PRICING` is per-second per model (`$0.05`–`$0.40/s`).
- New Runway TTS driver `runway_tts_driver.py` (+ async) routes by model: any `eleven_text_to_sound_v2` request hits `/v1/sound_effect`, anything else hits `/v1/text_to_speech`. Sound effects accept `duration` (0.5–30 s) and `loop`. TTS requires a preset voice — either a string preset name resolved to `{type: runway-preset, presetId: ...}` or a full voice dict. The 49 Runway preset voice names are exposed as `available_voices`. `AudioCostMixin` provides per-character TTS pricing (`$0.000030/char`) and per-second sound-effect pricing (`$0.04/s`).
- New `runway_audio_transform_driver.py` adds `RunwayAudioTransformDriver` for the three operations that take audio and return audio: `dub(audio, target_lang, ...)` (29 ISO-639-1 codes validated against `DUBBING_LANGUAGES`), `isolate(audio, ...)`, and `convert_voice(media, voice_preset_id, media_kind="audio"|"video", ...)`. All three submit a task, poll until terminal, download the resulting audio via the `_fetch_audio` helper, and return `{audio, media_type, meta}`. Lives outside the modality registry by design — STT and TTS contracts don't apply.
- `runway_capabilities.py` declares `RUNWAY_MODEL_INFO: dict[str, RunwayModelInfo]` covering 16 Runway models with modality, operations, endpoints, and cost notes. Exposes `get_runway_model_info(model_id_or_provider_path)`, `get_runway_models_by_op(operation)`, and `get_runway_models_by_modality(modality)`, plus `ALL_OPERATIONS` / `ALL_MODALITIES` sorted lists.
- `provider_descriptors.py` adds `video_gen_sync` / `video_gen_async` fields to `ProviderDescriptor`, a full Runway descriptor wiring image + video + TTS modalities, a new `_runway_kw` lookup (`runway_api_key`, `runway_endpoint`), and a `runwayml` alias for `runway` covering `{img_gen, video_gen, tts}`. The `xai` alias for `grok` now also covers `video_gen`. The descriptor-driven `register_all_builtin_drivers()` learns the two new modalities via `register_video_gen_driver` / `register_async_video_gen_driver`. Grok descriptor adds `video_gen_sync` / `video_gen_async` pointing at the new drivers with `grok_video_model` as the default key.
- `prompture/infra/settings.py` adds `xai_api_key`, `grok_video_model` (default `grok-imagine-video`), `runway_api_key`, and `runway_endpoint`. `provider_env.py` adds `xai_api_key` to `ProviderEnvironment` for per-consumer isolation.
- `prompture/infra/discovery.py` adds `get_available_video_gen_models()` (Grok + Runway via static `KNOWN_MODELS`, plus a models.dev fallback that scans `caps.modalities_output` for `"video"`), and extends `get_available_image_gen_models` and `get_available_audio_models` to include Runway when the key is present.
- `prompture/drivers/__init__.py` exports all new drivers, registry functions, the Runway capability helpers, and `VideoGenDriver` / `AsyncVideoGenDriver` base classes. `__all__` updated. `prompture/infra/__init__.py` re-exports `VideoCostMixin` and `get_available_video_gen_models`.
- New examples: `examples/grok_video_generation_example.py`, `examples/runway_image_generation_example.py`, `examples/runway_video_generation_example.py`, `examples/runway_audio_example.py`.
- `.env.copy` documents `XAI_API_KEY`, `GROK_VIDEO_MODEL`, and the Runway block. `.gitignore` adds entries for example output artifacts.
- `README.md` and `CLAUDE.md` document the new video modality, the Runway surface, the capability registry, and the discovery helpers. Provider count bumped from 17+ to 18+.

</details>
