### PR TITLE
Add Fal/Kling/MiniMax drivers and harden OpenAI strict-schema + LM Studio errors

### DIFF
--- a/.env.copy
+++ b/.env.copy
@@ -94,3 +94,24 @@ STABILITY_API_KEY=
 # ─── Runway (image / video / audio) ─────────────────────────────────────────
 # Either RUNWAY_API_KEY or RUNWAYML_API_SECRET is accepted.
 RUNWAY_API_KEY=
+
+# ─── Kling AI (image + video) ───────────────────────────────────────────────
+KLING_ACCESS_KEY=
+KLING_SECRET_KEY=
+KLING_ENDPOINT=
+KLING_IMAGE_MODEL=kling-v2-1
+KLING_VIDEO_MODEL=kling-v2-1
+
+# ─── MiniMax / Hailuo (LLM + video) ─────────────────────────────────────────
+# HAILUO_API_KEY is also supported.
+MINIMAX_API_KEY=
+HAILUO_API_KEY=
+MINIMAX_ENDPOINT=https://api.minimax.io/v1
+MINIMAX_MODEL=MiniMax-Text-01
+MINIMAX_VIDEO_MODEL=MiniMax-Hailuo-2.3
+
+# ─── Fal.ai (image + video aggregator) ──────────────────────────────────────
+FAL_API_KEY=
+FAL_ENDPOINT=
+FAL_IMAGE_MODEL=fal-ai/flux/dev
+FAL_VIDEO_MODEL=fal-ai/kling-video/v2.6/pro/image-to-video

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ print(person.name)  # Maria
 ## Key Features
 
 - **Structured output** — JSON schema enforcement and direct Pydantic model population
-- **18+ providers** — OpenAI, Claude, Google, Groq, Grok, Azure, Ollama, LM Studio, OpenRouter, HuggingFace, Moonshot, ModelScope, Z.ai, Vertex AI, AirLLM, CachiBot, Runway, and generic HTTP
+- **20+ providers** — OpenAI, Claude, Google, Groq, Grok, Azure, Ollama, LM Studio, OpenRouter, HuggingFace, Moonshot, ModelScope, Z.ai, Vertex AI, AirLLM, CachiBot, Runway, MiniMax/Hailuo, Kling AI, Fal.ai, and generic HTTP
 - **Multi-modal** — Drivers for embeddings, image generation (DALL-E, Imagen, Grok, Stability, Runway), video generation (Grok Imagine Video, Runway text/image/video → video), text-to-speech (OpenAI, ElevenLabs, Runway), sound effects, voice dubbing / isolation / conversion (Runway), and speech-to-text (Whisper, ElevenLabs)
 - **Multi-model fallback** — Try a list of models in sequence with per-attempt cost, token, and capability accounting
 - **Strategy cascade** — Auto-selects between provider-native JSON mode, tool-call extraction, and prompted repair so extraction works on any model
@@ -128,16 +128,19 @@ Model strings use `"provider/model"` format. The provider prefix routes to the c
 | `airllm` | `airllm/Qwen2-7B` | Free (local) |
 | `local_http` | `local_http/self-hosted` | Free |
 | `runway` | `runway/gen4.5` (video), `runway/gpt_image_2` (image), `runway/eleven_multilingual_v2` (TTS) | Automatic |
+| `minimax` | `minimax/MiniMax-Text-01` (LLM), `minimax/MiniMax-Hailuo-2.3` (video) | Automatic |
+| `kling` | `kling/kling-v2-1` (image + video) | Automatic |
+| `fal` | `fal/fal-ai/flux/dev` (image), `fal/fal-ai/kling-video/v2.6/pro/image-to-video` (video) | Automatic |
 
-Aliases (`anthropic`, `gemini`, `chatgpt`, `xai`, `lm_studio`, `zhipu`, `hf`, `dalle`, `runwayml`) route to their canonical providers.
+Aliases (`anthropic`, `gemini`, `chatgpt`, `xai`, `lm_studio`, `zhipu`, `hf`, `dalle`, `runwayml`, `hailuo`) route to their canonical providers.
 
 ## Multi-Modal
 
 Beyond text LLMs, Prompture exposes drivers for adjacent modalities under the same `provider/model` routing:
 
 - **Embeddings** — OpenAI (`text-embedding-3-*`) and Ollama (`nomic-embed-text`)
-- **Image generation** — OpenAI DALL-E + GPT image, Google Imagen, Grok, Stability AI, Runway (`gen4_image`, `gen4_image_turbo`, `gpt_image_2`, `gemini_image3_pro`, `gemini_2.5_flash`)
-- **Video generation** — Grok Imagine Video; Runway text/image/video → video (`gen4.5`, `gen4_turbo`, `gen3a_turbo`, `gen4_aleph`, `veo3`, `veo3.1`, `veo3.1_fast`)
+- **Image generation** — OpenAI DALL-E + GPT image, Google Imagen, Grok, Stability AI, Runway (`gen4_image`, `gen4_image_turbo`, `gpt_image_2`, `gemini_image3_pro`, `gemini_2.5_flash`), Kling AI, Fal.ai
+- **Video generation** — Grok Imagine Video; Runway text/image/video → video (`gen4.5`, `gen4_turbo`, `gen3a_turbo`, `gen4_aleph`, `veo3`, `veo3.1`, `veo3.1_fast`); MiniMax / Hailuo; Kling AI; Fal.ai
 - **Text-to-speech** — OpenAI (`tts-1`), ElevenLabs, Runway (`eleven_multilingual_v2`)
 - **Sound effects** — Runway (`eleven_text_to_sound_v2`)
 - **Audio transforms** — Runway voice dubbing, voice isolation, speech-to-speech (`RunwayAudioTransformDriver`)

--- a/prompture/drivers/async_fal_img_gen_driver.py
+++ b/prompture/drivers/async_fal_img_gen_driver.py
@@ -1,0 +1,7 @@
+"""Async Fal.ai image generation driver (re-export)."""
+
+from __future__ import annotations
+
+from .fal_img_gen_driver import AsyncFalImageGenDriver
+
+__all__ = ["AsyncFalImageGenDriver"]

--- a/prompture/drivers/async_fal_video_gen_driver.py
+++ b/prompture/drivers/async_fal_video_gen_driver.py
@@ -1,0 +1,7 @@
+"""Async Fal.ai video generation driver (re-export)."""
+
+from __future__ import annotations
+
+from .fal_video_gen_driver import AsyncFalVideoGenDriver
+
+__all__ = ["AsyncFalVideoGenDriver"]

--- a/prompture/drivers/async_kling_img_gen_driver.py
+++ b/prompture/drivers/async_kling_img_gen_driver.py
@@ -1,0 +1,159 @@
+"""Async Kling AI image generation driver."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+
+from ..infra.cost_mixin import ImageCostMixin
+from ..media.image import image_from_url
+from .async_img_gen_base import AsyncImageGenDriver
+from .kling_img_gen_driver import (
+    KlingImageGenDriver,
+    _get_kling_credentials,
+    _DEFAULT_ENDPOINT,
+    generate_kling_jwt,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncKlingImageGenDriver(ImageCostMixin, AsyncImageGenDriver):
+    """Async image generation via Kling AI."""
+
+    supports_multiple = KlingImageGenDriver.supports_multiple
+    supports_size_variants = KlingImageGenDriver.supports_size_variants
+    supported_sizes = KlingImageGenDriver.supported_sizes
+    max_images = KlingImageGenDriver.max_images
+
+    KNOWN_MODELS = KlingImageGenDriver.KNOWN_MODELS
+    IMAGE_PRICING = KlingImageGenDriver.IMAGE_PRICING
+
+    def __init__(
+        self,
+        access_key: str | None = None,
+        secret_key: str | None = None,
+        model: str = "kling-v2-1",
+        endpoint: str | None = None,
+    ):
+        import os
+        ak, sk = _get_kling_credentials(access_key, secret_key)
+        self.access_key = ak
+        self.secret_key = sk
+        self.model = model
+        self.endpoint = (endpoint or os.getenv("KLING_ENDPOINT") or _DEFAULT_ENDPOINT).rstrip("/")
+
+    def _token(self) -> str:
+        if not self.access_key or not self.secret_key:
+            raise RuntimeError("KLING_ACCESS_KEY and KLING_SECRET_KEY must be configured")
+        return generate_kling_jwt(self.access_key, self.secret_key)
+
+    def _headers(self, token: str) -> dict[str, str]:
+        return {"Content-Type": "application/json", "Authorization": f"Bearer {token}"}
+
+    async def generate_image(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        if not prompt:
+            raise ValueError("prompt cannot be empty")
+        token = self._token()
+        # Reuse the sync build helper — it's pure.
+        sync = KlingImageGenDriver(
+            access_key=self.access_key,
+            secret_key=self.secret_key,
+            model=self.model,
+            endpoint=self.endpoint,
+        )
+        path, body = sync._build_body(prompt, options)
+        is_multi = path.endswith("multi-image2image")
+
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            resp = await client.post(
+                f"{self.endpoint}{path}", headers=self._headers(token), json=body
+            )
+            if resp.status_code >= 400:
+                raise RuntimeError(f"Kling API error {resp.status_code}: {resp.text}")
+            result = resp.json()
+            if result.get("code") != 0:
+                raise RuntimeError(f"Kling API error: {result.get('message')}")
+            task_id = result.get("data", {}).get("task_id")
+            if not task_id:
+                raise RuntimeError(f"Kling response missing task_id: {result}")
+
+            if not options.get("poll", True):
+                return {
+                    "images": [],
+                    "meta": {
+                        "image_count": 0,
+                        "size": body.get("aspect_ratio"),
+                        "revised_prompt": None,
+                        "cost": 0.0,
+                        "model_name": f"kling/{body['model_name']}",
+                        "task_id": task_id,
+                        "status": "pending",
+                        "raw_response": result,
+                    },
+                }
+
+            final = await self._poll_image(
+                client,
+                task_id,
+                token,
+                multi=is_multi,
+                poll_interval=float(options.get("poll_interval", 3)),
+                timeout_seconds=float(options.get("timeout", 120)),
+            )
+
+        urls = [
+            img["url"]
+            for img in (final.get("data", {}).get("task_result", {}).get("images") or [])
+            if img.get("url")
+        ]
+        images = [image_from_url(u) for u in urls]
+        cost = self._calculate_image_cost(
+            "kling", body["model_name"], size=str(body["image_size"]), n=max(len(images), 1)
+        )
+        return {
+            "images": images,
+            "meta": {
+                "image_count": len(images),
+                "size": body["aspect_ratio"],
+                "revised_prompt": None,
+                "cost": cost,
+                "model_name": f"kling/{body['model_name']}",
+                "task_id": task_id,
+                "raw_response": final,
+            },
+        }
+
+    async def _poll_image(
+        self,
+        client: httpx.AsyncClient,
+        task_id: str,
+        token: str,
+        *,
+        multi: bool,
+        poll_interval: float,
+        timeout_seconds: float,
+    ) -> dict[str, Any]:
+        base = "multi-image2image" if multi else "generations"
+        path = f"/v1/images/{base}/{task_id}"
+        import time as _t
+        deadline = _t.monotonic() + timeout_seconds
+        while True:
+            r = await client.get(f"{self.endpoint}{path}", headers=self._headers(token))
+            if r.status_code >= 400:
+                raise RuntimeError(f"Kling poll failed {r.status_code}: {r.text}")
+            data = r.json()
+            if data.get("code") != 0:
+                raise RuntimeError(f"Kling poll error: {data.get('message')}")
+            status = data.get("data", {}).get("task_status")
+            if status == "succeed":
+                return data
+            if status == "failed":
+                msg = data.get("data", {}).get("task_status_msg", "unknown")
+                raise RuntimeError(f"Kling image task failed: {msg}")
+            if _t.monotonic() >= deadline:
+                raise TimeoutError(f"Kling image task {task_id} timed out (status={status})")
+            await asyncio.sleep(poll_interval)

--- a/prompture/drivers/async_kling_video_gen_driver.py
+++ b/prompture/drivers/async_kling_video_gen_driver.py
@@ -1,0 +1,7 @@
+"""Async Kling AI video generation driver (re-export)."""
+
+from __future__ import annotations
+
+from .kling_video_gen_driver import AsyncKlingVideoGenDriver
+
+__all__ = ["AsyncKlingVideoGenDriver"]

--- a/prompture/drivers/async_lmstudio_driver.py
+++ b/prompture/drivers/async_lmstudio_driver.py
@@ -90,10 +90,25 @@ class AsyncLMStudioDriver(AsyncDriver):
         async with httpx.AsyncClient() as client:
             try:
                 r = await client.post(self.endpoint, json=payload, headers=self._headers, timeout=120)
-                r.raise_for_status()
-                response_data = r.json()
             except Exception as e:
                 raise RuntimeError(f"AsyncLMStudioDriver request failed: {e}") from e
+            if r.status_code >= 400:
+                # Surface the server's actual rejection reason. LM Studio
+                # returns useful JSON bodies on 400 (model not loaded,
+                # context overflow, schema rejected) that httpx's default
+                # HTTPStatusError throws away.
+                body = (r.text or "").strip()
+                snippet = body[:500] + ("…" if len(body) > 500 else "")
+                raise RuntimeError(
+                    f"AsyncLMStudioDriver request failed: HTTP {r.status_code} "
+                    f"from {self.endpoint} — body: {snippet or '<empty>'}"
+                )
+            try:
+                response_data = r.json()
+            except Exception as e:
+                raise RuntimeError(
+                    f"AsyncLMStudioDriver got non-JSON response (HTTP {r.status_code}): {e}"
+                ) from e
 
         if "choices" not in response_data or not response_data["choices"]:
             raise ValueError(f"Unexpected response format: {response_data}")

--- a/prompture/drivers/async_minimax_driver.py
+++ b/prompture/drivers/async_minimax_driver.py
@@ -1,0 +1,169 @@
+"""Async MiniMax LLM driver."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import httpx
+
+from ..infra.cost_mixin import CostMixin, prepare_strict_schema
+from .async_base import AsyncDriver
+from .base import _parse_tool_arguments
+from .minimax_driver import _DEFAULT_ENDPOINT, MiniMaxDriver
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncMiniMaxDriver(CostMixin, AsyncDriver):
+    supports_json_mode = MiniMaxDriver.supports_json_mode
+    supports_json_schema = MiniMaxDriver.supports_json_schema
+    supports_tool_use = MiniMaxDriver.supports_tool_use
+    supports_streaming = False
+    supports_vision = False
+    supports_messages = True
+
+    MODEL_PRICING = MiniMaxDriver.MODEL_PRICING
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = "MiniMax-Text-01",
+        endpoint: str | None = None,
+    ):
+        self.api_key = api_key or os.getenv("MINIMAX_API_KEY") or os.getenv("HAILUO_API_KEY")
+        if not self.api_key:
+            raise ValueError("MiniMax API key not found. Set MINIMAX_API_KEY env var.")
+        self.model = model
+        self.base_url = (endpoint or os.getenv("MINIMAX_ENDPOINT") or _DEFAULT_ENDPOINT).rstrip("/")
+        self.headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    async def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        return await self._do_generate([{"role": "user", "content": prompt}], options)
+
+    async def generate_messages(self, messages: list[dict[str, str]], options: dict[str, Any]) -> dict[str, Any]:
+        return await self._do_generate(list(messages), options)
+
+    async def _do_generate(self, messages: list[dict[str, Any]], options: dict[str, Any]) -> dict[str, Any]:
+        model = options.get("model", self.model)
+        opts = {"temperature": 1.0, "max_tokens": 1024, **options}
+
+        data: dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "max_tokens": opts["max_tokens"],
+            "temperature": opts["temperature"],
+        }
+        if options.get("json_mode"):
+            json_schema = options.get("json_schema")
+            if json_schema:
+                data["response_format"] = {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "extraction",
+                        "strict": True,
+                        "schema": prepare_strict_schema(json_schema),
+                    },
+                }
+            else:
+                data["response_format"] = {"type": "json_object"}
+
+        async with httpx.AsyncClient(timeout=opts.get("timeout", 300)) as client:
+            response = await client.post(
+                f"{self.base_url}/text/chatcompletion_v2",
+                headers=self.headers,
+                json=data,
+            )
+            if response.status_code >= 400:
+                raise RuntimeError(f"MiniMax API error {response.status_code}: {response.text}")
+            resp = response.json()
+
+        base_resp = resp.get("base_resp")
+        if isinstance(base_resp, dict) and base_resp.get("status_code", 0) != 0:
+            raise RuntimeError(f"MiniMax API error: {base_resp.get('status_msg')}")
+
+        usage = resp.get("usage", {})
+        prompt_tokens = usage.get("prompt_tokens") or usage.get("total_input_tokens", 0) or 0
+        completion_tokens = usage.get("completion_tokens") or usage.get("total_output_tokens", 0) or 0
+        total_tokens = usage.get("total_tokens", prompt_tokens + completion_tokens)
+        total_cost = self._calculate_cost("minimax", model, prompt_tokens, completion_tokens)
+
+        text = ""
+        choices = resp.get("choices") or []
+        if choices:
+            text = (choices[0].get("message") or {}).get("content") or ""
+
+        return {
+            "text": text,
+            "meta": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": total_tokens,
+                "cost": round(total_cost, 6),
+                "raw_response": resp,
+                "model_name": model,
+            },
+        }
+
+    async def generate_messages_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> dict[str, Any]:
+        model = options.get("model", self.model)
+        opts = {"temperature": 1.0, "max_tokens": 4096, **options}
+        data: dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "tools": tools,
+            "max_tokens": opts["max_tokens"],
+            "temperature": opts["temperature"],
+        }
+        if "tool_choice" in options:
+            data["tool_choice"] = options["tool_choice"]
+
+        async with httpx.AsyncClient(timeout=opts.get("timeout", 300)) as client:
+            response = await client.post(
+                f"{self.base_url}/text/chatcompletion_v2",
+                headers=self.headers,
+                json=data,
+            )
+            if response.status_code >= 400:
+                raise RuntimeError(f"MiniMax API error {response.status_code}: {response.text}")
+            resp = response.json()
+
+        usage = resp.get("usage", {})
+        prompt_tokens = usage.get("prompt_tokens", 0) or 0
+        completion_tokens = usage.get("completion_tokens", 0) or 0
+        total_tokens = usage.get("total_tokens", prompt_tokens + completion_tokens)
+        total_cost = self._calculate_cost("minimax", model, prompt_tokens, completion_tokens)
+
+        choice = (resp.get("choices") or [{}])[0]
+        message = choice.get("message") or {}
+        text = message.get("content") or ""
+        stop_reason = choice.get("finish_reason")
+
+        tool_calls_out: list[dict[str, Any]] = []
+        for tc in message.get("tool_calls") or []:
+            fn = tc.get("function") or {}
+            args = _parse_tool_arguments(fn.get("arguments"), fn.get("name", ""), stop_reason)
+            tool_calls_out.append({"id": tc.get("id"), "name": fn.get("name"), "arguments": args})
+
+        return {
+            "text": text,
+            "meta": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": total_tokens,
+                "cost": round(total_cost, 6),
+                "raw_response": resp,
+                "model_name": model,
+            },
+            "tool_calls": tool_calls_out,
+            "stop_reason": stop_reason,
+        }

--- a/prompture/drivers/async_minimax_video_gen_driver.py
+++ b/prompture/drivers/async_minimax_video_gen_driver.py
@@ -1,0 +1,7 @@
+"""Async MiniMax video generation driver (re-export)."""
+
+from __future__ import annotations
+
+from .minimax_video_gen_driver import AsyncMiniMaxVideoGenDriver
+
+__all__ = ["AsyncMiniMaxVideoGenDriver"]

--- a/prompture/drivers/fal_img_gen_driver.py
+++ b/prompture/drivers/fal_img_gen_driver.py
@@ -1,0 +1,291 @@
+"""Fal.ai image generation driver.
+
+Same queue API as :mod:`fal_video_gen_driver`.  Model strings are arbitrary
+Fal model ids (e.g. ``fal-ai/flux/dev``, ``fal-ai/stable-diffusion-v35-medium``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Any
+
+import httpx
+
+from ..infra.cost_mixin import ImageCostMixin
+from ..media.image import image_from_url
+from .async_img_gen_base import AsyncImageGenDriver
+from .fal_video_gen_driver import _QUEUE_BASE, _get_fal_api_key
+from .img_gen_base import ImageGenDriver
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MODEL = "fal-ai/flux/dev"
+
+
+def _build_img_input(prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    if prompt:
+        payload["prompt"] = prompt
+    for key in ("image_url", "image_size", "num_images", "seed", "negative_prompt"):
+        if key in options:
+            payload[key] = options[key]
+    if "image" in options and "image_url" not in options:
+        payload["image_url"] = options["image"]
+    if "size" in options and "image_size" not in options:
+        payload["image_size"] = options["size"]
+    extra = options.get("extra")
+    if isinstance(extra, dict):
+        payload.update(extra)
+    return payload
+
+
+def _extract_image_urls(result: dict[str, Any]) -> list[str]:
+    images = result.get("images")
+    if isinstance(images, list):
+        return [img["url"] for img in images if isinstance(img, dict) and img.get("url")]
+    image = result.get("image")
+    if isinstance(image, dict) and image.get("url"):
+        return [image["url"]]
+    return []
+
+
+class FalImageGenDriver(ImageCostMixin, ImageGenDriver):
+    """Image generation via Fal.ai queue API."""
+
+    supports_multiple = True
+    supports_size_variants = True
+    supported_sizes = []
+    max_images = 4
+
+    KNOWN_MODELS = [
+        "fal-ai/flux/dev",
+        "fal-ai/flux/schnell",
+        "fal-ai/stable-diffusion-v35-medium",
+        "fal-ai/stable-diffusion-v35-large",
+        "fal-ai/kling-v1-5/text-to-image",
+    ]
+
+    IMAGE_PRICING: dict[str, dict[str, float]] = {}
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = _DEFAULT_MODEL,
+        endpoint: str | None = None,
+    ):
+        self.api_key = _get_fal_api_key(api_key)
+        self.model = model
+        self.endpoint = (endpoint or os.getenv("FAL_ENDPOINT") or _QUEUE_BASE).rstrip("/")
+
+    @classmethod
+    def list_models(cls, **kw: object) -> list[str] | None:
+        return list(cls.KNOWN_MODELS)
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Key {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def generate_image(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        if not self.api_key:
+            raise RuntimeError("FAL_API_KEY is not configured")
+        model_id = options.get("model", self.model)
+        input_payload = _build_img_input(prompt, options)
+
+        with httpx.Client(timeout=120.0) as client:
+            submit = client.post(
+                f"{self.endpoint}/{model_id}", headers=self._headers(), json=input_payload
+            )
+            if submit.status_code >= 400:
+                raise RuntimeError(f"Fal submit failed {submit.status_code}: {submit.text}")
+            submitted = submit.json()
+            request_id = submitted.get("request_id")
+            if not request_id:
+                raise RuntimeError(f"Fal response missing request_id: {submitted}")
+
+            if not options.get("poll", True):
+                return {
+                    "images": [],
+                    "meta": {
+                        "image_count": 0,
+                        "size": options.get("image_size") or options.get("size"),
+                        "revised_prompt": None,
+                        "cost": 0.0,
+                        "model_name": f"fal/{model_id}",
+                        "request_id": request_id,
+                        "status": "pending",
+                        "raw_response": submitted,
+                    },
+                }
+
+            self._poll_status(
+                client,
+                model_id,
+                request_id,
+                poll_interval=float(options.get("poll_interval", 3)),
+                timeout_seconds=float(options.get("timeout", 300)),
+            )
+            result_url = f"{self.endpoint}/{model_id}/requests/{request_id}"
+            r = client.get(result_url, headers=self._headers())
+            if r.status_code >= 400:
+                raise RuntimeError(f"Fal result fetch failed: {r.text}")
+            result = r.json()
+
+        urls = _extract_image_urls(result)
+        images = [image_from_url(u) for u in urls]
+        cost = self._calculate_image_cost("fal", model_id, n=max(len(images), 1))
+        return {
+            "images": images,
+            "meta": {
+                "image_count": len(images),
+                "size": options.get("image_size") or options.get("size"),
+                "revised_prompt": None,
+                "cost": cost,
+                "model_name": f"fal/{model_id}",
+                "request_id": request_id,
+                "raw_response": result,
+            },
+        }
+
+    def _poll_status(
+        self,
+        client: httpx.Client,
+        model_id: str,
+        request_id: str,
+        *,
+        poll_interval: float,
+        timeout_seconds: float,
+    ) -> None:
+        url = f"{self.endpoint}/{model_id}/requests/{request_id}/status"
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            r = client.get(url, headers=self._headers())
+            if r.status_code >= 400:
+                raise RuntimeError(f"Fal status failed: {r.status_code} {r.text}")
+            data = r.json()
+            status = data.get("status")
+            if status == "COMPLETED":
+                return
+            if status in {"FAILED", "ERROR", "CANCELED"}:
+                raise RuntimeError(f"Fal job {request_id} {status}: {data}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Fal job {request_id} timed out (status={status})")
+            time.sleep(poll_interval)
+
+
+class AsyncFalImageGenDriver(ImageCostMixin, AsyncImageGenDriver):
+    """Async image generation via Fal.ai."""
+
+    supports_multiple = FalImageGenDriver.supports_multiple
+    supports_size_variants = FalImageGenDriver.supports_size_variants
+    supported_sizes = FalImageGenDriver.supported_sizes
+    max_images = FalImageGenDriver.max_images
+
+    KNOWN_MODELS = FalImageGenDriver.KNOWN_MODELS
+    IMAGE_PRICING = FalImageGenDriver.IMAGE_PRICING
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = _DEFAULT_MODEL,
+        endpoint: str | None = None,
+    ):
+        self.api_key = _get_fal_api_key(api_key)
+        self.model = model
+        self.endpoint = (endpoint or os.getenv("FAL_ENDPOINT") or _QUEUE_BASE).rstrip("/")
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Key {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    async def generate_image(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        if not self.api_key:
+            raise RuntimeError("FAL_API_KEY is not configured")
+        model_id = options.get("model", self.model)
+        input_payload = _build_img_input(prompt, options)
+
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            submit = await client.post(
+                f"{self.endpoint}/{model_id}", headers=self._headers(), json=input_payload
+            )
+            if submit.status_code >= 400:
+                raise RuntimeError(f"Fal submit failed {submit.status_code}: {submit.text}")
+            submitted = submit.json()
+            request_id = submitted.get("request_id")
+            if not request_id:
+                raise RuntimeError(f"Fal response missing request_id: {submitted}")
+
+            if not options.get("poll", True):
+                return {
+                    "images": [],
+                    "meta": {
+                        "image_count": 0,
+                        "size": options.get("image_size") or options.get("size"),
+                        "revised_prompt": None,
+                        "cost": 0.0,
+                        "model_name": f"fal/{model_id}",
+                        "request_id": request_id,
+                        "status": "pending",
+                        "raw_response": submitted,
+                    },
+                }
+
+            await self._poll_status(
+                client,
+                model_id,
+                request_id,
+                poll_interval=float(options.get("poll_interval", 3)),
+                timeout_seconds=float(options.get("timeout", 300)),
+            )
+            url = f"{self.endpoint}/{model_id}/requests/{request_id}"
+            r = await client.get(url, headers=self._headers())
+            if r.status_code >= 400:
+                raise RuntimeError(f"Fal result fetch failed: {r.text}")
+            result = r.json()
+
+        urls = _extract_image_urls(result)
+        images = [image_from_url(u) for u in urls]
+        cost = self._calculate_image_cost("fal", model_id, n=max(len(images), 1))
+        return {
+            "images": images,
+            "meta": {
+                "image_count": len(images),
+                "size": options.get("image_size") or options.get("size"),
+                "revised_prompt": None,
+                "cost": cost,
+                "model_name": f"fal/{model_id}",
+                "request_id": request_id,
+                "raw_response": result,
+            },
+        }
+
+    async def _poll_status(
+        self,
+        client: httpx.AsyncClient,
+        model_id: str,
+        request_id: str,
+        *,
+        poll_interval: float,
+        timeout_seconds: float,
+    ) -> None:
+        url = f"{self.endpoint}/{model_id}/requests/{request_id}/status"
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            r = await client.get(url, headers=self._headers())
+            if r.status_code >= 400:
+                raise RuntimeError(f"Fal status failed: {r.status_code} {r.text}")
+            data = r.json()
+            status = data.get("status")
+            if status == "COMPLETED":
+                return
+            if status in {"FAILED", "ERROR", "CANCELED"}:
+                raise RuntimeError(f"Fal job {request_id} {status}: {data}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Fal job {request_id} timed out (status={status})")
+            await asyncio.sleep(poll_interval)

--- a/prompture/drivers/fal_video_gen_driver.py
+++ b/prompture/drivers/fal_video_gen_driver.py
@@ -1,0 +1,336 @@
+"""Fal.ai video generation driver.
+
+Fal is a serverless inference aggregator that hosts a large catalog of
+image/video models under a uniform queue-based REST API.  This driver
+targets the public queue endpoints directly so we don't pull in the
+``fal-client`` SDK as a hard dependency:
+
+- ``POST https://queue.fal.run/{model_id}`` — submit a job, returns a request_id
+- ``GET https://queue.fal.run/{model_id}/requests/{request_id}/status`` — poll
+- ``GET https://queue.fal.run/{model_id}/requests/{request_id}`` — fetch result
+
+The Prompture ``model`` string is the Fal model id, e.g.
+``fal-ai/kling-video/v2.6/pro/image-to-video``.  Any options are forwarded to
+the model's input schema.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Any
+
+import httpx
+
+from ..infra.cost_mixin import VideoCostMixin
+from ..media.video import video_from_url
+from .async_video_gen_base import AsyncVideoGenDriver
+from .video_gen_base import VideoGenDriver
+
+logger = logging.getLogger(__name__)
+
+_QUEUE_BASE = "https://queue.fal.run"
+_DEFAULT_MODEL = "fal-ai/kling-video/v2.6/pro/image-to-video"
+
+
+def _get_fal_api_key(api_key: str | None = None) -> str | None:
+    return api_key or os.getenv("FAL_API_KEY") or os.getenv("FAL_KEY")
+
+
+def _build_video_input(prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+    """Pass-through builder. Caller is responsible for shaping options
+    to match the target Fal model's input schema."""
+    input_payload: dict[str, Any] = {}
+    if prompt:
+        input_payload["prompt"] = prompt
+    # Common Fal video keys we map from generic options.
+    if "image" in options or "image_url" in options:
+        input_payload["image_url"] = options.get("image_url") or options.get("image")
+    if "video" in options or "video_url" in options:
+        input_payload["video_url"] = options.get("video_url") or options.get("video")
+    if "duration" in options:
+        input_payload["duration"] = str(options["duration"])
+    if "negative_prompt" in options:
+        input_payload["negative_prompt"] = options["negative_prompt"]
+    if options.get("generate_audio") is not None:
+        input_payload["generate_audio"] = bool(options["generate_audio"])
+    # Allow callers to pass-through anything else via ``extra``.
+    extra = options.get("extra")
+    if isinstance(extra, dict):
+        input_payload.update(extra)
+    return input_payload
+
+
+class FalVideoGenDriver(VideoCostMixin, VideoGenDriver):
+    """Video generation via Fal.ai queue API."""
+
+    supports_image_input = True
+    supports_reference_images = True
+    supports_video_input = True
+    supports_audio = True
+    supports_polling = True
+    supported_aspect_ratios = []
+    supported_resolutions = []
+    max_seconds = None
+
+    KNOWN_MODELS = [
+        "fal-ai/kling-video/v2.6/pro/image-to-video",
+        "fal-ai/kling-video/v2.6/pro/motion-control",
+        "fal-ai/kling-video/v2/master/image-to-video",
+        "fal-ai/luma-dream-machine",
+        "fal-ai/runway-gen3/turbo/image-to-video",
+        "fal-ai/minimax-video",
+        "fal-ai/veo3",
+    ]
+
+    # Per-second placeholder pricing. Real Fal pricing varies per model
+    # (see fal.ai/pricing) — refine via the local KB.
+    VIDEO_PRICING: dict[str, dict[str, Any]] = {}
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = _DEFAULT_MODEL,
+        endpoint: str | None = None,
+    ):
+        self.api_key = _get_fal_api_key(api_key)
+        self.model = model
+        self.endpoint = (endpoint or os.getenv("FAL_ENDPOINT") or _QUEUE_BASE).rstrip("/")
+
+    @classmethod
+    def list_models(cls, **kw: object) -> list[str] | None:
+        return list(cls.KNOWN_MODELS)
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Key {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def generate_video(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        if not self.api_key:
+            raise RuntimeError("FAL_API_KEY is not configured")
+        model_id = options.get("model", self.model)
+        input_payload = _build_video_input(prompt, options)
+
+        with httpx.Client(timeout=120.0) as client:
+            submit = client.post(
+                f"{self.endpoint}/{model_id}", headers=self._headers(), json=input_payload
+            )
+            if submit.status_code >= 400:
+                raise RuntimeError(f"Fal submit failed {submit.status_code}: {submit.text}")
+            submitted = submit.json()
+            request_id = submitted.get("request_id")
+            if not request_id:
+                raise RuntimeError(f"Fal response missing request_id: {submitted}")
+
+            if not options.get("poll", True):
+                return self._pending_response(model_id, request_id, submitted)
+
+            self._poll_status(
+                client,
+                model_id,
+                request_id,
+                poll_interval=float(options.get("poll_interval", 5)),
+                timeout_seconds=float(options.get("timeout", 900)),
+            )
+            result = self._fetch_result(client, model_id, request_id)
+
+        url = self._extract_video_url(result)
+        videos = [video_from_url(url)] if url else []
+        duration = float(options.get("duration", 0) or 0)
+        cost = self._calculate_video_cost("fal", model_id, duration_seconds=duration, n=1)
+        return {
+            "videos": videos,
+            "meta": {
+                "video_count": len(videos),
+                "duration_seconds": duration or None,
+                "aspect_ratio": options.get("aspect_ratio"),
+                "resolution": options.get("resolution"),
+                "cost": cost,
+                "model_name": f"fal/{model_id}",
+                "request_id": request_id,
+                "raw_response": result,
+            },
+        }
+
+    def _poll_status(
+        self,
+        client: httpx.Client,
+        model_id: str,
+        request_id: str,
+        *,
+        poll_interval: float,
+        timeout_seconds: float,
+    ) -> None:
+        url = f"{self.endpoint}/{model_id}/requests/{request_id}/status"
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            r = client.get(url, headers=self._headers())
+            if r.status_code >= 400:
+                raise RuntimeError(f"Fal status failed: {r.status_code} {r.text}")
+            data = r.json()
+            status = data.get("status")
+            if status == "COMPLETED":
+                return
+            if status in {"FAILED", "ERROR", "CANCELED"}:
+                raise RuntimeError(f"Fal job {request_id} {status}: {data}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Fal job {request_id} timed out (status={status})")
+            time.sleep(poll_interval)
+
+    def _fetch_result(
+        self, client: httpx.Client, model_id: str, request_id: str
+    ) -> dict[str, Any]:
+        url = f"{self.endpoint}/{model_id}/requests/{request_id}"
+        r = client.get(url, headers=self._headers())
+        if r.status_code >= 400:
+            raise RuntimeError(f"Fal result fetch failed: {r.status_code} {r.text}")
+        return r.json()
+
+    @staticmethod
+    def _extract_video_url(result: dict[str, Any]) -> str | None:
+        # Fal result shapes vary: {"video": {"url": ...}}, {"videos": [{"url": ...}]}, etc.
+        video = result.get("video")
+        if isinstance(video, dict) and video.get("url"):
+            return video["url"]
+        videos = result.get("videos")
+        if isinstance(videos, list) and videos:
+            first = videos[0]
+            if isinstance(first, dict) and first.get("url"):
+                return first["url"]
+        return None
+
+    def _pending_response(
+        self, model_id: str, request_id: str, raw: dict[str, Any]
+    ) -> dict[str, Any]:
+        return {
+            "videos": [],
+            "meta": {
+                "video_count": 0,
+                "duration_seconds": None,
+                "aspect_ratio": None,
+                "resolution": None,
+                "cost": 0.0,
+                "model_name": f"fal/{model_id}",
+                "request_id": request_id,
+                "status": "pending",
+                "raw_response": raw,
+            },
+        }
+
+
+class AsyncFalVideoGenDriver(VideoCostMixin, AsyncVideoGenDriver):
+    """Async video generation via Fal.ai."""
+
+    supports_image_input = FalVideoGenDriver.supports_image_input
+    supports_reference_images = FalVideoGenDriver.supports_reference_images
+    supports_video_input = FalVideoGenDriver.supports_video_input
+    supports_audio = FalVideoGenDriver.supports_audio
+    supports_polling = FalVideoGenDriver.supports_polling
+    supported_aspect_ratios = FalVideoGenDriver.supported_aspect_ratios
+    supported_resolutions = FalVideoGenDriver.supported_resolutions
+    max_seconds = FalVideoGenDriver.max_seconds
+
+    KNOWN_MODELS = FalVideoGenDriver.KNOWN_MODELS
+    VIDEO_PRICING = FalVideoGenDriver.VIDEO_PRICING
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = _DEFAULT_MODEL,
+        endpoint: str | None = None,
+    ):
+        self.api_key = _get_fal_api_key(api_key)
+        self.model = model
+        self.endpoint = (endpoint or os.getenv("FAL_ENDPOINT") or _QUEUE_BASE).rstrip("/")
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Key {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    async def generate_video(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        if not self.api_key:
+            raise RuntimeError("FAL_API_KEY is not configured")
+        model_id = options.get("model", self.model)
+        input_payload = _build_video_input(prompt, options)
+
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            submit = await client.post(
+                f"{self.endpoint}/{model_id}", headers=self._headers(), json=input_payload
+            )
+            if submit.status_code >= 400:
+                raise RuntimeError(f"Fal submit failed {submit.status_code}: {submit.text}")
+            submitted = submit.json()
+            request_id = submitted.get("request_id")
+            if not request_id:
+                raise RuntimeError(f"Fal response missing request_id: {submitted}")
+
+            if not options.get("poll", True):
+                helper = FalVideoGenDriver(api_key=self.api_key)
+                return helper._pending_response(model_id, request_id, submitted)
+
+            await self._poll_status(
+                client,
+                model_id,
+                request_id,
+                poll_interval=float(options.get("poll_interval", 5)),
+                timeout_seconds=float(options.get("timeout", 900)),
+            )
+            result = await self._fetch_result(client, model_id, request_id)
+
+        url = FalVideoGenDriver._extract_video_url(result)
+        videos = [video_from_url(url)] if url else []
+        duration = float(options.get("duration", 0) or 0)
+        cost = self._calculate_video_cost("fal", model_id, duration_seconds=duration, n=1)
+        return {
+            "videos": videos,
+            "meta": {
+                "video_count": len(videos),
+                "duration_seconds": duration or None,
+                "aspect_ratio": options.get("aspect_ratio"),
+                "resolution": options.get("resolution"),
+                "cost": cost,
+                "model_name": f"fal/{model_id}",
+                "request_id": request_id,
+                "raw_response": result,
+            },
+        }
+
+    async def _poll_status(
+        self,
+        client: httpx.AsyncClient,
+        model_id: str,
+        request_id: str,
+        *,
+        poll_interval: float,
+        timeout_seconds: float,
+    ) -> None:
+        url = f"{self.endpoint}/{model_id}/requests/{request_id}/status"
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            r = await client.get(url, headers=self._headers())
+            if r.status_code >= 400:
+                raise RuntimeError(f"Fal status failed: {r.status_code} {r.text}")
+            data = r.json()
+            status = data.get("status")
+            if status == "COMPLETED":
+                return
+            if status in {"FAILED", "ERROR", "CANCELED"}:
+                raise RuntimeError(f"Fal job {request_id} {status}: {data}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Fal job {request_id} timed out (status={status})")
+            await asyncio.sleep(poll_interval)
+
+    async def _fetch_result(
+        self, client: httpx.AsyncClient, model_id: str, request_id: str
+    ) -> dict[str, Any]:
+        url = f"{self.endpoint}/{model_id}/requests/{request_id}"
+        r = await client.get(url, headers=self._headers())
+        if r.status_code >= 400:
+            raise RuntimeError(f"Fal result fetch failed: {r.status_code} {r.text}")
+        return r.json()

--- a/prompture/drivers/kling_img_gen_driver.py
+++ b/prompture/drivers/kling_img_gen_driver.py
@@ -1,0 +1,299 @@
+"""Kling AI image generation driver.
+
+Kling exposes a polled task-based REST API at ``api-singapore.klingai.com``.
+Authentication uses a short-lived (30-minute) HS256 JWT signed from a pair of
+access/secret keys, mirroring the official upstream pattern.
+
+This driver covers ``POST /v1/images/generations`` (text-to-image and
+single-reference image-to-image). For multi-image composition, see
+``generate_image`` with ``subject_images`` in ``options``, which routes to
+``POST /v1/images/multi-image2image``.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import os
+import re
+import time
+from typing import Any
+
+import httpx
+
+from ..infra.cost_mixin import ImageCostMixin
+from ..media.image import image_from_url
+from .img_gen_base import ImageGenDriver
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_ENDPOINT = "https://api-singapore.klingai.com"
+_DATA_URL_RE = re.compile(r"^data:[^;]+;base64,")
+
+_KLING_IMAGE_MODELS = {"kling-v1-5", "kling-v2-1", "kling-v2"}
+_KLING_RATIOS = {"1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3", "21:9"}
+_KLING_RESOLUTIONS = {"1k", "2k"}
+
+
+def _get_kling_credentials(
+    access_key: str | None = None, secret_key: str | None = None
+) -> tuple[str | None, str | None]:
+    return (
+        access_key or os.getenv("KLING_ACCESS_KEY"),
+        secret_key or os.getenv("KLING_SECRET_KEY"),
+    )
+
+
+def _b64url(payload: bytes) -> str:
+    return base64.urlsafe_b64encode(payload).rstrip(b"=").decode("ascii")
+
+
+def generate_kling_jwt(access_key: str, secret_key: str, ttl_seconds: int = 1800) -> str:
+    """Generate an HS256 JWT for the Kling API. Valid for ``ttl_seconds``."""
+    if not access_key or not secret_key:
+        raise RuntimeError("Kling API credentials not configured")
+    header = {"alg": "HS256", "typ": "JWT"}
+    now = int(time.time())
+    payload = {"iss": access_key, "exp": now + ttl_seconds, "nbf": now - 5}
+    h_enc = _b64url(json.dumps(header, separators=(",", ":")).encode())
+    p_enc = _b64url(json.dumps(payload, separators=(",", ":")).encode())
+    signing_input = f"{h_enc}.{p_enc}".encode()
+    sig = hmac.new(secret_key.encode(), signing_input, hashlib.sha256).digest()
+    return f"{h_enc}.{p_enc}.{_b64url(sig)}"
+
+
+def _strip_data_url(value: str) -> str:
+    """Strip a ``data:image/...;base64,`` prefix from a base64 string."""
+    return _DATA_URL_RE.sub("", value) if isinstance(value, str) else value
+
+
+def _normalize_image(value: Any) -> str:
+    """Normalize a base64/data-URL/http-URL image input into a Kling-acceptable form.
+
+    Kling accepts either a publicly reachable URL or a raw base64 string.
+    """
+    if not isinstance(value, str):
+        raise ValueError("image input must be a string (URL or base64)")
+    if value.startswith(("http://", "https://")):
+        return value
+    return _strip_data_url(value)
+
+
+class KlingImageGenDriver(ImageCostMixin, ImageGenDriver):
+    """Image generation via Kling AI."""
+
+    supports_multiple = False
+    supports_size_variants = True
+    supported_sizes = sorted(_KLING_RATIOS)
+    max_images = 1
+
+    KNOWN_MODELS = sorted(_KLING_IMAGE_MODELS)
+
+    # USD per image. Public Kling pricing is in credits and varies by mode;
+    # these are conservative placeholder rates — update via the local KB.
+    IMAGE_PRICING: dict[str, dict[str, float]] = {
+        "kling-v1-5": {"1k": 0.014, "2k": 0.028, "default": 0.014},
+        "kling-v2-1": {"1k": 0.028, "2k": 0.056, "default": 0.028},
+        "kling-v2": {"1k": 0.028, "2k": 0.056, "default": 0.028},
+    }
+
+    def __init__(
+        self,
+        access_key: str | None = None,
+        secret_key: str | None = None,
+        model: str = "kling-v2-1",
+        endpoint: str | None = None,
+    ):
+        ak, sk = _get_kling_credentials(access_key, secret_key)
+        self.access_key = ak
+        self.secret_key = sk
+        self.model = model
+        self.endpoint = (endpoint or os.getenv("KLING_ENDPOINT") or _DEFAULT_ENDPOINT).rstrip("/")
+
+    @classmethod
+    def list_models(cls, **kw: object) -> list[str] | None:
+        return list(cls.KNOWN_MODELS)
+
+    def _token(self) -> str:
+        if not self.access_key or not self.secret_key:
+            raise RuntimeError(
+                "KLING_ACCESS_KEY and KLING_SECRET_KEY must be configured"
+            )
+        return generate_kling_jwt(self.access_key, self.secret_key)
+
+    def _headers(self, token: str) -> dict[str, str]:
+        return {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        }
+
+    def _build_body(self, prompt: str, options: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+        """Return (path, body) for the request. Routes multi-image when ``subject_images`` is given."""
+        model = options.get("model", self.model)
+        ratio = options.get("aspect_ratio", options.get("ratio", "16:9"))
+        resolution = str(options.get("resolution", "1k")).lower()
+        if ratio not in _KLING_RATIOS:
+            raise ValueError(f"Unsupported aspect_ratio '{ratio}'")
+        if resolution not in _KLING_RESOLUTIONS:
+            raise ValueError(f"Unsupported resolution '{resolution}'")
+
+        subject_images = options.get("subject_images")
+        if subject_images:
+            return self._build_multi_image_body(
+                prompt, model, ratio, resolution, subject_images, options
+            )
+
+        body: dict[str, Any] = {
+            "model_name": model,
+            "prompt": prompt,
+            "aspect_ratio": ratio,
+            "image_size": resolution,
+            "n": int(options.get("n", 1)),
+        }
+
+        image = options.get("image")
+        if image is not None:
+            first = image[0] if isinstance(image, list) else image
+            body["image"] = _normalize_image(first)
+            if model == "kling-v1-5":
+                ref_mode = options.get("reference_mode", "subject")
+                body["image_reference"] = ref_mode
+                if ref_mode == "subject":
+                    body["face_reference_intensity"] = (
+                        float(options.get("face_intensity", 65)) / 100
+                    )
+                    body["subject_reference_intensity"] = (
+                        float(options.get("subject_intensity", 50)) / 100
+                    )
+                elif ref_mode == "face":
+                    body["face_reference_intensity"] = (
+                        float(options.get("face_intensity", 42)) / 100
+                    )
+        return "/v1/images/generations", body
+
+    def _build_multi_image_body(
+        self,
+        prompt: str,
+        model: str,
+        ratio: str,
+        resolution: str,
+        subject_images: list[Any],
+        options: dict[str, Any],
+    ) -> tuple[str, dict[str, Any]]:
+        if model not in {"kling-v2", "kling-v2-1"}:
+            model = "kling-v2-1"
+        body: dict[str, Any] = {
+            "model_name": model,
+            "prompt": prompt,
+            "aspect_ratio": ratio,
+            "image_size": resolution,
+            "n": int(options.get("n", 1)),
+            "subject_image_list": [
+                {"subject_image": _normalize_image(img)} for img in subject_images[:4]
+            ],
+        }
+        if options.get("scene_image"):
+            body["scene_image"] = _normalize_image(options["scene_image"])
+        if options.get("style_image"):
+            body["style_image"] = _normalize_image(options["style_image"])
+        return "/v1/images/multi-image2image", body
+
+    def generate_image(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        if not prompt:
+            raise ValueError("prompt cannot be empty")
+        token = self._token()
+        path, body = self._build_body(prompt, options)
+        is_multi = path.endswith("multi-image2image")
+
+        with httpx.Client(timeout=120.0) as client:
+            resp = client.post(
+                f"{self.endpoint}{path}", headers=self._headers(token), json=body
+            )
+            if resp.status_code >= 400:
+                raise RuntimeError(f"Kling API error {resp.status_code}: {resp.text}")
+            result = resp.json()
+            if result.get("code") != 0:
+                raise RuntimeError(f"Kling API error: {result.get('message')}")
+            task_id = result.get("data", {}).get("task_id")
+            if not task_id:
+                raise RuntimeError(f"Kling response missing task_id: {result}")
+
+            if not options.get("poll", True):
+                return self._pending_response(task_id, body, result)
+
+            final = self._poll_image(
+                client,
+                task_id,
+                token,
+                multi=is_multi,
+                poll_interval=float(options.get("poll_interval", 3)),
+                timeout_seconds=float(options.get("timeout", 120)),
+            )
+
+        urls = [img["url"] for img in (final.get("data", {}).get("task_result", {}).get("images") or []) if img.get("url")]
+        images = [image_from_url(u) for u in urls]
+        cost = self._calculate_image_cost(
+            "kling", body["model_name"], size=str(body["image_size"]), n=max(len(images), 1)
+        )
+        return {
+            "images": images,
+            "meta": {
+                "image_count": len(images),
+                "size": body["aspect_ratio"],
+                "revised_prompt": None,
+                "cost": cost,
+                "model_name": f"kling/{body['model_name']}",
+                "task_id": task_id,
+                "raw_response": final,
+            },
+        }
+
+    def _poll_image(
+        self,
+        client: httpx.Client,
+        task_id: str,
+        token: str,
+        *,
+        multi: bool,
+        poll_interval: float,
+        timeout_seconds: float,
+    ) -> dict[str, Any]:
+        base = "multi-image2image" if multi else "generations"
+        path = f"/v1/images/{base}/{task_id}"
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            r = client.get(f"{self.endpoint}{path}", headers=self._headers(token))
+            if r.status_code >= 400:
+                raise RuntimeError(f"Kling poll failed {r.status_code}: {r.text}")
+            data = r.json()
+            if data.get("code") != 0:
+                raise RuntimeError(f"Kling poll error: {data.get('message')}")
+            status = data.get("data", {}).get("task_status")
+            if status == "succeed":
+                return data
+            if status == "failed":
+                msg = data.get("data", {}).get("task_status_msg", "unknown")
+                raise RuntimeError(f"Kling image task failed: {msg}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Kling image task {task_id} timed out (status={status})")
+            time.sleep(poll_interval)
+
+    def _pending_response(
+        self, task_id: str, body: dict[str, Any], raw: dict[str, Any]
+    ) -> dict[str, Any]:
+        return {
+            "images": [],
+            "meta": {
+                "image_count": 0,
+                "size": body.get("aspect_ratio"),
+                "revised_prompt": None,
+                "cost": 0.0,
+                "model_name": f"kling/{body['model_name']}",
+                "task_id": task_id,
+                "status": "pending",
+                "raw_response": raw,
+            },
+        }

--- a/prompture/drivers/kling_video_gen_driver.py
+++ b/prompture/drivers/kling_video_gen_driver.py
@@ -1,0 +1,456 @@
+"""Kling AI video generation driver.
+
+Routes between the upstream image-to-video and multi-image-to-video endpoints
+based on the inputs in ``options``:
+
+- ``image_list`` (>= 2) → ``POST /v1/videos/multi-image2video``
+- ``image`` (one) or pure text → ``POST /v1/videos/image2video``
+
+For motion-control workflows (extract motion from a reference video, apply to
+a character image), pass ``character_image`` + ``motion_video`` — the driver
+runs the two-step upload + create flow against ``/v1/videos/motion``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Any
+
+import httpx
+
+from ..infra.cost_mixin import VideoCostMixin
+from ..media.video import video_from_url
+from .async_video_gen_base import AsyncVideoGenDriver
+from .kling_img_gen_driver import (
+    _DEFAULT_ENDPOINT,
+    _get_kling_credentials,
+    _normalize_image,
+    generate_kling_jwt,
+)
+from .video_gen_base import VideoGenDriver
+
+logger = logging.getLogger(__name__)
+
+_KLING_VIDEO_MODELS = {
+    "kling-v1-6",
+    "kling-v2-1",
+    "kling-v2-1-master",
+    "kling-v2-5-turbo",
+    "kling-v2-6",
+    "kling-v2-master",
+}
+_KLING_RATIOS = {"16:9", "9:16", "1:1"}
+_PRO_ONLY_MODELS = {"kling-v2-6", "kling-v2-master"}
+
+
+def _build_video_body(prompt: str, options: dict[str, Any], default_model: str) -> tuple[str, dict[str, Any]]:
+    """Return (path, body) for a Kling video request."""
+    model = options.get("model", default_model)
+    if model not in _KLING_VIDEO_MODELS:
+        logger.warning("Kling model %r not in known list", model)
+
+    duration = int(options.get("duration", options.get("seconds", 5)))
+    if duration not in (5, 10):
+        raise ValueError("Kling duration must be 5 or 10")
+
+    ratio = options.get("aspect_ratio", options.get("ratio", "16:9"))
+    if ratio not in _KLING_RATIOS:
+        raise ValueError(f"Unsupported aspect_ratio '{ratio}'")
+
+    image_list = options.get("image_list")
+    if image_list and len(image_list) > 1:
+        body = {
+            "model_name": "kling-v1-6",  # multi-image only supports v1-6 upstream
+            "mode": "std",
+            "duration": str(duration),
+            "prompt": prompt or "",
+            "aspect_ratio": ratio,
+            "image_list": [{"image": _normalize_image(i)} for i in image_list],
+        }
+        return "/v1/videos/multi-image2video", body
+
+    image = options.get("image")
+    last_frame = options.get("last_frame") or options.get("image_tail")
+    motion_video = options.get("motion_video")
+    use_pro = bool(last_frame or motion_video) or model in _PRO_ONLY_MODELS
+
+    body: dict[str, Any] = {
+        "model_name": model,
+        "mode": "pro" if use_pro else "std",
+        "duration": str(duration),
+        "aspect_ratio": ratio,
+        "prompt": prompt or "",
+    }
+    if image is not None:
+        body["image"] = _normalize_image(image)
+    if last_frame is not None:
+        body["image_tail"] = _normalize_image(last_frame)
+    if motion_video is not None:
+        body["motion_video"] = _normalize_image(motion_video)
+    return "/v1/videos/image2video", body
+
+
+class KlingVideoGenDriver(VideoCostMixin, VideoGenDriver):
+    """Video generation via Kling AI."""
+
+    supports_image_input = True
+    supports_reference_images = True
+    supports_video_input = False
+    supports_audio = False
+    supports_polling = True
+    supported_aspect_ratios = sorted(_KLING_RATIOS)
+    supported_resolutions = ["720p", "1080p"]
+    max_seconds = 10
+
+    KNOWN_MODELS = sorted(_KLING_VIDEO_MODELS)
+
+    # USD per second placeholders — tune via local KB.
+    VIDEO_PRICING: dict[str, dict[str, Any]] = {
+        "kling-v1-6": {"per_second": 0.07},
+        "kling-v2-1": {"per_second": 0.10},
+        "kling-v2-1-master": {"per_second": 0.14},
+        "kling-v2-5-turbo": {"per_second": 0.08},
+        "kling-v2-6": {"per_second": 0.14},
+        "kling-v2-master": {"per_second": 0.18},
+    }
+
+    def __init__(
+        self,
+        access_key: str | None = None,
+        secret_key: str | None = None,
+        model: str = "kling-v2-1",
+        endpoint: str | None = None,
+    ):
+        ak, sk = _get_kling_credentials(access_key, secret_key)
+        self.access_key = ak
+        self.secret_key = sk
+        self.model = model
+        self.endpoint = (endpoint or os.getenv("KLING_ENDPOINT") or _DEFAULT_ENDPOINT).rstrip("/")
+
+    @classmethod
+    def list_models(cls, **kw: object) -> list[str] | None:
+        return list(cls.KNOWN_MODELS)
+
+    def _token(self) -> str:
+        if not self.access_key or not self.secret_key:
+            raise RuntimeError("KLING_ACCESS_KEY and KLING_SECRET_KEY must be configured")
+        return generate_kling_jwt(self.access_key, self.secret_key)
+
+    def _headers(self, token: str) -> dict[str, str]:
+        return {"Content-Type": "application/json", "Authorization": f"Bearer {token}"}
+
+    def generate_video(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        token = self._token()
+
+        # Motion-control workflow has its own two-step flow.
+        if options.get("character_image") and options.get("motion_video_ref"):
+            return self._motion_control(prompt, options, token)
+
+        path, body = _build_video_body(prompt, options, self.model)
+        is_multi = path.endswith("multi-image2video")
+        poll_endpoint = "multi-image2video" if is_multi else "image2video"
+
+        with httpx.Client(timeout=120.0) as client:
+            resp = client.post(
+                f"{self.endpoint}{path}", headers=self._headers(token), json=body
+            )
+            if resp.status_code >= 400:
+                raise RuntimeError(f"Kling video API error {resp.status_code}: {resp.text}")
+            result = resp.json()
+            if result.get("code") != 0:
+                raise RuntimeError(f"Kling video API error: {result.get('message')}")
+            task_id = result.get("data", {}).get("task_id")
+            if not task_id:
+                raise RuntimeError(f"Kling video response missing task_id: {result}")
+
+            if not options.get("poll", True):
+                return self._pending_response(task_id, body, result)
+
+            final = self._poll_video(
+                client,
+                task_id,
+                token,
+                endpoint=poll_endpoint,
+                poll_interval=float(options.get("poll_interval", 5)),
+                timeout_seconds=float(options.get("timeout", 600)),
+            )
+
+        return self._success_response(final, body, options)
+
+    def _poll_video(
+        self,
+        client: httpx.Client,
+        task_id: str,
+        token: str,
+        *,
+        endpoint: str,
+        poll_interval: float,
+        timeout_seconds: float,
+    ) -> dict[str, Any]:
+        path = f"/v1/videos/{endpoint}/{task_id}"
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            r = client.get(f"{self.endpoint}{path}", headers=self._headers(token))
+            if r.status_code >= 400:
+                raise RuntimeError(f"Kling poll failed {r.status_code}: {r.text}")
+            data = r.json()
+            if data.get("code") != 0:
+                raise RuntimeError(f"Kling poll error: {data.get('message')}")
+            status = data.get("data", {}).get("task_status")
+            if status == "succeed":
+                return data
+            if status == "failed":
+                msg = data.get("data", {}).get("task_status_msg", "unknown")
+                raise RuntimeError(f"Kling video task failed: {msg}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Kling video task {task_id} timed out (status={status})")
+            time.sleep(poll_interval)
+
+    def _motion_control(self, prompt: str, options: dict[str, Any], token: str) -> dict[str, Any]:
+        """Run two-step motion-control workflow."""
+        character = _normalize_image(options["character_image"])
+        motion = _normalize_image(options["motion_video_ref"])
+        duration = int(options.get("duration", 5))
+
+        with httpx.Client(timeout=120.0) as client:
+            up = client.post(
+                f"{self.endpoint}/v1/videos/motion/upload",
+                headers=self._headers(token),
+                json={"video": motion},
+            )
+            if up.status_code >= 400:
+                raise RuntimeError(f"Kling motion upload failed {up.status_code}: {up.text}")
+            up_data = up.json()
+            if up_data.get("code") != 0:
+                raise RuntimeError(f"Kling motion upload error: {up_data.get('message')}")
+            upload_task_id = up_data.get("data", {}).get("task_id")
+
+            # Poll upload until succeeded → get work_id
+            work_id = self._poll_motion_upload(client, upload_task_id, token, options)
+
+            cr = client.post(
+                f"{self.endpoint}/v1/videos/motion",
+                headers=self._headers(token),
+                json={
+                    "work_id": work_id,
+                    "image": character,
+                    "prompt": prompt or "",
+                    "duration": str(duration),
+                    "mode": "pro",
+                },
+            )
+            if cr.status_code >= 400:
+                raise RuntimeError(f"Kling motion-create failed {cr.status_code}: {cr.text}")
+            cr_data = cr.json()
+            if cr_data.get("code") != 0:
+                raise RuntimeError(f"Kling motion-create error: {cr_data.get('message')}")
+            create_task_id = cr_data.get("data", {}).get("task_id")
+
+            final = self._poll_motion_create(client, create_task_id, token, options)
+
+        body = {"model_name": "kling-motion", "aspect_ratio": None, "duration": str(duration)}
+        return self._success_response(final, body, options, mode="motion_control")
+
+    def _poll_motion_upload(
+        self, client: httpx.Client, task_id: str, token: str, options: dict[str, Any]
+    ) -> str:
+        deadline = time.monotonic() + float(options.get("timeout", 600))
+        interval = float(options.get("poll_interval", 3))
+        while True:
+            r = client.get(
+                f"{self.endpoint}/v1/videos/motion/upload/{task_id}",
+                headers=self._headers(token),
+            )
+            if r.status_code >= 400:
+                raise RuntimeError(f"Motion upload poll failed: {r.text}")
+            d = r.json()
+            if d.get("code") != 0:
+                raise RuntimeError(f"Motion upload poll error: {d.get('message')}")
+            status = d.get("data", {}).get("task_status")
+            if status == "succeed":
+                work_id = d.get("data", {}).get("task_result", {}).get("work_id")
+                if not work_id:
+                    raise RuntimeError("Motion upload succeeded but no work_id")
+                return work_id
+            if status == "failed":
+                raise RuntimeError(f"Motion extraction failed: {d}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError("Motion extraction timed out")
+            time.sleep(interval)
+
+    def _poll_motion_create(
+        self, client: httpx.Client, task_id: str, token: str, options: dict[str, Any]
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + float(options.get("timeout", 600))
+        interval = float(options.get("poll_interval", 5))
+        while True:
+            r = client.get(
+                f"{self.endpoint}/v1/videos/motion/{task_id}", headers=self._headers(token)
+            )
+            if r.status_code >= 400:
+                raise RuntimeError(f"Motion-create poll failed: {r.text}")
+            d = r.json()
+            if d.get("code") != 0:
+                raise RuntimeError(f"Motion-create poll error: {d.get('message')}")
+            status = d.get("data", {}).get("task_status")
+            if status == "succeed":
+                return d
+            if status == "failed":
+                raise RuntimeError(f"Motion-create failed: {d}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError("Motion-create timed out")
+            time.sleep(interval)
+
+    def _pending_response(
+        self, task_id: str, body: dict[str, Any], raw: dict[str, Any]
+    ) -> dict[str, Any]:
+        return {
+            "videos": [],
+            "meta": {
+                "video_count": 0,
+                "duration_seconds": float(body.get("duration", 0) or 0),
+                "aspect_ratio": body.get("aspect_ratio"),
+                "resolution": None,
+                "cost": 0.0,
+                "model_name": f"kling/{body['model_name']}",
+                "task_id": task_id,
+                "status": "pending",
+                "raw_response": raw,
+            },
+        }
+
+    def _success_response(
+        self,
+        final: dict[str, Any],
+        body: dict[str, Any],
+        options: dict[str, Any],
+        mode: str | None = None,
+    ) -> dict[str, Any]:
+        videos = final.get("data", {}).get("task_result", {}).get("videos") or []
+        urls = [v.get("url") for v in videos if v.get("url")]
+        video_contents = [video_from_url(u) for u in urls]
+        duration = float(body.get("duration", 0) or 0)
+        cost = self._calculate_video_cost(
+            "kling",
+            body["model_name"],
+            duration_seconds=duration,
+            n=max(len(video_contents), 1),
+        )
+        return {
+            "videos": video_contents,
+            "meta": {
+                "video_count": len(video_contents),
+                "duration_seconds": duration,
+                "aspect_ratio": body.get("aspect_ratio"),
+                "resolution": None,
+                "cost": cost,
+                "model_name": f"kling/{body['model_name']}",
+                "mode": mode,
+                "task_id": final.get("data", {}).get("task_id"),
+                "raw_response": final,
+            },
+        }
+
+
+class AsyncKlingVideoGenDriver(VideoCostMixin, AsyncVideoGenDriver):
+    """Async video generation via Kling AI."""
+
+    supports_image_input = KlingVideoGenDriver.supports_image_input
+    supports_reference_images = KlingVideoGenDriver.supports_reference_images
+    supports_video_input = KlingVideoGenDriver.supports_video_input
+    supports_audio = KlingVideoGenDriver.supports_audio
+    supports_polling = KlingVideoGenDriver.supports_polling
+    supported_aspect_ratios = KlingVideoGenDriver.supported_aspect_ratios
+    supported_resolutions = KlingVideoGenDriver.supported_resolutions
+    max_seconds = KlingVideoGenDriver.max_seconds
+
+    KNOWN_MODELS = KlingVideoGenDriver.KNOWN_MODELS
+    VIDEO_PRICING = KlingVideoGenDriver.VIDEO_PRICING
+
+    def __init__(
+        self,
+        access_key: str | None = None,
+        secret_key: str | None = None,
+        model: str = "kling-v2-1",
+        endpoint: str | None = None,
+    ):
+        ak, sk = _get_kling_credentials(access_key, secret_key)
+        self.access_key = ak
+        self.secret_key = sk
+        self.model = model
+        self.endpoint = (endpoint or os.getenv("KLING_ENDPOINT") or _DEFAULT_ENDPOINT).rstrip("/")
+
+    def _token(self) -> str:
+        if not self.access_key or not self.secret_key:
+            raise RuntimeError("KLING_ACCESS_KEY and KLING_SECRET_KEY must be configured")
+        return generate_kling_jwt(self.access_key, self.secret_key)
+
+    def _headers(self, token: str) -> dict[str, str]:
+        return {"Content-Type": "application/json", "Authorization": f"Bearer {token}"}
+
+    async def generate_video(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        token = self._token()
+        path, body = _build_video_body(prompt, options, self.model)
+        poll_endpoint = "multi-image2video" if path.endswith("multi-image2video") else "image2video"
+
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            resp = await client.post(
+                f"{self.endpoint}{path}", headers=self._headers(token), json=body
+            )
+            if resp.status_code >= 400:
+                raise RuntimeError(f"Kling video API error {resp.status_code}: {resp.text}")
+            result = resp.json()
+            if result.get("code") != 0:
+                raise RuntimeError(f"Kling video API error: {result.get('message')}")
+            task_id = result.get("data", {}).get("task_id")
+            if not task_id:
+                raise RuntimeError(f"Kling video response missing task_id: {result}")
+
+            if not options.get("poll", True):
+                # mirror sync pending shape
+                helper = KlingVideoGenDriver(access_key=self.access_key, secret_key=self.secret_key)
+                return helper._pending_response(task_id, body, result)
+
+            final = await self._poll_video(
+                client,
+                task_id,
+                token,
+                endpoint=poll_endpoint,
+                poll_interval=float(options.get("poll_interval", 5)),
+                timeout_seconds=float(options.get("timeout", 600)),
+            )
+
+        helper = KlingVideoGenDriver(access_key=self.access_key, secret_key=self.secret_key)
+        return helper._success_response(final, body, options)
+
+    async def _poll_video(
+        self,
+        client: httpx.AsyncClient,
+        task_id: str,
+        token: str,
+        *,
+        endpoint: str,
+        poll_interval: float,
+        timeout_seconds: float,
+    ) -> dict[str, Any]:
+        path = f"/v1/videos/{endpoint}/{task_id}"
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            r = await client.get(f"{self.endpoint}{path}", headers=self._headers(token))
+            if r.status_code >= 400:
+                raise RuntimeError(f"Kling poll failed {r.status_code}: {r.text}")
+            data = r.json()
+            if data.get("code") != 0:
+                raise RuntimeError(f"Kling poll error: {data.get('message')}")
+            status = data.get("data", {}).get("task_status")
+            if status == "succeed":
+                return data
+            if status == "failed":
+                msg = data.get("data", {}).get("task_status_msg", "unknown")
+                raise RuntimeError(f"Kling video task failed: {msg}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Kling video task {task_id} timed out (status={status})")
+            await asyncio.sleep(poll_interval)

--- a/prompture/drivers/lmstudio_driver.py
+++ b/prompture/drivers/lmstudio_driver.py
@@ -104,7 +104,15 @@ class LMStudioDriver(Driver):
             logger.debug(f"Request payload: {payload}")
 
             r = requests.post(self.endpoint, json=payload, headers=self._headers, timeout=120)
-            r.raise_for_status()
+            if r.status_code >= 400:
+                # Surface the server's actual rejection reason — see the
+                # async driver for rationale.
+                body = (r.text or "").strip()
+                snippet = body[:500] + ("…" if len(body) > 500 else "")
+                raise RuntimeError(
+                    f"LMStudioDriver request failed: HTTP {r.status_code} "
+                    f"from {self.endpoint} — body: {snippet or '<empty>'}"
+                )
 
             response_data = r.json()
             logger.debug(f"Parsed response data: {response_data}")

--- a/prompture/drivers/minimax_driver.py
+++ b/prompture/drivers/minimax_driver.py
@@ -1,0 +1,185 @@
+"""MiniMax LLM driver (OpenAI-compatible).
+
+MiniMax exposes an OpenAI-style chat completion endpoint at
+``POST /v1/text/chatcompletion_v2``. This driver supports text generation,
+``generate_messages``, JSON mode, and tool use via the standard
+OpenAI-compatible request shape.
+
+Streaming and reasoning-content handling are intentionally omitted from the
+initial version — they can be added later if MiniMax usage in Prompture
+calls for it.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import requests
+
+from ..infra.cost_mixin import CostMixin, prepare_strict_schema
+from .base import Driver, _parse_tool_arguments
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_ENDPOINT = "https://api.minimax.io/v1"
+
+
+class MiniMaxDriver(CostMixin, Driver):
+    supports_json_mode = True
+    supports_json_schema = True
+    supports_tool_use = True
+    supports_streaming = False
+    supports_vision = False
+    supports_messages = True
+
+    MODEL_PRICING: dict[str, dict[str, Any]] = {}
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = "MiniMax-Text-01",
+        endpoint: str | None = None,
+    ):
+        self.api_key = api_key or os.getenv("MINIMAX_API_KEY") or os.getenv("HAILUO_API_KEY")
+        if not self.api_key:
+            raise ValueError("MiniMax API key not found. Set MINIMAX_API_KEY env var.")
+        self.model = model
+        self.base_url = (endpoint or os.getenv("MINIMAX_ENDPOINT") or _DEFAULT_ENDPOINT).rstrip("/")
+        self.headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        return self._do_generate([{"role": "user", "content": prompt}], options)
+
+    def generate_messages(self, messages: list[dict[str, str]], options: dict[str, Any]) -> dict[str, Any]:
+        return self._do_generate(list(messages), options)
+
+    def _do_generate(self, messages: list[dict[str, Any]], options: dict[str, Any]) -> dict[str, Any]:
+        model = options.get("model", self.model)
+        opts = {"temperature": 1.0, "max_tokens": 1024, **options}
+
+        data: dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "max_tokens": opts["max_tokens"],
+            "temperature": opts["temperature"],
+        }
+
+        if options.get("json_mode"):
+            json_schema = options.get("json_schema")
+            if json_schema:
+                data["response_format"] = {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "extraction",
+                        "strict": True,
+                        "schema": prepare_strict_schema(json_schema),
+                    },
+                }
+            else:
+                data["response_format"] = {"type": "json_object"}
+
+        try:
+            response = requests.post(
+                f"{self.base_url}/text/chatcompletion_v2",
+                headers=self.headers,
+                json=data,
+                timeout=opts.get("timeout", 300),  # nosec B113
+            )
+            response.raise_for_status()
+            resp = response.json()
+        except requests.exceptions.RequestException as e:
+            raise RuntimeError(f"MiniMax API request failed: {e!s}") from e
+
+        base_resp = resp.get("base_resp")
+        if isinstance(base_resp, dict) and base_resp.get("status_code", 0) != 0:
+            raise RuntimeError(f"MiniMax API error: {base_resp.get('status_msg')}")
+
+        usage = resp.get("usage", {})
+        prompt_tokens = usage.get("prompt_tokens") or usage.get("total_input_tokens", 0) or 0
+        completion_tokens = usage.get("completion_tokens") or usage.get("total_output_tokens", 0) or 0
+        total_tokens = usage.get("total_tokens", prompt_tokens + completion_tokens)
+        total_cost = self._calculate_cost("minimax", model, prompt_tokens, completion_tokens)
+
+        choices = resp.get("choices") or []
+        text = ""
+        if choices:
+            msg = choices[0].get("message") or {}
+            text = msg.get("content") or ""
+
+        return {
+            "text": text,
+            "meta": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": total_tokens,
+                "cost": round(total_cost, 6),
+                "raw_response": resp,
+                "model_name": model,
+            },
+        }
+
+    def generate_messages_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> dict[str, Any]:
+        model = options.get("model", self.model)
+        opts = {"temperature": 1.0, "max_tokens": 4096, **options}
+        data: dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "tools": tools,
+            "max_tokens": opts["max_tokens"],
+            "temperature": opts["temperature"],
+        }
+        if "tool_choice" in options:
+            data["tool_choice"] = options["tool_choice"]
+
+        try:
+            response = requests.post(
+                f"{self.base_url}/text/chatcompletion_v2",
+                headers=self.headers,
+                json=data,
+                timeout=opts.get("timeout", 300),  # nosec B113
+            )
+            response.raise_for_status()
+            resp = response.json()
+        except requests.exceptions.RequestException as e:
+            raise RuntimeError(f"MiniMax API request failed: {e!s}") from e
+
+        usage = resp.get("usage", {})
+        prompt_tokens = usage.get("prompt_tokens", 0) or 0
+        completion_tokens = usage.get("completion_tokens", 0) or 0
+        total_tokens = usage.get("total_tokens", prompt_tokens + completion_tokens)
+        total_cost = self._calculate_cost("minimax", model, prompt_tokens, completion_tokens)
+
+        choice = (resp.get("choices") or [{}])[0]
+        message = choice.get("message") or {}
+        text = message.get("content") or ""
+        stop_reason = choice.get("finish_reason")
+
+        tool_calls_out: list[dict[str, Any]] = []
+        for tc in message.get("tool_calls") or []:
+            fn = tc.get("function") or {}
+            args = _parse_tool_arguments(fn.get("arguments"), fn.get("name", ""), stop_reason)
+            tool_calls_out.append({"id": tc.get("id"), "name": fn.get("name"), "arguments": args})
+
+        return {
+            "text": text,
+            "meta": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": total_tokens,
+                "cost": round(total_cost, 6),
+                "raw_response": resp,
+                "model_name": model,
+            },
+            "tool_calls": tool_calls_out,
+            "stop_reason": stop_reason,
+        }

--- a/prompture/drivers/minimax_video_gen_driver.py
+++ b/prompture/drivers/minimax_video_gen_driver.py
@@ -1,0 +1,386 @@
+"""MiniMax (Hailuo) AI video generation driver.
+
+Wraps the four ``POST /v1/video_generation`` modes exposed by MiniMax:
+
+- **T2V** — Text-to-Video (default)
+- **I2V** — Image-to-Video (first frame supplied)
+- **FL2V** — First-and-Last-Frame Video (first + last frame; forces ``MiniMax-Hailuo-02``)
+- **S2V** — Subject-Reference Video (uses ``S2V-01`` with a character reference image)
+
+The endpoint returns a ``task_id``; the driver then polls
+``GET /v1/query/video_generation`` and resolves the resulting ``file_id`` to
+a download URL via ``GET /v1/files/retrieve``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Any
+
+import httpx
+
+from ..infra.cost_mixin import VideoCostMixin
+from ..media.video import video_from_url
+from .async_video_gen_base import AsyncVideoGenDriver
+from .video_gen_base import VideoGenDriver
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_ENDPOINT = "https://api.minimax.io/v1"
+
+_KNOWN_MODELS = {
+    "MiniMax-Hailuo-2.3",
+    "MiniMax-Hailuo-2.3-Fast",
+    "MiniMax-Hailuo-02",
+    "S2V-01",
+}
+_RESOLUTIONS = {"768P", "1080P"}
+
+
+def _get_minimax_api_key(api_key: str | None = None) -> str | None:
+    return api_key or os.getenv("MINIMAX_API_KEY") or os.getenv("HAILUO_API_KEY")
+
+
+def _normalize_image(value: str, mime: str = "image/jpeg") -> str:
+    """Return either an http(s) URL or a base64 data URL."""
+    if value.startswith(("http://", "https://", "data:")):
+        return value
+    return f"data:{mime};base64,{value}"
+
+
+def _duration(options: dict[str, Any]) -> int:
+    """MiniMax supports only 6 and 10 second outputs."""
+    raw = int(options.get("duration", options.get("seconds", 6)))
+    return 10 if raw > 8 else 6
+
+
+def _resolution(options: dict[str, Any]) -> str:
+    r = str(options.get("resolution", "768P")).upper()
+    return r if r in _RESOLUTIONS else "768P"
+
+
+def _select_model(model: str, has_first: bool, has_last: bool) -> str:
+    # FL2V requires Hailuo-02
+    if has_first and has_last:
+        return "MiniMax-Hailuo-02"
+    return model
+
+
+def _build_body(prompt: str, options: dict[str, Any], default_model: str) -> dict[str, Any]:
+    image = options.get("image")
+    last_frame = options.get("last_frame")
+    subject_image = options.get("subject_image")
+
+    if subject_image:
+        # S2V mode
+        return {
+            "model": "S2V-01",
+            "prompt": prompt or "",
+            "subject_reference": [
+                {"type": "character", "image": [_normalize_image(subject_image)]}
+            ],
+        }
+
+    model = _select_model(options.get("model", default_model), bool(image), bool(last_frame))
+
+    body: dict[str, Any] = {
+        "model": model,
+        "prompt": prompt or "",
+        "duration": _duration(options),
+        "resolution": _resolution(options),
+        "aspect_ratio": options.get("aspect_ratio", "16:9"),
+    }
+    if image:
+        body["first_frame_image"] = _normalize_image(image)
+    if last_frame:
+        body["last_frame_image"] = _normalize_image(last_frame)
+    return body
+
+
+def _check_base_resp(payload: dict[str, Any]) -> None:
+    base = payload.get("base_resp")
+    if isinstance(base, dict) and base.get("status_code", 0) != 0:
+        raise RuntimeError(f"MiniMax API error: {base.get('status_msg')}")
+
+
+class MiniMaxVideoGenDriver(VideoCostMixin, VideoGenDriver):
+    """Video generation via MiniMax / Hailuo."""
+
+    supports_image_input = True
+    supports_reference_images = True
+    supports_video_input = False
+    supports_audio = False
+    supports_polling = True
+    supported_aspect_ratios = ["16:9", "9:16"]
+    supported_resolutions = ["768P", "1080P"]
+    max_seconds = 10
+
+    KNOWN_MODELS = sorted(_KNOWN_MODELS)
+
+    # USD per second placeholders — refine via local KB.
+    VIDEO_PRICING: dict[str, dict[str, Any]] = {
+        "MiniMax-Hailuo-2.3": {"per_second": 0.07},
+        "MiniMax-Hailuo-2.3-Fast": {"per_second": 0.04},
+        "MiniMax-Hailuo-02": {"per_second": 0.09},
+        "S2V-01": {"per_second": 0.08},
+    }
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = "MiniMax-Hailuo-2.3",
+        endpoint: str | None = None,
+    ):
+        self.api_key = _get_minimax_api_key(api_key)
+        self.model = model
+        self.endpoint = (endpoint or os.getenv("MINIMAX_ENDPOINT") or _DEFAULT_ENDPOINT).rstrip("/")
+
+    @classmethod
+    def list_models(cls, **kw: object) -> list[str] | None:
+        return list(cls.KNOWN_MODELS)
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def generate_video(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        if not self.api_key:
+            raise RuntimeError("MINIMAX_API_KEY is not configured")
+        body = _build_body(prompt, options, self.model)
+
+        with httpx.Client(timeout=120.0) as client:
+            resp = client.post(
+                f"{self.endpoint}/video_generation", headers=self._headers(), json=body
+            )
+            if resp.status_code >= 400:
+                raise RuntimeError(f"MiniMax API error {resp.status_code}: {resp.text}")
+            result = resp.json()
+            _check_base_resp(result)
+            task_id = result.get("task_id")
+            if not task_id:
+                raise RuntimeError(f"MiniMax response missing task_id: {result}")
+
+            if not options.get("poll", True):
+                return self._pending_response(task_id, body, result)
+
+            file_id, status_data = self._poll_task(
+                client,
+                task_id,
+                poll_interval=float(options.get("poll_interval", 5)),
+                timeout_seconds=float(options.get("timeout", 600)),
+            )
+            video_url = self._resolve_file(client, file_id)
+
+        video = video_from_url(video_url)
+        duration = float(body.get("duration", 0))
+        cost = self._calculate_video_cost(
+            "minimax", body["model"], duration_seconds=duration, n=1
+        )
+        return {
+            "videos": [video],
+            "meta": {
+                "video_count": 1,
+                "duration_seconds": duration,
+                "aspect_ratio": body.get("aspect_ratio"),
+                "resolution": body.get("resolution"),
+                "cost": cost,
+                "model_name": f"minimax/{body['model']}",
+                "task_id": task_id,
+                "raw_response": {"task": status_data, "url": video_url},
+            },
+        }
+
+    def _poll_task(
+        self,
+        client: httpx.Client,
+        task_id: str,
+        *,
+        poll_interval: float,
+        timeout_seconds: float,
+    ) -> tuple[str, dict[str, Any]]:
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            r = client.get(
+                f"{self.endpoint}/query/video_generation",
+                params={"task_id": task_id},
+                headers=self._headers(),
+            )
+            if r.status_code >= 400:
+                raise RuntimeError(f"MiniMax poll failed {r.status_code}: {r.text}")
+            data = r.json()
+            _check_base_resp(data)
+            status = data.get("status")
+            if status == "Success":
+                file_id = data.get("file_id")
+                if not file_id:
+                    raise RuntimeError("MiniMax success but no file_id")
+                return file_id, data
+            if status == "Fail":
+                raise RuntimeError(f"MiniMax generation failed: {data}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"MiniMax task {task_id} timed out (status={status})")
+            time.sleep(poll_interval)
+
+    def _resolve_file(self, client: httpx.Client, file_id: str) -> str:
+        r = client.get(
+            f"{self.endpoint}/files/retrieve",
+            params={"file_id": file_id},
+            headers=self._headers(),
+        )
+        if r.status_code >= 400:
+            raise RuntimeError(f"MiniMax file retrieve failed: {r.text}")
+        data = r.json()
+        _check_base_resp(data)
+        url = (data.get("file") or {}).get("download_url")
+        if not url:
+            raise RuntimeError(f"MiniMax file response missing download_url: {data}")
+        return url
+
+    def _pending_response(
+        self, task_id: str, body: dict[str, Any], raw: dict[str, Any]
+    ) -> dict[str, Any]:
+        return {
+            "videos": [],
+            "meta": {
+                "video_count": 0,
+                "duration_seconds": float(body.get("duration", 0) or 0),
+                "aspect_ratio": body.get("aspect_ratio"),
+                "resolution": body.get("resolution"),
+                "cost": 0.0,
+                "model_name": f"minimax/{body['model']}",
+                "task_id": task_id,
+                "status": "pending",
+                "raw_response": raw,
+            },
+        }
+
+
+class AsyncMiniMaxVideoGenDriver(VideoCostMixin, AsyncVideoGenDriver):
+    """Async video generation via MiniMax / Hailuo."""
+
+    supports_image_input = MiniMaxVideoGenDriver.supports_image_input
+    supports_reference_images = MiniMaxVideoGenDriver.supports_reference_images
+    supports_video_input = MiniMaxVideoGenDriver.supports_video_input
+    supports_audio = MiniMaxVideoGenDriver.supports_audio
+    supports_polling = MiniMaxVideoGenDriver.supports_polling
+    supported_aspect_ratios = MiniMaxVideoGenDriver.supported_aspect_ratios
+    supported_resolutions = MiniMaxVideoGenDriver.supported_resolutions
+    max_seconds = MiniMaxVideoGenDriver.max_seconds
+
+    KNOWN_MODELS = MiniMaxVideoGenDriver.KNOWN_MODELS
+    VIDEO_PRICING = MiniMaxVideoGenDriver.VIDEO_PRICING
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = "MiniMax-Hailuo-2.3",
+        endpoint: str | None = None,
+    ):
+        self.api_key = _get_minimax_api_key(api_key)
+        self.model = model
+        self.endpoint = (endpoint or os.getenv("MINIMAX_ENDPOINT") or _DEFAULT_ENDPOINT).rstrip("/")
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    async def generate_video(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        if not self.api_key:
+            raise RuntimeError("MINIMAX_API_KEY is not configured")
+        body = _build_body(prompt, options, self.model)
+
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            resp = await client.post(
+                f"{self.endpoint}/video_generation", headers=self._headers(), json=body
+            )
+            if resp.status_code >= 400:
+                raise RuntimeError(f"MiniMax API error {resp.status_code}: {resp.text}")
+            result = resp.json()
+            _check_base_resp(result)
+            task_id = result.get("task_id")
+            if not task_id:
+                raise RuntimeError(f"MiniMax response missing task_id: {result}")
+
+            if not options.get("poll", True):
+                helper = MiniMaxVideoGenDriver(api_key=self.api_key)
+                return helper._pending_response(task_id, body, result)
+
+            file_id, status_data = await self._poll_task(
+                client,
+                task_id,
+                poll_interval=float(options.get("poll_interval", 5)),
+                timeout_seconds=float(options.get("timeout", 600)),
+            )
+            video_url = await self._resolve_file(client, file_id)
+
+        video = video_from_url(video_url)
+        duration = float(body.get("duration", 0))
+        cost = self._calculate_video_cost(
+            "minimax", body["model"], duration_seconds=duration, n=1
+        )
+        return {
+            "videos": [video],
+            "meta": {
+                "video_count": 1,
+                "duration_seconds": duration,
+                "aspect_ratio": body.get("aspect_ratio"),
+                "resolution": body.get("resolution"),
+                "cost": cost,
+                "model_name": f"minimax/{body['model']}",
+                "task_id": task_id,
+                "raw_response": {"task": status_data, "url": video_url},
+            },
+        }
+
+    async def _poll_task(
+        self,
+        client: httpx.AsyncClient,
+        task_id: str,
+        *,
+        poll_interval: float,
+        timeout_seconds: float,
+    ) -> tuple[str, dict[str, Any]]:
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            r = await client.get(
+                f"{self.endpoint}/query/video_generation",
+                params={"task_id": task_id},
+                headers=self._headers(),
+            )
+            if r.status_code >= 400:
+                raise RuntimeError(f"MiniMax poll failed {r.status_code}: {r.text}")
+            data = r.json()
+            _check_base_resp(data)
+            status = data.get("status")
+            if status == "Success":
+                file_id = data.get("file_id")
+                if not file_id:
+                    raise RuntimeError("MiniMax success but no file_id")
+                return file_id, data
+            if status == "Fail":
+                raise RuntimeError(f"MiniMax generation failed: {data}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"MiniMax task {task_id} timed out (status={status})")
+            await asyncio.sleep(poll_interval)
+
+    async def _resolve_file(self, client: httpx.AsyncClient, file_id: str) -> str:
+        r = await client.get(
+            f"{self.endpoint}/files/retrieve",
+            params={"file_id": file_id},
+            headers=self._headers(),
+        )
+        if r.status_code >= 400:
+            raise RuntimeError(f"MiniMax file retrieve failed: {r.text}")
+        data = r.json()
+        _check_base_resp(data)
+        url = (data.get("file") or {}).get("download_url")
+        if not url:
+            raise RuntimeError(f"MiniMax file response missing download_url: {data}")
+        return url

--- a/prompture/drivers/provider_descriptors.py
+++ b/prompture/drivers/provider_descriptors.py
@@ -522,7 +522,7 @@ def _build_descriptors() -> list[ProviderDescriptor]:
     # ── Kling AI (image + video) ─────────────────────────────────────
     _kling_kw = {
         "access_key": "kling_access_key",
-        "secret_key": "kling_secret_key",
+        "secret_key": "kling_secret_key",  # nosec B105 — settings attribute name, not a credential
         "endpoint": "kling_endpoint",
     }
     descriptors.append(

--- a/prompture/drivers/provider_descriptors.py
+++ b/prompture/drivers/provider_descriptors.py
@@ -519,6 +519,86 @@ def _build_descriptors() -> list[ProviderDescriptor]:
         )
     )
 
+    # ── Kling AI (image + video) ─────────────────────────────────────
+    _kling_kw = {
+        "access_key": "kling_access_key",
+        "secret_key": "kling_secret_key",
+        "endpoint": "kling_endpoint",
+    }
+    descriptors.append(
+        ProviderDescriptor(
+            name="kling",
+            img_gen_sync=DriverSpec(
+                "kling_img_gen_driver.KlingImageGenDriver", _kling_kw, "kling_image_model"
+            ),
+            img_gen_async=DriverSpec(
+                "async_kling_img_gen_driver.AsyncKlingImageGenDriver",
+                _kling_kw,
+                "kling_image_model",
+            ),
+            video_gen_sync=DriverSpec(
+                "kling_video_gen_driver.KlingVideoGenDriver", _kling_kw, "kling_video_model"
+            ),
+            video_gen_async=DriverSpec(
+                "async_kling_video_gen_driver.AsyncKlingVideoGenDriver",
+                _kling_kw,
+                "kling_video_model",
+            ),
+            display_name="Kling AI",
+            is_configured_check="kling_access_key",
+        )
+    )
+
+    # ── MiniMax / Hailuo (LLM + video) ───────────────────────────────
+    _mm_kw = {"api_key": "minimax_api_key", "endpoint": "minimax_endpoint"}
+    descriptors.append(
+        ProviderDescriptor(
+            name="minimax",
+            **_llm(
+                "minimax_driver",
+                "MiniMaxDriver",
+                "async_minimax_driver",
+                "AsyncMiniMaxDriver",
+                _mm_kw,
+                "minimax_model",
+            ),
+            video_gen_sync=DriverSpec(
+                "minimax_video_gen_driver.MiniMaxVideoGenDriver", _mm_kw, "minimax_video_model"
+            ),
+            video_gen_async=DriverSpec(
+                "async_minimax_video_gen_driver.AsyncMiniMaxVideoGenDriver",
+                _mm_kw,
+                "minimax_video_model",
+            ),
+            display_name="MiniMax",
+            is_configured_check="minimax_api_key",
+            list_models_kwargs=[("api_key", "minimax_api_key", "MINIMAX_API_KEY")],
+            models_dev_name="minimax",
+        )
+    )
+
+    # ── Fal.ai (image + video aggregator) ────────────────────────────
+    _fal_kw = {"api_key": "fal_api_key", "endpoint": "fal_endpoint"}
+    descriptors.append(
+        ProviderDescriptor(
+            name="fal",
+            img_gen_sync=DriverSpec(
+                "fal_img_gen_driver.FalImageGenDriver", _fal_kw, "fal_image_model"
+            ),
+            img_gen_async=DriverSpec(
+                "async_fal_img_gen_driver.AsyncFalImageGenDriver", _fal_kw, "fal_image_model"
+            ),
+            video_gen_sync=DriverSpec(
+                "fal_video_gen_driver.FalVideoGenDriver", _fal_kw, "fal_video_model"
+            ),
+            video_gen_async=DriverSpec(
+                "async_fal_video_gen_driver.AsyncFalVideoGenDriver", _fal_kw, "fal_video_model"
+            ),
+            display_name="Fal.ai",
+            is_configured_check="fal_api_key",
+        )
+    )
+
     # ── Aliases ───────────────────────────────────────────────────────
     # Each alias specifies exactly which modalities it covers, matching
     # the original per-file registrations.  Format:
@@ -537,6 +617,7 @@ def _build_descriptors() -> list[ProviderDescriptor]:
         ("runwayml", "runway", {"img_gen", "video_gen", "tts"}),
         ("vertex", "google_vertexai", {"llm"}),
         ("vertexai", "google_vertexai", {"llm"}),
+        ("hailuo", "minimax", {"video_gen"}),
     ]
 
     # Build a lookup of canonical descriptors by name.

--- a/prompture/infra/cost_mixin.py
+++ b/prompture/infra/cost_mixin.py
@@ -33,8 +33,14 @@ def _patch_strict(node: dict[str, Any]) -> None:
     if not isinstance(node, dict):
         return
     if node.get("type") == "object" and "properties" in node:
-        node.setdefault("additionalProperties", False)
-        node.setdefault("required", list(node["properties"].keys()))
+        node["additionalProperties"] = False
+        # Strict mode requires `required` to list *every* property — not
+        # just the ones Pydantic considers required (i.e. those without a
+        # default). Overwrite rather than setdefault so a partial Pydantic-
+        # generated list doesn't slip through and get rejected with
+        # "'required' is required to be supplied and to be an array
+        # including every key in properties".
+        node["required"] = list(node["properties"].keys())
         for prop in node["properties"].values():
             _patch_strict(prop)
     if node.get("type") == "array" and isinstance(node.get("items"), dict):

--- a/prompture/infra/cost_mixin.py
+++ b/prompture/infra/cost_mixin.py
@@ -29,8 +29,20 @@ def _patch_strict(node: dict[str, Any]) -> None:
     those nested objects keep their default open-properties semantics
     and OpenAI's strict mode rejects the whole request with
     ``'additionalProperties' is required to be supplied and to be false``.
+
+    Also strips sibling keywords from ``$ref`` nodes — Pydantic emits
+    things like ``{"$ref": "#/$defs/Foo", "description": "..."}`` for
+    referenced sub-models, and OpenAI strict mode rejects with
+    ``$ref cannot have keywords {'description'}``. Older JSON Schema
+    drafts ignored siblings of ``$ref``, so dropping them is lossless
+    for our purposes.
     """
     if not isinstance(node, dict):
+        return
+    if "$ref" in node and len(node) > 1:
+        ref_value = node["$ref"]
+        node.clear()
+        node["$ref"] = ref_value
         return
     if node.get("type") == "object" and "properties" in node:
         node["additionalProperties"] = False

--- a/prompture/infra/cost_mixin.py
+++ b/prompture/infra/cost_mixin.py
@@ -20,14 +20,35 @@ def prepare_strict_schema(schema: dict[str, Any]) -> dict[str, Any]:
 
 
 def _patch_strict(node: dict[str, Any]) -> None:
-    """Recursively add strict-mode constraints to an object schema node."""
+    """Recursively add strict-mode constraints to an object schema node.
+
+    Walks ``properties``, ``items``, composite keywords (``anyOf`` /
+    ``oneOf`` / ``allOf``), and Pydantic's ``$defs`` registry — the last
+    matters because Pydantic v2 puts nested ``BaseModel`` schemas there
+    and references them via ``$ref``; without descending into ``$defs``
+    those nested objects keep their default open-properties semantics
+    and OpenAI's strict mode rejects the whole request with
+    ``'additionalProperties' is required to be supplied and to be false``.
+    """
+    if not isinstance(node, dict):
+        return
     if node.get("type") == "object" and "properties" in node:
         node.setdefault("additionalProperties", False)
         node.setdefault("required", list(node["properties"].keys()))
         for prop in node["properties"].values():
             _patch_strict(prop)
-    elif node.get("type") == "array" and isinstance(node.get("items"), dict):
+    if node.get("type") == "array" and isinstance(node.get("items"), dict):
         _patch_strict(node["items"])
+    for keyword in ("anyOf", "oneOf", "allOf"):
+        for sub in node.get(keyword, []) or []:
+            _patch_strict(sub)
+    # Pydantic v2 nested model definitions live here. They're referenced
+    # via $ref from properties but never reached by walking properties
+    # alone — recurse explicitly.
+    for sub in (node.get("$defs") or {}).values():
+        _patch_strict(sub)
+    for sub in (node.get("definitions") or {}).values():
+        _patch_strict(sub)
 
 
 class CostMixin:
@@ -107,7 +128,7 @@ class CostMixin:
 
         caps = get_model_capabilities(provider, model)
 
-        tokens_param = "max_tokens"
+        tokens_param = _default_tokens_param(provider, model)
         supports_temperature = True
         context_window: int | None = None
         max_output_tokens: int | None = None
@@ -126,6 +147,29 @@ class CostMixin:
             "context_window": context_window,
             "max_output_tokens": max_output_tokens,
         }
+
+
+def _default_tokens_param(provider: str, model: str) -> str:
+    """Pick the per-call output-tokens parameter when the capabilities KB
+    has no entry for ``model``.
+
+    OpenAI's GPT-5 family and the o-series reasoning models (o1, o3, o4)
+    only accept ``max_completion_tokens`` — sending ``max_tokens`` 400s
+    with ``Unsupported parameter``. We name-detect those so brand-new
+    model IDs (e.g. ``gpt-5.4-mini``) work without waiting for a KB
+    update. Everything else stays on the legacy ``max_tokens`` default.
+    """
+    if provider != "openai":
+        return "max_tokens"
+    name = (model or "").split("/")[-1].lower()
+    if (
+        name.startswith("gpt-5")
+        or name.startswith("o1")
+        or name.startswith("o3")
+        or name.startswith("o4")
+    ):
+        return "max_completion_tokens"
+    return "max_tokens"
 
 
 class AudioCostMixin:

--- a/prompture/infra/settings.py
+++ b/prompture/infra/settings.py
@@ -101,6 +101,26 @@ class Settings(BaseSettings):
     runway_api_key: Optional[str] = None
     runway_endpoint: Optional[str] = None
 
+    # Kling AI (image + video generation)
+    kling_access_key: Optional[str] = None
+    kling_secret_key: Optional[str] = None
+    kling_endpoint: Optional[str] = None
+    kling_image_model: str = "kling-v2-1"
+    kling_video_model: str = "kling-v2-1"
+
+    # MiniMax / Hailuo (LLM + video generation)
+    minimax_api_key: Optional[str] = None
+    hailuo_api_key: Optional[str] = None
+    minimax_endpoint: str = "https://api.minimax.io/v1"
+    minimax_model: str = "MiniMax-Text-01"
+    minimax_video_model: str = "MiniMax-Hailuo-2.3"
+
+    # Fal.ai (image + video generation aggregator)
+    fal_api_key: Optional[str] = None
+    fal_endpoint: Optional[str] = None
+    fal_image_model: str = "fal-ai/flux/dev"
+    fal_video_model: str = "fal-ai/kling-video/v2.6/pro/image-to-video"
+
     # ElevenLabs (audio)
     elevenlabs_api_key: Optional[str] = None
     elevenlabs_tts_model: str = "eleven_multilingual_v2"

--- a/tests/test_new_providers.py
+++ b/tests/test_new_providers.py
@@ -1,0 +1,318 @@
+"""Unit tests for Kling, MiniMax/Hailuo, and Fal.ai drivers.
+
+These verify driver construction, header/auth shape, body builders, and
+response parsing — all without making live network calls. Integration tests
+against the real APIs would require credentials and are not included.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from prompture.drivers.fal_img_gen_driver import (
+    AsyncFalImageGenDriver,
+    FalImageGenDriver,
+    _build_img_input,
+    _extract_image_urls,
+)
+from prompture.drivers.fal_video_gen_driver import (
+    AsyncFalVideoGenDriver,
+    FalVideoGenDriver,
+    _build_video_input,
+)
+from prompture.drivers.async_kling_img_gen_driver import AsyncKlingImageGenDriver
+from prompture.drivers.kling_img_gen_driver import (
+    KlingImageGenDriver,
+    generate_kling_jwt,
+)
+from prompture.drivers.kling_video_gen_driver import (
+    AsyncKlingVideoGenDriver,
+    KlingVideoGenDriver,
+    _build_video_body,
+)
+from prompture.drivers.minimax_driver import MiniMaxDriver
+from prompture.drivers.minimax_video_gen_driver import (
+    AsyncMiniMaxVideoGenDriver,
+    MiniMaxVideoGenDriver,
+    _build_body,
+    _duration,
+    _resolution,
+    _select_model,
+)
+
+
+# ───────────────────────── Kling ────────────────────────────
+
+
+class TestKlingJWT:
+    def test_jwt_three_segments(self):
+        token = generate_kling_jwt("ak", "sk", ttl_seconds=60)
+        assert token.count(".") == 2
+        h, p, s = token.split(".")
+        assert all(part for part in (h, p, s))
+
+    def test_jwt_requires_credentials(self):
+        with pytest.raises(RuntimeError):
+            generate_kling_jwt("", "sk")
+
+
+class TestKlingImageGen:
+    def test_construct(self):
+        d = KlingImageGenDriver(access_key="ak", secret_key="sk")
+        assert d.access_key == "ak"
+        assert d.model == "kling-v2-1"
+        assert d.endpoint.startswith("https://api-singapore.klingai.com")
+
+    def test_build_body_text_to_image(self):
+        d = KlingImageGenDriver(access_key="ak", secret_key="sk")
+        path, body = d._build_body("a cat", {"aspect_ratio": "16:9", "resolution": "1k"})
+        assert path == "/v1/images/generations"
+        assert body["model_name"] == "kling-v2-1"
+        assert body["prompt"] == "a cat"
+        assert body["aspect_ratio"] == "16:9"
+        assert body["image_size"] == "1k"
+
+    def test_build_body_v1_5_subject_mode(self):
+        d = KlingImageGenDriver(access_key="ak", secret_key="sk", model="kling-v1-5")
+        path, body = d._build_body(
+            "a cat",
+            {"image": "https://example.com/x.png", "reference_mode": "subject"},
+        )
+        assert body["image"] == "https://example.com/x.png"
+        assert body["image_reference"] == "subject"
+        assert 0 < body["face_reference_intensity"] <= 1
+        assert 0 < body["subject_reference_intensity"] <= 1
+
+    def test_build_body_multi_image(self):
+        d = KlingImageGenDriver(access_key="ak", secret_key="sk")
+        path, body = d._build_body(
+            "compose",
+            {"subject_images": ["data:image/png;base64,AAAA", "https://x/y.jpg"]},
+        )
+        assert path == "/v1/images/multi-image2image"
+        assert len(body["subject_image_list"]) == 2
+        # data URL prefix should be stripped
+        assert body["subject_image_list"][0]["subject_image"] == "AAAA"
+
+    def test_invalid_aspect_ratio(self):
+        d = KlingImageGenDriver(access_key="ak", secret_key="sk")
+        with pytest.raises(ValueError):
+            d._build_body("x", {"aspect_ratio": "999:1"})
+
+    def test_missing_creds_raises_on_call(self):
+        d = KlingImageGenDriver(access_key=None, secret_key=None)
+        with pytest.raises(RuntimeError, match="KLING_ACCESS_KEY"):
+            d.generate_image("hello", {})
+
+
+class TestKlingVideoGen:
+    def test_build_image_to_video(self):
+        path, body = _build_video_body(
+            "wave", {"image": "https://x/y.png", "duration": 5}, "kling-v2-1"
+        )
+        assert path == "/v1/videos/image2video"
+        assert body["mode"] == "std"
+        assert body["duration"] == "5"
+
+    def test_pro_mode_for_last_frame(self):
+        path, body = _build_video_body(
+            "wave",
+            {"image": "https://x/y.png", "last_frame": "https://x/z.png", "duration": 5},
+            "kling-v2-1",
+        )
+        assert body["mode"] == "pro"
+        assert "image_tail" in body
+
+    def test_pro_mode_for_v2_6(self):
+        path, body = _build_video_body("x", {"duration": 5}, "kling-v2-6")
+        assert body["mode"] == "pro"
+
+    def test_multi_image_video(self):
+        path, body = _build_video_body(
+            "x", {"image_list": ["https://x/1.png", "https://x/2.png"], "duration": 10}, "kling-v2-1"
+        )
+        assert path == "/v1/videos/multi-image2video"
+        assert body["model_name"] == "kling-v1-6"
+        assert len(body["image_list"]) == 2
+
+    def test_bad_duration(self):
+        with pytest.raises(ValueError):
+            _build_video_body("x", {"duration": 7}, "kling-v2-1")
+
+    def test_known_models(self):
+        assert "kling-v2-6" in KlingVideoGenDriver.KNOWN_MODELS
+
+    def test_async_class_inherits_metadata(self):
+        assert AsyncKlingVideoGenDriver.max_seconds == KlingVideoGenDriver.max_seconds
+
+
+# ───────────────────────── MiniMax ──────────────────────────
+
+
+class TestMiniMaxHelpers:
+    def test_duration_clamps_to_6_or_10(self):
+        assert _duration({"duration": 5}) == 6
+        assert _duration({"duration": 8}) == 6
+        assert _duration({"duration": 9}) == 10
+        assert _duration({}) == 6
+
+    def test_resolution_fallback(self):
+        assert _resolution({"resolution": "1080p"}) == "1080P"
+        assert _resolution({"resolution": "weird"}) == "768P"
+
+    def test_select_model_fl2v_forces_hailuo_02(self):
+        assert _select_model("MiniMax-Hailuo-2.3", True, True) == "MiniMax-Hailuo-02"
+
+    def test_build_body_s2v(self):
+        body = _build_body("x", {"subject_image": "https://x/c.png"}, "MiniMax-Hailuo-2.3")
+        assert body["model"] == "S2V-01"
+        assert body["subject_reference"][0]["type"] == "character"
+
+    def test_build_body_i2v(self):
+        body = _build_body(
+            "x", {"image": "https://x/img.png", "aspect_ratio": "9:16"}, "MiniMax-Hailuo-2.3"
+        )
+        assert body["first_frame_image"] == "https://x/img.png"
+        assert body["aspect_ratio"] == "9:16"
+
+    def test_build_body_fl2v(self):
+        body = _build_body(
+            "x",
+            {"image": "https://x/1.png", "last_frame": "https://x/2.png"},
+            "MiniMax-Hailuo-2.3",
+        )
+        assert body["model"] == "MiniMax-Hailuo-02"
+        assert "last_frame_image" in body
+
+    def test_base64_normalizes_to_data_url(self):
+        body = _build_body("x", {"image": "AAAA="}, "MiniMax-Hailuo-2.3")
+        assert body["first_frame_image"].startswith("data:image/jpeg;base64,")
+
+
+class TestMiniMaxVideoDriver:
+    def test_construct(self):
+        d = MiniMaxVideoGenDriver(api_key="k")
+        assert d.api_key == "k"
+        assert d.endpoint == "https://api.minimax.io/v1"
+
+    def test_missing_key_raises(self):
+        d = MiniMaxVideoGenDriver(api_key=None)
+        with pytest.raises(RuntimeError):
+            d.generate_video("x", {})
+
+    def test_async_construct(self):
+        d = AsyncMiniMaxVideoGenDriver(api_key="k")
+        assert d.api_key == "k"
+
+    def test_known_models(self):
+        assert "MiniMax-Hailuo-02" in MiniMaxVideoGenDriver.KNOWN_MODELS
+
+
+class TestMiniMaxLLMDriver:
+    def test_construct_raises_without_key(self):
+        with pytest.raises(ValueError):
+            MiniMaxDriver(api_key=None)
+
+    def test_construct(self):
+        d = MiniMaxDriver(api_key="k")
+        assert d.model == "MiniMax-Text-01"
+        assert d.headers["Authorization"] == "Bearer k"
+        assert d.base_url == "https://api.minimax.io/v1"
+
+
+# ───────────────────────── Fal.ai ───────────────────────────
+
+
+class TestFalHelpers:
+    def test_build_video_input_prompt_only(self):
+        payload = _build_video_input("a cat", {})
+        assert payload == {"prompt": "a cat"}
+
+    def test_build_video_input_image(self):
+        payload = _build_video_input("a", {"image": "https://x/y.png", "duration": 5})
+        assert payload["image_url"] == "https://x/y.png"
+        assert payload["duration"] == "5"
+
+    def test_build_img_input_size_alias(self):
+        payload = _build_img_input("a", {"size": "square_hd"})
+        assert payload["image_size"] == "square_hd"
+
+    def test_extract_image_urls_list(self):
+        urls = _extract_image_urls({"images": [{"url": "u1"}, {"url": "u2"}]})
+        assert urls == ["u1", "u2"]
+
+    def test_extract_image_urls_single(self):
+        urls = _extract_image_urls({"image": {"url": "u1"}})
+        assert urls == ["u1"]
+
+    def test_extract_image_urls_empty(self):
+        assert _extract_image_urls({}) == []
+
+
+class TestFalDrivers:
+    def test_fal_video_construct(self):
+        d = FalVideoGenDriver(api_key="k")
+        assert d.api_key == "k"
+        assert d.model == "fal-ai/kling-video/v2.6/pro/image-to-video"
+        assert d.endpoint == "https://queue.fal.run"
+
+    def test_fal_image_construct(self):
+        d = FalImageGenDriver(api_key="k")
+        assert d.model == "fal-ai/flux/dev"
+
+    def test_fal_async_construct(self):
+        d_v = AsyncFalVideoGenDriver(api_key="k")
+        d_i = AsyncFalImageGenDriver(api_key="k")
+        assert d_v.api_key == "k"
+        assert d_i.api_key == "k"
+
+    def test_missing_key_raises(self):
+        d = FalVideoGenDriver(api_key=None)
+        with pytest.raises(RuntimeError):
+            d.generate_video("x", {})
+
+    def test_headers_use_key_scheme(self):
+        d = FalVideoGenDriver(api_key="abc")
+        assert d._headers()["Authorization"] == "Key abc"
+
+
+# ───────────────── Registry integration smoke ───────────────
+
+
+class TestProviderDescriptors:
+    def test_all_three_registered(self):
+        from prompture.drivers.provider_descriptors import PROVIDER_DESCRIPTOR_MAP
+
+        assert "kling" in PROVIDER_DESCRIPTOR_MAP
+        assert "minimax" in PROVIDER_DESCRIPTOR_MAP
+        assert "fal" in PROVIDER_DESCRIPTOR_MAP
+        assert "hailuo" in PROVIDER_DESCRIPTOR_MAP
+
+    def test_kling_has_image_and_video(self):
+        from prompture.drivers.provider_descriptors import PROVIDER_DESCRIPTOR_MAP
+
+        d = PROVIDER_DESCRIPTOR_MAP["kling"]
+        assert d.img_gen_sync is not None
+        assert d.img_gen_async is not None
+        assert d.video_gen_sync is not None
+        assert d.video_gen_async is not None
+
+    def test_minimax_has_llm_and_video(self):
+        from prompture.drivers.provider_descriptors import PROVIDER_DESCRIPTOR_MAP
+
+        d = PROVIDER_DESCRIPTOR_MAP["minimax"]
+        assert d.llm_sync is not None
+        assert d.llm_async is not None
+        assert d.video_gen_sync is not None
+
+    def test_hailuo_alias_inherits_video(self):
+        from prompture.drivers.provider_descriptors import PROVIDER_DESCRIPTOR_MAP
+
+        d = PROVIDER_DESCRIPTOR_MAP["hailuo"]
+        assert d.alias_for == "minimax"
+        assert d.video_gen_sync is not None
+        assert d.llm_sync is None  # alias only covers video_gen


### PR DESCRIPTION
Three new media providers walk into the registry, and OpenAI strict mode finally stops gaslighting us about `$ref` siblings. This PR ships Fal.ai, Kling AI, and MiniMax/Hailuo drivers (image + video + LLM where applicable) and fixes several long-standing rejections from OpenAI's strict JSON-schema mode and LM Studio's error reporting.

### Highlights

- New provider: **Fal.ai** (image + video aggregator) with sync and async drivers
- New provider: **Kling AI** (image + video), including the `kling-v2-1` default
- New provider: **MiniMax / Hailuo** — LLM (`MiniMax-Text-01`) plus video generation (`MiniMax-Hailuo-2.3`), with `hailuo` as an alias for video
- OpenAI strict-mode extractions on nested Pydantic models now succeed instead of erroring out on `$defs`, `$ref` siblings, or missing `required` entries
- GPT-5 family and o-series reasoning models (o1/o3/o4) work out of the box even before the capabilities KB knows about them
- LM Studio errors now surface the server's actual rejection reason (wrong model loaded, context overflow, schema issue) instead of an opaque HTTP status

<details>
<summary>Technical changes</summary>

- Add `fal_img_gen_driver.FalImageGenDriver`, `fal_video_gen_driver.FalVideoGenDriver`, and async siblings under `prompture/drivers/`
- Add `kling_img_gen_driver.KlingImageGenDriver`, `kling_video_gen_driver.KlingVideoGenDriver`, and async siblings; auth uses `KLING_ACCESS_KEY` + `KLING_SECRET_KEY`
- Add `minimax_driver.MiniMaxDriver` (LLM) and `minimax_video_gen_driver.MiniMaxVideoGenDriver`, plus async siblings; accepts either `MINIMAX_API_KEY` or `HAILUO_API_KEY`
- Register all new providers in `provider_descriptors.py` via `ProviderDescriptor` + `DriverSpec`; wire `minimax` into `_llm(...)` for sync/async LLM dispatch and `list_models_kwargs` / `models_dev_name="minimax"`
- Add `hailuo` → `minimax` alias scoped to `{"video_gen"}`
- Extend `infra/settings.py` with `kling_*`, `minimax_*`, `hailuo_api_key`, and `fal_*` fields, including sensible defaults (`kling-v2-1`, `MiniMax-Text-01`, `MiniMax-Hailuo-2.3`, `fal-ai/flux/dev`, `fal-ai/kling-video/v2.6/pro/image-to-video`)
- Mirror the new env vars in `.env.copy`
- `prepare_strict_schema` / `_patch_strict` in `infra/cost_mixin.py`:
  - Recurse into `$defs` and `definitions` so nested Pydantic v2 models get `additionalProperties: false` (fixes `'additionalProperties' is required to be supplied and to be false` on nested `BaseModel`s)
  - Strip sibling keywords from `$ref` nodes (e.g. Pydantic's `description` alongside `$ref`) to satisfy OpenAI's `$ref cannot have keywords {...}` rule
  - Force-overwrite `required` to list every property instead of `setdefault`, so partial Pydantic-emitted `required` arrays no longer slip through
  - Walk `anyOf` / `oneOf` / `allOf` subschemas in addition to `properties` and `items`
- Add `_default_tokens_param(provider, model)` in `cost_mixin.py`: name-detects `gpt-5*`, `o1*`, `o3*`, `o4*` and returns `max_completion_tokens`, so unknown OpenAI reasoning models don't 400 on `max_tokens`
- `lmstudio_driver.py` / `async_lmstudio_driver.py`: on HTTP ≥ 400, raise `RuntimeError` with the response body (truncated to 500 chars) instead of letting `raise_for_status()` discard it; async variant also handles non-JSON bodies explicitly
- Add `tests/test_new_providers.py` covering the new Fal/Kling/MiniMax drivers

</details>
