### PR TITLE
Add coding-agent CLI integration: discovery, runner, streaming, and server

### DIFF
--- a/.env.copy
+++ b/.env.copy
@@ -211,3 +211,14 @@ SERPER_API_KEY=
 BRAVE_SEARCH_API_KEY=
 # SearXNG — self-hosted metasearch engine (no key, set the base URL).
 SEARXNG_ENDPOINT=
+
+# ─── Coding-agent CLI binaries (optional path overrides) ─────────────────────
+# Set if a CLI isn't on PATH or you want to pin a specific install.
+CODING_AGENT_BIN_CLAUDE=
+CODING_AGENT_BIN_CODEX=
+CODING_AGENT_BIN_GEMINI=
+CODING_AGENT_BIN_QWEN=
+CODING_AGENT_BIN_AIDER=
+CODING_AGENT_BIN_OPENCODE=
+CODING_AGENT_BIN_CURSOR_AGENT=
+CODING_AGENT_BIN_CRUSH=

--- a/README.md
+++ b/README.md
@@ -1203,69 +1203,93 @@ get_available_video_gen_models()        # ['runway/gen4.5', 'runway/gen4_aleph',
 get_available_audio_models(modality="tts")  # ['runway/eleven_multilingual_v2', ...]
 ```
 
-Prompture can also discover and run local coding-agent CLIs for app integrations:
+### Local coding-agent CLIs
+
+Prompture detects and runs the major terminal coding agents — Claude Code,
+Codex, Gemini, Qwen Code, Aider, OpenCode, Cursor Agent, and Crush — through
+one unified interface. Useful when an app wants to delegate code-editing
+tasks to whatever agent the user already has installed, without reimplementing
+the per-CLI flag dance for each one.
+
+| Agent | Binary | Install | Provider |
+|---|---|---|---|
+| Claude Code | `claude` | `npm i -g @anthropic-ai/claude-code` | Anthropic |
+| Codex CLI | `codex` | `npm i -g @openai/codex` | OpenAI |
+| Gemini CLI | `gemini` | `npm i -g @google/gemini-cli` | Google |
+| Qwen Code | `qwen` | `npm i -g @qwen-code/qwen-code` | Alibaba (gemini-cli fork) |
+| Aider | `aider` | `pip install aider-chat` | model-agnostic |
+| OpenCode | `opencode` | `npm i -g opencode-ai` | model-agnostic (sst) |
+| Cursor Agent | `cursor-agent` | Cursor installer | Cursor / Anysphere |
+| Crush | `crush` | `brew install charmbracelet/tap/crush` | model-agnostic (Charm) |
+
+#### Discover
 
 ```python
-from prompture import get_available_coding_agents, run_coding_agent
+from prompture import get_available_coding_agents
 
-agents = get_available_coding_agents(verify=True)
-print(agents)
-
-result = run_coding_agent(
-    "codex",  # claude, codex, gemini, qwen, aider, opencode, cursor-agent, crush
-    "Add focused tests for the discovery helper.",
-    cwd=".",
-    approval_mode="auto",  # avoids repeated approval prompts where supported
-)
-print(result.output)
+for agent in get_available_coding_agents(verify=True):
+    print(agent.id, agent.available, agent.binary, agent.source)
 ```
 
-The same integration is available from the CLI:
+`verify=True` runs a `--version` health check on each resolved binary and
+reports the failure reason for broken PATH shims — common after Node version
+switches on Windows or WSL. Discovery resolves both PATH installs and the
+underlying `node_modules` package entrypoint, so a working agent can still be
+found when the npm shim is broken.
+
+#### Run
+
+```python
+from prompture import run_coding_agent
+
+result = run_coding_agent(
+    "claude",  # claude, codex, gemini, qwen, aider, opencode, cursor-agent, crush
+    "Add focused tests for the discovery helper.",
+    cwd=".",
+    approval_mode="auto",   # default | auto | yolo
+    model="sonnet",         # optional, passed to CLIs that support --model
+    timeout=600,
+)
+print(result.output)
+print("ok:", result.ok, "exit:", result.returncode, "duration:", result.duration_seconds)
+```
+
+Approval modes:
+
+- **`default`** — run interactively; the CLI asks for approvals as it edits or runs commands.
+- **`auto`** — skip approval prompts but stay within the CLI's normal sandboxing where it has one (codex `--sandbox workspace-write`, gemini/qwen `-y`, aider `--yes-always`, crush `--yolo`). Claude Code has no intermediate mode, so `auto` maps to `--dangerously-skip-permissions` there.
+- **`yolo`** — every CLI's full bypass: claude `--dangerously-skip-permissions`, codex `--dangerously-bypass-approvals-and-sandbox`, gemini/qwen `-y`, crush `--yolo`. Use only inside an environment whose blast radius you already trust.
+
+Before launching the task, the binary is health-checked by default so a
+broken shim fails fast with a clear error rather than hanging or producing
+opaque output. Pass `verify_binary=False` to skip the preflight.
+
+#### From the CLI
 
 ```bash
 prompture coding-agents --verify
-prompture code-agent codex --auto-approve "Add tests for the pricing cache"
 prompture code-agent claude --auto-approve "Review this package for release blockers"
+prompture code-agent codex  --auto-approve "Add tests for the pricing cache"
+prompture code-agent aider  --auto-approve --model gpt-4o "Rename foo to bar across the package"
 ```
 
-Use `verify=True` (or `prompture coding-agents --verify`) when PATH may contain
-broken shims; Prompture runs a quick `--version` health check and reports the
-failure reason. Actual `run_coding_agent(...)` calls also health-check by
-default before launching the task; pass `verify_binary=False` only if you
-explicitly want to skip that preflight.
+#### From the server
 
-Supported agents:
-
-| Agent | Binary | Install |
-|---|---|---|
-| Claude Code | `claude` | npm `@anthropic-ai/claude-code` |
-| Codex CLI | `codex` | npm `@openai/codex` |
-| Gemini CLI | `gemini` | npm `@google/gemini-cli` |
-| Qwen Code | `qwen` | npm `@qwen-code/qwen-code` (gemini-cli fork) |
-| Aider | `aider` | `pip install aider-chat` |
-| OpenCode | `opencode` | npm `opencode-ai` |
-| Cursor Agent | `cursor-agent` | Cursor installer |
-| Crush | `crush` | brew / scoop / Go install |
-
-Discovery checks normal PATH installs and npm-style installs (`node_modules`
-package entrypoints). If a shim is present but broken, verified discovery can
-fall back to the package entrypoint plus a working `node` or `node.exe`. To
-register an additional agent, add a `CodingAgentSpec` to
-`prompture.infra.coding_agent_specs.CODING_AGENT_SPECS`.
-
-Apps can use the server endpoint too:
+`prompture serve` exposes the same discovery as an HTTP endpoint so any app
+talking to the OpenAI-compatible server can also list local agents:
 
 ```bash
 curl "http://localhost:9471/v1/coding-agents"
 curl "http://localhost:9471/v1/coding-agents?verify=false"
 ```
 
-For fully unattended sandboxed environments, `approval_mode="yolo"` maps to
-each CLI's dangerous bypass flag:
+#### Adding a new agent
 
-```python
-run_coding_agent("codex", "Fix the failing tests", approval_mode="yolo")
-```
+Drop a `CodingAgentSpec` into
+`prompture.infra.coding_agent_specs.CODING_AGENT_SPECS` with a `build_args`
+callable that produces the CLI's argv from a task, approval mode, model, and
+extra args. Discovery, health checks, command construction, the CLI, and the
+server endpoint all read from this registry — no other changes are needed.
 
 ### Logging and Debugging
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ print(person.name)  # Maria
 - **Tool use** — Function calling and streaming across supported providers, with automatic prompt-based simulation for models without native tool support
 - **Sandboxed Python execution** — Drop-in `python_execute` tool backed by Tukuy's `PythonSandbox` (import whitelist, path restrictions, timeout, memory limit, AST risk gate)
 - **Web search** — Drop-in `web_search` tool with Tavily, Serper, Brave, and SearXNG backends; returns Markdown so the LLM can cite by URL
-- **OpenAI-compatible server** — `prompture serve` exposes `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/models`; point Claude Code, Codex, Cursor, Aider, or any OpenAI SDK at it and route to any of the 36+ providers
+- **OpenAI-compatible server** — `prompture serve` exposes `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/models`, and `/v1/coding-agents`; point Claude Code, Codex, Cursor, Aider, or any OpenAI SDK at it and route to any of the 36+ providers
 - **Synthetic datasets** — `generate_qa_dataset()` turns documents into fine-tuning JSONL (Q&A, ShareGPT, or Alpaca) ready for Unsloth, Axolotl, or TRL
 - **Refusal detection** — `RefusalDetector` + `RefusalEvaluator` flag and score LLM refusals (5 categories, en/es markers, position-weighted confidence); useful for cross-provider alignment comparison and validating abliterated models
 - **Input safety** — `PromptInjectionDetector` (jailbreak, role-hijack, delimiter attacks, encoded payloads) + `PIIRedactor` (emails, phones, Luhn-checked cards, SSN, IBAN, IPs, API keys, embedded URL credentials)
@@ -1208,7 +1208,7 @@ Prompture can also discover and run local coding-agent CLIs for app integrations
 ```python
 from prompture import get_available_coding_agents, run_coding_agent
 
-agents = get_available_coding_agents()
+agents = get_available_coding_agents(verify=True)
 print(agents)
 
 result = run_coding_agent(
@@ -1223,9 +1223,27 @@ print(result.output)
 The same integration is available from the CLI:
 
 ```bash
-prompture coding-agents
+prompture coding-agents --verify
 prompture code-agent codex --auto-approve "Add tests for the pricing cache"
 prompture code-agent claude --auto-approve "Review this package for release blockers"
+```
+
+Use `verify=True` (or `prompture coding-agents --verify`) when PATH may contain
+broken shims; Prompture runs a quick `--version` health check and reports the
+failure reason. Actual `run_coding_agent(...)` calls also health-check by
+default before launching the task; pass `verify_binary=False` only if you
+explicitly want to skip that preflight.
+
+Discovery checks normal PATH installs and npm-style installs for Claude Code
+(`@anthropic-ai/claude-code`), Codex CLI (`@openai/codex`), and Gemini CLI
+(`@google/gemini-cli`). If a shim is present but broken, verified discovery can
+fall back to the package entrypoint plus a working `node` or `node.exe`.
+
+Apps can use the server endpoint too:
+
+```bash
+curl "http://localhost:9471/v1/coding-agents"
+curl "http://localhost:9471/v1/coding-agents?verify=false"
 ```
 
 For fully unattended sandboxed environments, `approval_mode="yolo"` maps to
@@ -1274,7 +1292,7 @@ Run spec-driven extraction suites for cross-model comparison.
 
 `prompture serve` exposes an OpenAI-shaped API
 (`/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`,
-`/v1/models`) backed by Prompture's driver registry.  Point any
+`/v1/models`, `/v1/coding-agents`) backed by Prompture's driver registry.  Point any
 OpenAI SDK — or any tool that speaks the OpenAI API (Claude Code,
 Codex, Cursor, Aider, LangChain) — at it and route to any of the 36+
 supported providers under one endpoint.

--- a/README.md
+++ b/README.md
@@ -1203,6 +1203,15 @@ get_available_video_gen_models()        # ['runway/gen4.5', 'runway/gen4_aleph',
 get_available_audio_models(modality="tts")  # ['runway/eleven_multilingual_v2', ...]
 ```
 
+Prompture can also discover local coding-agent CLIs for app integrations:
+
+```python
+from prompture import get_available_coding_agents
+
+agents = get_available_coding_agents()
+# [CodingAgentInfo(id='claude', available=True, ...), ...]
+```
+
 ### Logging and Debugging
 
 ```python

--- a/README.md
+++ b/README.md
@@ -1203,13 +1203,36 @@ get_available_video_gen_models()        # ['runway/gen4.5', 'runway/gen4_aleph',
 get_available_audio_models(modality="tts")  # ['runway/eleven_multilingual_v2', ...]
 ```
 
-Prompture can also discover local coding-agent CLIs for app integrations:
+Prompture can also discover and run local coding-agent CLIs for app integrations:
 
 ```python
-from prompture import get_available_coding_agents
+from prompture import get_available_coding_agents, run_coding_agent
 
 agents = get_available_coding_agents()
-# [CodingAgentInfo(id='claude', available=True, ...), ...]
+print(agents)
+
+result = run_coding_agent(
+    "codex",  # or "claude" / "gemini"
+    "Add focused tests for the discovery helper.",
+    cwd=".",
+    approval_mode="auto",  # avoids repeated approval prompts where supported
+)
+print(result.output)
+```
+
+The same integration is available from the CLI:
+
+```bash
+prompture coding-agents
+prompture code-agent codex --auto-approve "Add tests for the pricing cache"
+prompture code-agent claude --auto-approve "Review this package for release blockers"
+```
+
+For fully unattended sandboxed environments, `approval_mode="yolo"` maps to
+each CLI's dangerous bypass flag:
+
+```python
+run_coding_agent("codex", "Fix the failing tests", approval_mode="yolo")
 ```
 
 ### Logging and Debugging

--- a/README.md
+++ b/README.md
@@ -1264,6 +1264,98 @@ Before launching the task, the binary is health-checked by default so a
 broken shim fails fast with a clear error rather than hanging or producing
 opaque output. Pass `verify_binary=False` to skip the preflight.
 
+#### Structured output
+
+Claude Code (`--output-format stream-json`) and Codex (`exec --json`) emit a
+JSON event stream that Prompture normalises into a typed `CodingAgentEvent`
+union — `system`, `message`, `tool_call`, `tool_result`, `done`, `error`. Pass
+`output_format="json"` to get parsed events, cost, and token counts on the
+result:
+
+```python
+result = run_coding_agent(
+    "claude",
+    "Find every TODO that references issue #42 and summarise them.",
+    cwd=".",
+    approval_mode="auto",
+    output_format="json",
+)
+print(f"${result.cost_usd:.4f} — {result.input_tokens} in / {result.output_tokens} out")
+for event in result.events:
+    if event.type == "tool_call":
+        print("→", event.tool_name, event.tool_input)
+    elif event.type == "message":
+        print(event.text)
+```
+
+For live progress, use `astream_coding_agent` — an async generator that yields
+events as the CLI emits them:
+
+```python
+from prompture import astream_coding_agent
+
+async for event in astream_coding_agent("claude", "refactor X", cwd="."):
+    if event.type == "tool_call":
+        ui.show_pending(event.tool_name, event.tool_input)
+    elif event.type == "done":
+        ui.show_cost(event.cost_usd)
+```
+
+Streaming requires an agent whose spec provides a parser (Claude Code and
+Codex today). Cancelling the iterator terminates the underlying subprocess.
+
+#### Detecting clarifying questions
+
+Coding agents often pause to ask the user a clarifying question ("which
+approach do you want?", "should I delete this file?") instead of acting. In
+non-interactive mode this manifests as a final assistant message that ends in
+a question. Prompture's event parser detects question patterns and emits a
+typed `question` event alongside the `message`, with extracted numbered /
+bulleted / lettered choices when present:
+
+```python
+result = run_coding_agent("claude", "refactor X", cwd=".", output_format="json")
+if (q := result.asked_question):
+    print("Agent asked:", q.text)
+    if q.choices:
+        for i, choice in enumerate(q.choices, 1):
+            print(f"  {i}. {choice}")
+    # …then re-run with extra_args=["The answer is option 2"] to continue.
+```
+
+The same `detect_question(text)` helper is exported for callers that want to
+run their own heuristic over arbitrary agent text.
+
+#### Budget tracking
+
+Pass a `UsageSession` and coding-agent runs participate in the same per-model
+cost / token / latency summary as direct LLM calls:
+
+```python
+from prompture import UsageSession, run_coding_agent
+
+session = UsageSession()
+run_coding_agent("claude", "task 1", cwd=".", output_format="json", session=session)
+run_coding_agent("claude", "task 2", cwd=".", output_format="json", session=session)
+print(session.summary()["formatted"])
+# Session: 3,200 tokens across 2 call(s) costing $0.0421 | …
+```
+
+#### Binary path overrides
+
+When a CLI isn't on PATH, or you want to pin a specific install, set the
+matching `CODING_AGENT_BIN_*` env var (or field in `Settings`) and discovery
+will pick it up without threading the path through every call. Hyphenated ids
+use underscores in the variable name:
+
+```bash
+export CODING_AGENT_BIN_CLAUDE=/opt/claude/claude
+export CODING_AGENT_BIN_CURSOR_AGENT="/c/Program Files/Cursor/resources/app/bin/cursor-agent.exe"
+```
+
+Explicit `agent_paths={"claude": "..."}` kwargs still override settings when
+needed.
+
 #### From the CLI
 
 ```bash
@@ -1275,12 +1367,24 @@ prompture code-agent aider  --auto-approve --model gpt-4o "Rename foo to bar acr
 
 #### From the server
 
-`prompture serve` exposes the same discovery as an HTTP endpoint so any app
-talking to the OpenAI-compatible server can also list local agents:
+`prompture serve` exposes coding-agent discovery and execution as HTTP
+endpoints so any app talking to the OpenAI-compatible server can also drive a
+local agent:
 
 ```bash
+# Discover
 curl "http://localhost:9471/v1/coding-agents"
 curl "http://localhost:9471/v1/coding-agents?verify=false"
+
+# Run, blocking
+curl -X POST "http://localhost:9471/v1/coding-agents/run" \
+  -H "content-type: application/json" \
+  -d '{"agent": "claude", "task": "summarise CHANGELOG.md", "approval_mode": "auto", "output_format": "json"}'
+
+# Run, SSE-streaming live events
+curl -N -X POST "http://localhost:9471/v1/coding-agents/run" \
+  -H "content-type: application/json" \
+  -d '{"agent": "claude", "task": "refactor X", "approval_mode": "auto", "stream": true}'
 ```
 
 #### Adding a new agent

--- a/README.md
+++ b/README.md
@@ -1212,7 +1212,7 @@ agents = get_available_coding_agents(verify=True)
 print(agents)
 
 result = run_coding_agent(
-    "codex",  # or "claude" / "gemini" / "qwen"
+    "codex",  # claude, codex, gemini, qwen, aider, opencode, cursor-agent, crush
     "Add focused tests for the discovery helper.",
     cwd=".",
     approval_mode="auto",  # avoids repeated approval prompts where supported
@@ -1234,12 +1234,23 @@ failure reason. Actual `run_coding_agent(...)` calls also health-check by
 default before launching the task; pass `verify_binary=False` only if you
 explicitly want to skip that preflight.
 
-Discovery checks normal PATH installs and npm-style installs for Claude Code
-(`@anthropic-ai/claude-code`), Codex CLI (`@openai/codex`), Gemini CLI
-(`@google/gemini-cli`), and Qwen Code (`@qwen-code/qwen-code`, a gemini-cli
-fork). If a shim is present but broken, verified discovery can fall back to
-the package entrypoint plus a working `node` or `node.exe`. To register an
-additional agent, add a `CodingAgentSpec` to
+Supported agents:
+
+| Agent | Binary | Install |
+|---|---|---|
+| Claude Code | `claude` | npm `@anthropic-ai/claude-code` |
+| Codex CLI | `codex` | npm `@openai/codex` |
+| Gemini CLI | `gemini` | npm `@google/gemini-cli` |
+| Qwen Code | `qwen` | npm `@qwen-code/qwen-code` (gemini-cli fork) |
+| Aider | `aider` | `pip install aider-chat` |
+| OpenCode | `opencode` | npm `opencode-ai` |
+| Cursor Agent | `cursor-agent` | Cursor installer |
+| Crush | `crush` | brew / scoop / Go install |
+
+Discovery checks normal PATH installs and npm-style installs (`node_modules`
+package entrypoints). If a shim is present but broken, verified discovery can
+fall back to the package entrypoint plus a working `node` or `node.exe`. To
+register an additional agent, add a `CodingAgentSpec` to
 `prompture.infra.coding_agent_specs.CODING_AGENT_SPECS`.
 
 Apps can use the server endpoint too:

--- a/README.md
+++ b/README.md
@@ -1212,7 +1212,7 @@ agents = get_available_coding_agents(verify=True)
 print(agents)
 
 result = run_coding_agent(
-    "codex",  # or "claude" / "gemini"
+    "codex",  # or "claude" / "gemini" / "qwen"
     "Add focused tests for the discovery helper.",
     cwd=".",
     approval_mode="auto",  # avoids repeated approval prompts where supported
@@ -1235,9 +1235,12 @@ default before launching the task; pass `verify_binary=False` only if you
 explicitly want to skip that preflight.
 
 Discovery checks normal PATH installs and npm-style installs for Claude Code
-(`@anthropic-ai/claude-code`), Codex CLI (`@openai/codex`), and Gemini CLI
-(`@google/gemini-cli`). If a shim is present but broken, verified discovery can
-fall back to the package entrypoint plus a working `node` or `node.exe`.
+(`@anthropic-ai/claude-code`), Codex CLI (`@openai/codex`), Gemini CLI
+(`@google/gemini-cli`), and Qwen Code (`@qwen-code/qwen-code`, a gemini-cli
+fork). If a shim is present but broken, verified discovery can fall back to
+the package entrypoint plus a working `node` or `node.exe`. To register an
+additional agent, add a `CodingAgentSpec` to
+`prompture.infra.coding_agent_specs.CODING_AGENT_SPECS`.
 
 Apps can use the server endpoint too:
 

--- a/examples/coding_agents_example.py
+++ b/examples/coding_agents_example.py
@@ -23,10 +23,11 @@ PREFERRED_AGENT = os.getenv("PROMPTURE_CODING_AGENT", "codex")
 
 
 print("Detected coding agents:")
-agents = get_available_coding_agents()
+agents = get_available_coding_agents(verify=True)
 for agent in agents:
-    status = "available" if agent.available else "missing"
-    print(f"- {agent.id}: {status} ({agent.binary})")
+    status = "available" if agent.available else ("failed" if agent.verified else "missing")
+    detail = f" - {agent.error}" if agent.error else ""
+    print(f"- {agent.id}: {status} ({agent.binary}){detail}")
 
 available = {agent.id for agent in agents if agent.available}
 if PREFERRED_AGENT not in available:

--- a/examples/coding_agents_example.py
+++ b/examples/coding_agents_example.py
@@ -1,0 +1,60 @@
+"""
+Example: Discovering and running local coding-agent CLIs.
+
+This script demonstrates:
+1. Detecting Claude Code, Codex CLI, and Gemini CLI from PATH.
+2. Previewing the command Prompture would run.
+3. Optionally running Codex/Claude/Gemini with Prompture's wrapper.
+
+Run:
+    python examples/coding_agents_example.py
+
+To actually launch an agent, opt in explicitly:
+    PROMPTURE_RUN_CODING_AGENT=1 python examples/coding_agents_example.py
+"""
+
+import os
+import shlex
+
+from prompture import build_coding_agent_command, get_available_coding_agents, run_coding_agent
+
+TASK = "Summarize the repository structure and suggest one low-risk cleanup."
+PREFERRED_AGENT = os.getenv("PROMPTURE_CODING_AGENT", "codex")
+
+
+print("Detected coding agents:")
+agents = get_available_coding_agents()
+for agent in agents:
+    status = "available" if agent.available else "missing"
+    print(f"- {agent.id}: {status} ({agent.binary})")
+
+available = {agent.id for agent in agents if agent.available}
+if PREFERRED_AGENT not in available:
+    print(f"\n{PREFERRED_AGENT!r} is not available here. Set PROMPTURE_CODING_AGENT=claude or gemini.")
+    raise SystemExit(0)
+
+print("\nCommand preview with auto-approve mode:")
+command = build_coding_agent_command(
+    PREFERRED_AGENT,
+    TASK,
+    approval_mode="auto",
+)
+print(shlex.join(command.argv))
+
+if os.getenv("PROMPTURE_RUN_CODING_AGENT") != "1":
+    print("\nSet PROMPTURE_RUN_CODING_AGENT=1 to run it.")
+    raise SystemExit(0)
+
+result = run_coding_agent(
+    PREFERRED_AGENT,
+    TASK,
+    approval_mode="auto",
+    timeout=600,
+)
+
+print("\nAgent output:")
+print(result.output)
+print("\nRun metadata:")
+print(f"Agent: {result.agent}")
+print(f"Exit code: {result.returncode}")
+print(f"Duration: {result.duration_seconds:.2f}s")

--- a/examples/coding_agents_structured_example.py
+++ b/examples/coding_agents_structured_example.py
@@ -1,0 +1,127 @@
+"""Structured coding-agent output: events, cost, questions, session continuity.
+
+Demonstrates the full feature set built on top of run_coding_agent /
+astream_coding_agent:
+
+1. JSON event stream parsing (Claude or Codex)
+2. Live event streaming for UI updates
+3. Cost + token capture via UsageSession
+4. Clarifying-question detection
+5. Session continuity (resume an answered question)
+
+Run:
+    python examples/coding_agents_structured_example.py
+
+Opt in to actually launching the agent (otherwise everything but the live
+calls is shown):
+    PROMPTURE_RUN_CODING_AGENT=1 python examples/coding_agents_structured_example.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from prompture import (
+    UsageSession,
+    astream_coding_agent,
+    get_available_coding_agents,
+    run_coding_agent,
+)
+
+PREFERRED_AGENT = os.getenv("PROMPTURE_CODING_AGENT", "claude")
+TASK_1 = "Summarise pyproject.toml in two bullet points."
+TASK_2 = "Now also list the optional dependency extras you noticed."
+
+
+def _check_available() -> bool:
+    agents = {a.id for a in get_available_coding_agents(verify=True) if a.available}
+    if PREFERRED_AGENT not in agents:
+        print(f"{PREFERRED_AGENT!r} is not installed. Available: {sorted(agents)}")
+        return False
+    if os.getenv("PROMPTURE_RUN_CODING_AGENT") != "1":
+        print("Set PROMPTURE_RUN_CODING_AGENT=1 to actually invoke the agent.")
+        return False
+    return True
+
+
+def demo_structured_output() -> str | None:
+    """Run a single task in JSON mode; show events, cost, and any question."""
+    session = UsageSession()
+    result = run_coding_agent(
+        PREFERRED_AGENT,
+        TASK_1,
+        approval_mode="auto",
+        output_format="json",
+        session=session,
+    )
+
+    print(f"\n=== {PREFERRED_AGENT} (one-shot, json mode) ===")
+    print(f"exit={result.returncode}  duration={result.duration_seconds:.2f}s")
+    if result.cost_usd is not None:
+        print(f"cost=${result.cost_usd:.4f}  in={result.input_tokens}  out={result.output_tokens}")
+    print(f"session_id={result.session_id}")
+
+    for ev in result.events:
+        if ev.type == "message":
+            print(f"  [message] {ev.text}")
+        elif ev.type == "tool_call":
+            print(f"  [tool]    {ev.tool_name}({ev.tool_input})")
+        elif ev.type == "question":
+            print(f"  [QUESTION] {ev.text}")
+            if ev.choices:
+                for i, c in enumerate(ev.choices, 1):
+                    print(f"       {i}. {c}")
+
+    if (q := result.asked_question):
+        print(f"\nAgent asked a clarifying question:\n  {q.text}")
+
+    print(f"\nSession summary: {session.summary()['formatted']}")
+    return result.session_id
+
+
+async def demo_streaming() -> None:
+    """Live event stream — useful for UIs that want progress as it happens."""
+    print(f"\n=== {PREFERRED_AGENT} (streaming) ===")
+    async for ev in astream_coding_agent(
+        PREFERRED_AGENT,
+        TASK_1,
+        approval_mode="auto",
+    ):
+        if ev.type == "message":
+            print(f"  [stream] {ev.text}")
+        elif ev.type == "tool_call":
+            print(f"  [stream] →  {ev.tool_name}")
+        elif ev.type == "done":
+            cost = f"${ev.cost_usd:.4f}" if ev.cost_usd is not None else "n/a"
+            print(f"  [stream] done  cost={cost}")
+
+
+def demo_session_continuity(session_id: str | None) -> None:
+    """Resume the previous turn to ask a follow-up question."""
+    if not session_id:
+        print("\nNo session_id captured — skipping continuity demo.")
+        return
+    print(f"\n=== {PREFERRED_AGENT} (resuming session {session_id}) ===")
+    result = run_coding_agent(
+        PREFERRED_AGENT,
+        TASK_2,
+        approval_mode="auto",
+        output_format="json",
+        session_id=session_id,
+    )
+    print(f"exit={result.returncode}  duration={result.duration_seconds:.2f}s")
+    print(result.output[:500])
+
+
+def main() -> None:
+    if not _check_available():
+        return
+
+    session_id = demo_structured_output()
+    asyncio.run(demo_streaming())
+    demo_session_continuity(session_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/prompture/cli/cli.py
+++ b/prompture/cli/cli.py
@@ -64,8 +64,15 @@ def coding_agents(json_output: bool, verify: bool) -> None:
         click.echo(f"{agent.id:<7} {status:<9} {source:<12} {agent.binary}{detail}")
 
 
+def _supported_coding_agent_ids() -> list[str]:
+    """Source the choice list for the `code-agent` command from the spec registry."""
+    from ..infra import supported_coding_agent_ids
+
+    return list(supported_coding_agent_ids())
+
+
 @cli.command("code-agent")
-@click.argument("agent", type=click.Choice(["claude", "codex", "gemini"]))
+@click.argument("agent", type=click.Choice(_supported_coding_agent_ids()))
 @click.argument("task", nargs=-1, required=True)
 @click.option("--cwd", default=".", type=click.Path(exists=True, file_okay=False), help="Working directory.")
 @click.option("--model", default=None, help="Model passed through to the agent CLI.")
@@ -89,7 +96,11 @@ def code_agent(
     verify: bool,
     dry_run: bool,
 ) -> None:
-    """Run Claude Code, Codex CLI, or Gemini CLI from Prompture."""
+    """Run a supported coding-agent CLI from Prompture.
+
+    Agent ids are sourced from ``CODING_AGENT_SPECS`` — currently Claude Code,
+    Codex CLI, Gemini CLI, Qwen Code, Aider, OpenCode, Cursor Agent, and Crush.
+    """
     from ..infra import build_coding_agent_command, run_coding_agent
 
     if auto_approve and yolo:

--- a/prompture/cli/cli.py
+++ b/prompture/cli/cli.py
@@ -42,21 +42,26 @@ def _build_drivers(providers: list[str]) -> dict[str, object]:
 
 @cli.command("coding-agents")
 @click.option("--json", "json_output", is_flag=True, help="Output machine-readable JSON.")
-def coding_agents(json_output: bool) -> None:
+@click.option("--verify", is_flag=True, help="Run a lightweight health check for each detected CLI.")
+def coding_agents(json_output: bool, verify: bool) -> None:
     """List detected local coding-agent CLIs."""
     from dataclasses import asdict
 
     from ..infra import get_available_coding_agents
 
-    agents = get_available_coding_agents()
+    agents = get_available_coding_agents(verify=verify)
     if json_output:
         click.echo(json.dumps([asdict(agent) for agent in agents], indent=2))
         return
 
     for agent in agents:
-        status = "available" if agent.available else "missing"
-        source = "custom" if agent.custom_path else "PATH"
-        click.echo(f"{agent.id:<7} {status:<9} {source:<6} {agent.binary}")
+        if verify:
+            status = "healthy" if agent.available else "failed"
+        else:
+            status = "available" if agent.available else "missing"
+        source = "custom" if agent.custom_path else (agent.source or "missing")
+        detail = f"  {agent.error}" if agent.error else ""
+        click.echo(f"{agent.id:<7} {status:<9} {source:<12} {agent.binary}{detail}")
 
 
 @cli.command("code-agent")
@@ -69,6 +74,7 @@ def coding_agents(json_output: bool) -> None:
 @click.option("--yolo", is_flag=True, help="Use the CLI's dangerous no-approval/no-sandbox mode.")
 @click.option("--timeout", default=600, type=int, help="Timeout in seconds.")
 @click.option("--max-output", default=50000, type=int, help="Maximum output characters to print.")
+@click.option("--verify/--no-verify", default=True, help="Health-check the CLI before running.")
 @click.option("--dry-run", is_flag=True, help="Print the resolved command without running it.")
 def code_agent(
     agent: str,
@@ -80,6 +86,7 @@ def code_agent(
     yolo: bool,
     timeout: int,
     max_output: int,
+    verify: bool,
     dry_run: bool,
 ) -> None:
     """Run Claude Code, Codex CLI, or Gemini CLI from Prompture."""
@@ -113,6 +120,7 @@ def code_agent(
         model=model,
         timeout=timeout,
         max_output_chars=max_output,
+        verify_binary=verify,
     )
 
     if result.output:

--- a/prompture/cli/cli.py
+++ b/prompture/cli/cli.py
@@ -1,4 +1,5 @@
 import json
+import shlex
 
 import click
 
@@ -37,6 +38,87 @@ def _build_drivers(providers: list[str]) -> dict[str, object]:
         except Exception as exc:
             click.echo(f"Warning: could not load driver for '{name}': {exc}", err=True)
     return drivers
+
+
+@cli.command("coding-agents")
+@click.option("--json", "json_output", is_flag=True, help="Output machine-readable JSON.")
+def coding_agents(json_output: bool) -> None:
+    """List detected local coding-agent CLIs."""
+    from dataclasses import asdict
+
+    from ..infra import get_available_coding_agents
+
+    agents = get_available_coding_agents()
+    if json_output:
+        click.echo(json.dumps([asdict(agent) for agent in agents], indent=2))
+        return
+
+    for agent in agents:
+        status = "available" if agent.available else "missing"
+        source = "custom" if agent.custom_path else "PATH"
+        click.echo(f"{agent.id:<7} {status:<9} {source:<6} {agent.binary}")
+
+
+@cli.command("code-agent")
+@click.argument("agent", type=click.Choice(["claude", "codex", "gemini"]))
+@click.argument("task", nargs=-1, required=True)
+@click.option("--cwd", default=".", type=click.Path(exists=True, file_okay=False), help="Working directory.")
+@click.option("--model", default=None, help="Model passed through to the agent CLI.")
+@click.option("--binary", default=None, help="Explicit binary path for this run.")
+@click.option("--auto-approve", is_flag=True, help="Avoid repeated approval prompts where the CLI supports it.")
+@click.option("--yolo", is_flag=True, help="Use the CLI's dangerous no-approval/no-sandbox mode.")
+@click.option("--timeout", default=600, type=int, help="Timeout in seconds.")
+@click.option("--max-output", default=50000, type=int, help="Maximum output characters to print.")
+@click.option("--dry-run", is_flag=True, help="Print the resolved command without running it.")
+def code_agent(
+    agent: str,
+    task: tuple[str, ...],
+    cwd: str,
+    model: str | None,
+    binary: str | None,
+    auto_approve: bool,
+    yolo: bool,
+    timeout: int,
+    max_output: int,
+    dry_run: bool,
+) -> None:
+    """Run Claude Code, Codex CLI, or Gemini CLI from Prompture."""
+    from ..infra import build_coding_agent_command, run_coding_agent
+
+    if auto_approve and yolo:
+        click.echo("Error: choose either --auto-approve or --yolo, not both.", err=True)
+        raise SystemExit(2)
+
+    approval_mode = "yolo" if yolo else ("auto" if auto_approve else "default")
+    task_text = " ".join(task).strip()
+
+    if dry_run:
+        command = build_coding_agent_command(
+            agent,
+            task_text,
+            cwd=cwd,
+            approval_mode=approval_mode,
+            binary=binary,
+            model=model,
+        )
+        click.echo(shlex.join(command.argv))
+        return
+
+    result = run_coding_agent(
+        agent,
+        task_text,
+        cwd=cwd,
+        approval_mode=approval_mode,
+        binary=binary,
+        model=model,
+        timeout=timeout,
+        max_output_chars=max_output,
+    )
+
+    if result.output:
+        click.echo(result.output)
+    if not result.ok:
+        raise SystemExit(result.returncode if result.returncode > 0 else 1)
 
 
 @cli.command("test-suite")

--- a/prompture/cli/server.py
+++ b/prompture/cli/server.py
@@ -819,6 +819,7 @@ def create_app(
         timeout: int = 600
         stream: bool = False
         output_format: str = "text"
+        session_id: Optional[str] = None
 
     @app.post("/v1/coding-agents/run")
     async def run_coding_agent_endpoint(req: CodingAgentRunRequest, _: None = Depends(_verify_api_key)) -> Any:
@@ -851,6 +852,7 @@ def create_app(
                         approval_mode=req.approval_mode,  # type: ignore[arg-type]
                         model=req.model,
                         extra_args=req.extra_args,
+                        session_id=req.session_id,
                     ):
                         yield {"data": json.dumps(asdict(event), default=str)}
                 except ValueError as exc:
@@ -869,6 +871,7 @@ def create_app(
                 extra_args=req.extra_args,
                 timeout=req.timeout,
                 output_format=req.output_format,
+                session_id=req.session_id,
             )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/prompture/cli/server.py
+++ b/prompture/cli/server.py
@@ -8,7 +8,9 @@ OpenAI SDK, …) need:
   optional server-side tool execution (sandbox / web search).
 * ``POST /v1/completions`` — legacy completions, thin wrapper around chat.
 * ``GET  /v1/models`` — list models discovered by Prompture.
-* ``GET  /v1/coding-agents`` — list local Claude/Codex/Gemini CLIs.
+* ``GET  /v1/coding-agents`` — list local coding-agent CLIs.
+* ``POST /v1/coding-agents/run`` — run a local coding-agent CLI; SSE-streams
+  normalised events when ``stream=true``.
 * ``POST /v1/embeddings`` — routes to ``get_embedding_driver_for_model``.
 
 Plus Prompture-native endpoints:
@@ -806,6 +808,78 @@ def create_app(
                 "coding_agents": [agent["id"] for agent in agent_objects if agent["available"]],
             }
         )
+
+    class CodingAgentRunRequest(BaseModel):
+        agent: str
+        task: str
+        cwd: Optional[str] = None
+        approval_mode: str = "default"
+        model: Optional[str] = None
+        extra_args: Optional[list[str]] = None
+        timeout: int = 600
+        stream: bool = False
+        output_format: str = "text"
+
+    @app.post("/v1/coding-agents/run")
+    async def run_coding_agent_endpoint(req: CodingAgentRunRequest, _: None = Depends(_verify_api_key)) -> Any:
+        """Run a local coding-agent CLI and return its output.
+
+        When ``stream=true`` the response is an SSE stream of normalised
+        :class:`CodingAgentEvent` objects (requires ``output_format='json'``,
+        which is forced on); when ``stream=false`` the agent runs to
+        completion and the JSON body mirrors :class:`CodingAgentRunResult`.
+        """
+        from dataclasses import asdict
+
+        from ..infra.coding_agents import arun_coding_agent, astream_coding_agent
+
+        if req.stream:
+            try:
+                from sse_starlette.sse import EventSourceResponse
+            except ImportError as exc:
+                raise HTTPException(
+                    status_code=501,
+                    detail="Streaming requires sse-starlette: pip install prompture[serve]",
+                ) from exc
+
+            async def event_generator() -> Any:
+                try:
+                    async for event in astream_coding_agent(
+                        req.agent,
+                        req.task,
+                        cwd=req.cwd,
+                        approval_mode=req.approval_mode,  # type: ignore[arg-type]
+                        model=req.model,
+                        extra_args=req.extra_args,
+                    ):
+                        yield {"data": json.dumps(asdict(event), default=str)}
+                except ValueError as exc:
+                    yield {"data": json.dumps({"type": "error", "error": str(exc)})}
+                yield {"data": json.dumps({"type": "stream_end"})}
+
+            return EventSourceResponse(event_generator(), media_type="text/event-stream")
+
+        try:
+            result = await arun_coding_agent(
+                req.agent,
+                req.task,
+                cwd=req.cwd,
+                approval_mode=req.approval_mode,
+                model=req.model,
+                extra_args=req.extra_args,
+                timeout=req.timeout,
+                output_format=req.output_format,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except RuntimeError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+        payload = asdict(result)
+        # tuples → lists; dataclass events are already dicts via asdict
+        payload["events"] = list(payload.get("events") or [])
+        payload["object"] = "coding_agent_run"
+        return JSONResponse(payload)
 
     @app.get("/v1/models")
     async def list_models() -> Any:

--- a/prompture/cli/server.py
+++ b/prompture/cli/server.py
@@ -8,6 +8,7 @@ OpenAI SDK, …) need:
   optional server-side tool execution (sandbox / web search).
 * ``POST /v1/completions`` — legacy completions, thin wrapper around chat.
 * ``GET  /v1/models`` — list models discovered by Prompture.
+* ``GET  /v1/coding-agents`` — list local Claude/Codex/Gemini CLIs.
 * ``POST /v1/embeddings`` — routes to ``get_embedding_driver_for_model``.
 
 Plus Prompture-native endpoints:
@@ -782,6 +783,29 @@ def create_app(
         )
 
     # ---- OpenAI-compatible: /v1/models ----
+
+    @app.get("/v1/coding-agents")
+    async def list_coding_agents(verify: bool = True) -> Any:
+        """List available local coding-agent CLIs."""
+        from dataclasses import asdict
+
+        from ..infra.discovery import get_available_coding_agents
+
+        agents = get_available_coding_agents(verify=verify)
+        agent_objects: list[dict[str, Any]] = []
+        for agent in agents:
+            item = asdict(agent)
+            item["object"] = "coding_agent"
+            agent_objects.append(item)
+
+        return JSONResponse(
+            {
+                "object": "list",
+                "data": agent_objects,
+                # Legacy/simple field for small app integrations.
+                "coding_agents": [agent["id"] for agent in agent_objects if agent["available"]],
+            }
+        )
 
     @app.get("/v1/models")
     async def list_models() -> Any:

--- a/prompture/infra/__init__.py
+++ b/prompture/infra/__init__.py
@@ -29,6 +29,10 @@ from .capabilities import (
     register_model,
     register_provider,
 )
+from .coding_agent_events import (
+    CodingAgentEvent,
+    parse_claude_stream_json_lines,
+)
 from .coding_agent_specs import (
     CODING_AGENT_SPECS,
     CodingAgentSpec,
@@ -96,6 +100,7 @@ __all__ = [
     "BudgetState",
     "CacheBackend",
     "CodingAgentCommand",
+    "CodingAgentEvent",
     "CodingAgentExecutable",
     "CodingAgentInfo",
     "CodingAgentRunResult",
@@ -148,6 +153,7 @@ __all__ = [
     "get_recently_used_models",
     "get_tracker",
     "override_capabilities",
+    "parse_claude_stream_json_lines",
     "refresh_rates_cache",
     "register_model",
     "register_provider",

--- a/prompture/infra/__init__.py
+++ b/prompture/infra/__init__.py
@@ -31,15 +31,18 @@ from .capabilities import (
 )
 from .cost_mixin import AudioCostMixin, EmbeddingCostMixin, VideoCostMixin
 from .discovery import (
+    CodingAgentInfo,
     clear_discovery_cache,
     display_available_models,
     get_available_audio_models,
+    get_available_coding_agents,
     get_available_embedding_models,
     get_available_image_gen_models,
     get_available_models,
     get_available_moderation_models,
     get_available_rerank_models,
     get_available_video_gen_models,
+    resolve_coding_agent_binary,
 )
 from .ledger import ModelUsageLedger, get_recently_used_models
 from .logging import JSONFormatter, configure_logging
@@ -67,6 +70,7 @@ __all__ = [
     "BudgetPolicy",
     "BudgetState",
     "CacheBackend",
+    "CodingAgentInfo",
     "CostEstimate",
     "DriverCallbacks",
     "EmbeddingCostMixin",
@@ -94,6 +98,7 @@ __all__ = [
     "estimate_cost",
     "estimate_tokens",
     "get_available_audio_models",
+    "get_available_coding_agents",
     "get_available_embedding_models",
     "get_available_image_gen_models",
     "get_available_models",
@@ -114,5 +119,6 @@ __all__ = [
     "register_model",
     "register_provider",
     "resolve_budget_policy",
+    "resolve_coding_agent_binary",
     "settings",
 ]

--- a/prompture/infra/__init__.py
+++ b/prompture/infra/__init__.py
@@ -29,6 +29,16 @@ from .capabilities import (
     register_model,
     register_provider,
 )
+from .coding_agent_specs import (
+    CODING_AGENT_SPECS,
+    CodingAgentSpec,
+)
+from .coding_agent_specs import (
+    get_spec as get_coding_agent_spec,
+)
+from .coding_agent_specs import (
+    supported_agent_ids as supported_coding_agent_ids,
+)
 from .coding_agents import (
     ApprovalMode,
     CodingAgentCommand,
@@ -79,6 +89,7 @@ from .settings import settings
 from .tracker import configure_tracker, get_tracker
 
 __all__ = [
+    "CODING_AGENT_SPECS",
     "ApprovalMode",
     "AudioCostMixin",
     "BudgetPolicy",
@@ -88,6 +99,7 @@ __all__ = [
     "CodingAgentExecutable",
     "CodingAgentInfo",
     "CodingAgentRunResult",
+    "CodingAgentSpec",
     "CostEstimate",
     "DriverCallbacks",
     "EmbeddingCostMixin",
@@ -127,6 +139,7 @@ __all__ = [
     "get_cache",
     "get_capabilities",
     "get_coding_agent_executable_candidates",
+    "get_coding_agent_spec",
     "get_compatibility_matrix",
     "get_model_capabilities",
     "get_model_info",
@@ -143,6 +156,7 @@ __all__ = [
     "resolve_coding_agent_executable",
     "run_coding_agent",
     "settings",
+    "supported_coding_agent_ids",
     "verify_coding_agent_binary",
     "verify_coding_agent_executable",
 ]

--- a/prompture/infra/__init__.py
+++ b/prompture/infra/__init__.py
@@ -39,6 +39,7 @@ from .coding_agents import (
 )
 from .cost_mixin import AudioCostMixin, EmbeddingCostMixin, VideoCostMixin
 from .discovery import (
+    CodingAgentExecutable,
     CodingAgentInfo,
     clear_discovery_cache,
     display_available_models,
@@ -50,7 +51,11 @@ from .discovery import (
     get_available_moderation_models,
     get_available_rerank_models,
     get_available_video_gen_models,
+    get_coding_agent_executable_candidates,
     resolve_coding_agent_binary,
+    resolve_coding_agent_executable,
+    verify_coding_agent_binary,
+    verify_coding_agent_executable,
 )
 from .ledger import ModelUsageLedger, get_recently_used_models
 from .logging import JSONFormatter, configure_logging
@@ -80,6 +85,7 @@ __all__ = [
     "BudgetState",
     "CacheBackend",
     "CodingAgentCommand",
+    "CodingAgentExecutable",
     "CodingAgentInfo",
     "CodingAgentRunResult",
     "CostEstimate",
@@ -120,6 +126,7 @@ __all__ = [
     "get_available_video_gen_models",
     "get_cache",
     "get_capabilities",
+    "get_coding_agent_executable_candidates",
     "get_compatibility_matrix",
     "get_model_capabilities",
     "get_model_info",
@@ -133,6 +140,9 @@ __all__ = [
     "register_provider",
     "resolve_budget_policy",
     "resolve_coding_agent_binary",
+    "resolve_coding_agent_executable",
     "run_coding_agent",
     "settings",
+    "verify_coding_agent_binary",
+    "verify_coding_agent_executable",
 ]

--- a/prompture/infra/__init__.py
+++ b/prompture/infra/__init__.py
@@ -29,6 +29,14 @@ from .capabilities import (
     register_model,
     register_provider,
 )
+from .coding_agents import (
+    ApprovalMode,
+    CodingAgentCommand,
+    CodingAgentRunResult,
+    arun_coding_agent,
+    build_coding_agent_command,
+    run_coding_agent,
+)
 from .cost_mixin import AudioCostMixin, EmbeddingCostMixin, VideoCostMixin
 from .discovery import (
     CodingAgentInfo,
@@ -66,11 +74,14 @@ from .settings import settings
 from .tracker import configure_tracker, get_tracker
 
 __all__ = [
+    "ApprovalMode",
     "AudioCostMixin",
     "BudgetPolicy",
     "BudgetState",
     "CacheBackend",
+    "CodingAgentCommand",
     "CodingAgentInfo",
+    "CodingAgentRunResult",
     "CostEstimate",
     "DriverCallbacks",
     "EmbeddingCostMixin",
@@ -86,6 +97,8 @@ __all__ = [
     "TukuyLLMBackend",
     "UsageSession",
     "VideoCostMixin",
+    "arun_coding_agent",
+    "build_coding_agent_command",
     "clear_discovery_cache",
     "clear_overrides",
     "configure_cache",
@@ -120,5 +133,6 @@ __all__ = [
     "register_provider",
     "resolve_budget_policy",
     "resolve_coding_agent_binary",
+    "run_coding_agent",
     "settings",
 ]

--- a/prompture/infra/__init__.py
+++ b/prompture/infra/__init__.py
@@ -32,6 +32,7 @@ from .capabilities import (
 from .coding_agent_events import (
     CodingAgentEvent,
     parse_claude_stream_json_lines,
+    parse_codex_json_lines,
 )
 from .coding_agent_specs import (
     CODING_AGENT_SPECS,
@@ -156,6 +157,7 @@ __all__ = [
     "get_tracker",
     "override_capabilities",
     "parse_claude_stream_json_lines",
+    "parse_codex_json_lines",
     "refresh_rates_cache",
     "register_model",
     "register_provider",

--- a/prompture/infra/__init__.py
+++ b/prompture/infra/__init__.py
@@ -31,6 +31,7 @@ from .capabilities import (
 )
 from .coding_agent_events import (
     CodingAgentEvent,
+    detect_question,
     parse_claude_stream_json_lines,
     parse_codex_json_lines,
 )
@@ -131,6 +132,7 @@ __all__ = [
     "configure_logging",
     "configure_tracker",
     "create_tukuy_backend",
+    "detect_question",
     "display_available_models",
     "enforce_budget",
     "estimate_call_cost",

--- a/prompture/infra/__init__.py
+++ b/prompture/infra/__init__.py
@@ -48,6 +48,7 @@ from .coding_agents import (
     CodingAgentCommand,
     CodingAgentRunResult,
     arun_coding_agent,
+    astream_coding_agent,
     build_coding_agent_command,
     run_coding_agent,
 )
@@ -121,6 +122,7 @@ __all__ = [
     "UsageSession",
     "VideoCostMixin",
     "arun_coding_agent",
+    "astream_coding_agent",
     "build_coding_agent_command",
     "clear_discovery_cache",
     "clear_overrides",

--- a/prompture/infra/coding_agent_events.py
+++ b/prompture/infra/coding_agent_events.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import re
 from collections.abc import Iterable, Iterator, Mapping
 from typing import Any, Literal
 
@@ -19,6 +20,7 @@ EventType = Literal[
     "message",
     "tool_call",
     "tool_result",
+    "question",
     "done",
     "error",
 ]
@@ -38,6 +40,7 @@ class CodingAgentEvent:
     output_tokens: int | None = None
     duration_ms: int | None = None
     error: str | None = None
+    choices: tuple[str, ...] | None = None
     raw: Mapping[str, Any] | None = None
 
 
@@ -79,6 +82,9 @@ def _claude_event_to_events(obj: Mapping[str, Any]) -> Iterator[CodingAgentEvent
             error=text if is_error else None,
             raw=obj,
         )
+        question = _question_event_for_text(text, obj)
+        if question is not None:
+            yield question
         return
     if kind in ("assistant", "user"):
         message = obj.get("message") if isinstance(obj.get("message"), dict) else {}
@@ -91,6 +97,9 @@ def _claude_event_to_events(obj: Mapping[str, Any]) -> Iterator[CodingAgentEvent
             part_type = part.get("type")
             if part_type == "text" and isinstance(part.get("text"), str):
                 yield CodingAgentEvent(type="message", text=part["text"], raw=obj)
+                question = _question_event_for_text(part["text"], obj)
+                if question is not None:
+                    yield question
             elif part_type == "tool_use":
                 yield CodingAgentEvent(
                     type="tool_call",
@@ -156,6 +165,9 @@ def _codex_event_to_events(obj: Mapping[str, Any]) -> Iterator[CodingAgentEvent]
         text = msg.get("message")
         if isinstance(text, str):
             yield CodingAgentEvent(type="message", text=text, raw=obj)
+            question = _question_event_for_text(text, obj)
+            if question is not None:
+                yield question
         return
     if kind == "agent_message_delta":
         delta = msg.get("delta")
@@ -216,6 +228,66 @@ def _codex_event_to_events(obj: Mapping[str, Any]) -> Iterator[CodingAgentEvent]
             raw=obj,
         )
         return
+
+
+_QUESTION_PHRASE_RE = re.compile(
+    r"\b(would you like|do you want|should i|which (?:one|option|of|approach)|"
+    r"can you (?:clarify|confirm|specify)|please (?:clarify|confirm|specify|choose)|"
+    r"how would you like|what would you like|let me know which)",
+    re.IGNORECASE,
+)
+
+_CHOICE_LINE_RE = re.compile(
+    r"^\s*(?:"
+    r"(?P<num>\d+)[.\):]\s+|"     # 1. foo  1) foo  1: foo
+    r"[-*•]\s+|"                  # - foo   * foo   • foo
+    r"\([a-zA-Z]\)\s+|"           # (a) foo
+    r"[a-zA-Z][.\)]\s+"           # a) foo  a. foo
+    r")(?P<body>.+\S)\s*$"
+)
+
+
+def detect_question(text: str | None) -> tuple[bool, tuple[str, ...] | None]:
+    """Return ``(is_question, choices)`` for an assistant message text.
+
+    A message is treated as a question when it ends in ``?`` or contains a
+    question-phrase trigger ("do you want", "would you like", …). Choices
+    are extracted from numbered, bulleted, or lettered list lines — at least
+    two such lines must appear together for them to count as choices.
+    """
+    if not text:
+        return False, None
+    stripped = text.rstrip()
+    if not stripped:
+        return False, None
+
+    is_question = stripped.endswith("?") or bool(_QUESTION_PHRASE_RE.search(stripped))
+
+    choices: list[str] = []
+    consecutive: list[str] = []
+    for raw_line in stripped.splitlines():
+        match = _CHOICE_LINE_RE.match(raw_line)
+        if match:
+            consecutive.append(match.group("body").strip())
+        else:
+            if len(consecutive) >= 2:
+                choices.extend(consecutive)
+            consecutive = []
+    if len(consecutive) >= 2:
+        choices.extend(consecutive)
+
+    # Choices in the absence of a `?` or phrase trigger don't make a question.
+    if choices and not is_question:
+        is_question = True
+
+    return is_question, tuple(choices) if choices else None
+
+
+def _question_event_for_text(text: str | None, raw: Mapping[str, Any] | None) -> CodingAgentEvent | None:
+    is_q, choices = detect_question(text)
+    if not is_q:
+        return None
+    return CodingAgentEvent(type="question", text=text, choices=choices, raw=raw)
 
 
 def _safe_float(value: Any) -> float | None:

--- a/prompture/infra/coding_agent_events.py
+++ b/prompture/infra/coding_agent_events.py
@@ -120,6 +120,104 @@ def _flatten_tool_result(content: Any) -> str | None:
     return None
 
 
+def parse_codex_json_lines(lines: Iterable[str]) -> Iterator[CodingAgentEvent]:
+    """Yield :class:`CodingAgentEvent` per ``codex exec --json`` line.
+
+    Codex emits one JSON object per event with shape
+    ``{"id": "...", "msg": {"type": ..., ...}}``. We translate the subset
+    of event types that have analogues in the normalised event model.
+    """
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            obj = json.loads(stripped)
+        except json.JSONDecodeError:
+            yield CodingAgentEvent(
+                type="error",
+                error=f"invalid JSON line: {stripped[:200]}",
+            )
+            continue
+        if not isinstance(obj, dict):
+            continue
+        yield from _codex_event_to_events(obj)
+
+
+def _codex_event_to_events(obj: Mapping[str, Any]) -> Iterator[CodingAgentEvent]:
+    msg = obj.get("msg") if isinstance(obj.get("msg"), dict) else None
+    if msg is None:
+        return
+    kind = msg.get("type")
+    if kind == "task_started":
+        yield CodingAgentEvent(type="system", raw=obj)
+        return
+    if kind == "agent_message":
+        text = msg.get("message")
+        if isinstance(text, str):
+            yield CodingAgentEvent(type="message", text=text, raw=obj)
+        return
+    if kind == "agent_message_delta":
+        delta = msg.get("delta")
+        if isinstance(delta, str) and delta:
+            yield CodingAgentEvent(type="message", text=delta, raw=obj)
+        return
+    if kind == "exec_command_begin":
+        command = msg.get("command")
+        yield CodingAgentEvent(
+            type="tool_call",
+            tool_name="exec",
+            tool_input={"command": command} if command is not None else None,
+            raw=obj,
+        )
+        return
+    if kind == "exec_command_end":
+        chunks = []
+        for key in ("stdout", "stderr"):
+            value = msg.get(key)
+            if isinstance(value, str) and value:
+                chunks.append(value)
+        yield CodingAgentEvent(
+            type="tool_result",
+            tool_output="\n".join(chunks) if chunks else None,
+            raw=obj,
+        )
+        return
+    if kind in ("mcp_tool_call_begin",):
+        yield CodingAgentEvent(
+            type="tool_call",
+            tool_name=msg.get("tool") if isinstance(msg.get("tool"), str) else None,
+            tool_input=msg.get("arguments") if isinstance(msg.get("arguments"), dict) else None,
+            raw=obj,
+        )
+        return
+    if kind in ("mcp_tool_call_end",):
+        result = msg.get("result")
+        yield CodingAgentEvent(
+            type="tool_result",
+            tool_output=result if isinstance(result, str) else None,
+            raw=obj,
+        )
+        return
+    if kind == "task_complete":
+        usage = msg.get("token_usage") if isinstance(msg.get("token_usage"), dict) else {}
+        yield CodingAgentEvent(
+            type="done",
+            text=msg.get("last_agent_message") if isinstance(msg.get("last_agent_message"), str) else None,
+            input_tokens=_safe_int(usage.get("input_tokens")),
+            output_tokens=_safe_int(usage.get("output_tokens")),
+            raw=obj,
+        )
+        return
+    if kind == "error":
+        yield CodingAgentEvent(
+            type="error",
+            error=msg.get("message") if isinstance(msg.get("message"), str) else "codex error",
+            raw=obj,
+        )
+        return
+
+
 def _safe_float(value: Any) -> float | None:
     if isinstance(value, (int, float)):
         return float(value)

--- a/prompture/infra/coding_agent_events.py
+++ b/prompture/infra/coding_agent_events.py
@@ -1,0 +1,134 @@
+"""Structured events emitted by coding-agent CLIs.
+
+Coding-agent CLIs that support a JSON event stream (Claude Code's
+``--output-format stream-json``, Codex's ``--json``, etc.) emit one JSON
+object per event. Each per-CLI parser in this module normalises that stream
+into a sequence of :class:`CodingAgentEvent` instances so callers don't have
+to know each CLI's payload shape.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from collections.abc import Iterable, Iterator, Mapping
+from typing import Any, Literal
+
+EventType = Literal[
+    "system",
+    "message",
+    "tool_call",
+    "tool_result",
+    "done",
+    "error",
+]
+
+
+@dataclasses.dataclass(frozen=True)
+class CodingAgentEvent:
+    """One normalised event emitted by a coding-agent CLI."""
+
+    type: EventType
+    text: str | None = None
+    tool_name: str | None = None
+    tool_input: Mapping[str, Any] | None = None
+    tool_output: str | None = None
+    cost_usd: float | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    duration_ms: int | None = None
+    error: str | None = None
+    raw: Mapping[str, Any] | None = None
+
+
+def parse_claude_stream_json_lines(lines: Iterable[str]) -> Iterator[CodingAgentEvent]:
+    """Yield :class:`CodingAgentEvent` per ``claude --output-format stream-json`` line."""
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            obj = json.loads(stripped)
+        except json.JSONDecodeError:
+            yield CodingAgentEvent(
+                type="error",
+                error=f"invalid JSON line: {stripped[:200]}",
+            )
+            continue
+        if not isinstance(obj, dict):
+            continue
+        yield from _claude_event_to_events(obj)
+
+
+def _claude_event_to_events(obj: Mapping[str, Any]) -> Iterator[CodingAgentEvent]:
+    kind = obj.get("type")
+    if kind == "system":
+        yield CodingAgentEvent(type="system", raw=obj)
+        return
+    if kind == "result":
+        usage = obj.get("usage") if isinstance(obj.get("usage"), dict) else {}
+        is_error = bool(obj.get("is_error"))
+        text = obj.get("result") if isinstance(obj.get("result"), str) else None
+        yield CodingAgentEvent(
+            type="done",
+            text=text,
+            cost_usd=_safe_float(obj.get("total_cost_usd")),
+            input_tokens=_safe_int(usage.get("input_tokens")),
+            output_tokens=_safe_int(usage.get("output_tokens")),
+            duration_ms=_safe_int(obj.get("duration_ms")),
+            error=text if is_error else None,
+            raw=obj,
+        )
+        return
+    if kind in ("assistant", "user"):
+        message = obj.get("message") if isinstance(obj.get("message"), dict) else {}
+        content = message.get("content")
+        if not isinstance(content, list):
+            return
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            part_type = part.get("type")
+            if part_type == "text" and isinstance(part.get("text"), str):
+                yield CodingAgentEvent(type="message", text=part["text"], raw=obj)
+            elif part_type == "tool_use":
+                yield CodingAgentEvent(
+                    type="tool_call",
+                    tool_name=part.get("name") if isinstance(part.get("name"), str) else None,
+                    tool_input=part.get("input") if isinstance(part.get("input"), dict) else None,
+                    raw=obj,
+                )
+            elif part_type == "tool_result":
+                yield CodingAgentEvent(
+                    type="tool_result",
+                    tool_output=_flatten_tool_result(part.get("content")),
+                    raw=obj,
+                )
+
+
+def _flatten_tool_result(content: Any) -> str | None:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        chunks: list[str] = []
+        for item in content:
+            if isinstance(item, dict) and isinstance(item.get("text"), str):
+                chunks.append(item["text"])
+            elif isinstance(item, str):
+                chunks.append(item)
+        return "\n".join(chunks) if chunks else None
+    return None
+
+
+def _safe_float(value: Any) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _safe_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None

--- a/prompture/infra/coding_agent_events.py
+++ b/prompture/infra/coding_agent_events.py
@@ -41,6 +41,7 @@ class CodingAgentEvent:
     duration_ms: int | None = None
     error: str | None = None
     choices: tuple[str, ...] | None = None
+    session_id: str | None = None
     raw: Mapping[str, Any] | None = None
 
 
@@ -66,12 +67,18 @@ def parse_claude_stream_json_lines(lines: Iterable[str]) -> Iterator[CodingAgent
 def _claude_event_to_events(obj: Mapping[str, Any]) -> Iterator[CodingAgentEvent]:
     kind = obj.get("type")
     if kind == "system":
-        yield CodingAgentEvent(type="system", raw=obj)
+        sid = obj.get("session_id")
+        yield CodingAgentEvent(
+            type="system",
+            session_id=sid if isinstance(sid, str) else None,
+            raw=obj,
+        )
         return
     if kind == "result":
         usage = obj.get("usage") if isinstance(obj.get("usage"), dict) else {}
         is_error = bool(obj.get("is_error"))
         text = obj.get("result") if isinstance(obj.get("result"), str) else None
+        sid = obj.get("session_id")
         yield CodingAgentEvent(
             type="done",
             text=text,
@@ -80,6 +87,7 @@ def _claude_event_to_events(obj: Mapping[str, Any]) -> Iterator[CodingAgentEvent
             output_tokens=_safe_int(usage.get("output_tokens")),
             duration_ms=_safe_int(obj.get("duration_ms")),
             error=text if is_error else None,
+            session_id=sid if isinstance(sid, str) else None,
             raw=obj,
         )
         question = _question_event_for_text(text, obj)
@@ -158,8 +166,12 @@ def _codex_event_to_events(obj: Mapping[str, Any]) -> Iterator[CodingAgentEvent]
     if msg is None:
         return
     kind = msg.get("type")
-    if kind == "task_started":
-        yield CodingAgentEvent(type="system", raw=obj)
+    if kind in ("task_started", "session_configured"):
+        # Codex emits session_id either nested in msg or at the envelope level.
+        sid = msg.get("session_id") if isinstance(msg.get("session_id"), str) else None
+        if sid is None and isinstance(obj.get("session_id"), str):
+            sid = obj["session_id"]
+        yield CodingAgentEvent(type="system", session_id=sid, raw=obj)
         return
     if kind == "agent_message":
         text = msg.get("message")

--- a/prompture/infra/coding_agent_specs.py
+++ b/prompture/infra/coding_agent_specs.py
@@ -48,6 +48,7 @@ def _build_claude_args(
     model: str | None,
     extra_args: Sequence[str],
     output_format: OutputFormat = "text",
+    session_id: str | None = None,
 ) -> list[str]:
     args = ["--print"]
     if output_format == "json":
@@ -57,6 +58,8 @@ def _build_claude_args(
         args.extend(["--output-format", "text"])
     if model:
         args.extend(["--model", model])
+    if session_id:
+        args.extend(["--resume", session_id])
     if approval_mode in {"auto", "yolo"}:
         args.append("--dangerously-skip-permissions")
     args.extend(extra_args)
@@ -71,8 +74,12 @@ def _build_codex_args(
     model: str | None,
     extra_args: Sequence[str],
     output_format: OutputFormat = "text",
+    session_id: str | None = None,
 ) -> list[str]:
-    args = ["exec"]
+    # Codex uses `exec` for a new task and `exec resume <id>` to continue one.
+    args: list[str] = ["exec"]
+    if session_id:
+        args.extend(["resume", session_id])
     if output_format == "json":
         args.append("--json")
     if model:
@@ -93,6 +100,7 @@ def _build_gemini_style_args(
     model: str | None,
     extra_args: Sequence[str],
     output_format: OutputFormat = "text",
+    session_id: str | None = None,
 ) -> list[str]:
     """Argument builder for gemini-cli and forks (e.g. Qwen Code)."""
     args: list[str] = []
@@ -112,6 +120,7 @@ def _build_aider_args(
     model: str | None,
     extra_args: Sequence[str],
     output_format: OutputFormat = "text",
+    session_id: str | None = None,
 ) -> list[str]:
     args: list[str] = []
     if model:
@@ -130,6 +139,7 @@ def _build_opencode_args(
     model: str | None,
     extra_args: Sequence[str],
     output_format: OutputFormat = "text",
+    session_id: str | None = None,
 ) -> list[str]:
     args = ["run"]
     if model:
@@ -146,6 +156,7 @@ def _build_cursor_agent_args(
     model: str | None,
     extra_args: Sequence[str],
     output_format: OutputFormat = "text",
+    session_id: str | None = None,
 ) -> list[str]:
     args = ["-p"]
     if model:
@@ -164,6 +175,7 @@ def _build_crush_args(
     model: str | None,
     extra_args: Sequence[str],
     output_format: OutputFormat = "text",
+    session_id: str | None = None,
 ) -> list[str]:
     args = ["run"]
     if model:

--- a/prompture/infra/coding_agent_specs.py
+++ b/prompture/infra/coding_agent_specs.py
@@ -9,12 +9,16 @@ checks) and command construction read from this registry.
 from __future__ import annotations
 
 import dataclasses
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from typing import Literal
 
+from .coding_agent_events import CodingAgentEvent, parse_claude_stream_json_lines
+
 ApprovalMode = Literal["default", "auto", "yolo"]
+OutputFormat = Literal["text", "json"]
 
 BuildArgsFn = Callable[..., list[str]]
+ParseEventsFn = Callable[[Iterable[str]], Iterator[CodingAgentEvent]]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -26,6 +30,11 @@ class CodingAgentSpec:
     default_binary: str
     npm_packages: tuple[str, ...]
     build_args: BuildArgsFn
+    parse_events: ParseEventsFn | None = None
+
+    @property
+    def supports_structured_output(self) -> bool:
+        return self.parse_events is not None
 
 
 def _build_claude_args(
@@ -34,8 +43,14 @@ def _build_claude_args(
     approval_mode: ApprovalMode,
     model: str | None,
     extra_args: Sequence[str],
+    output_format: OutputFormat = "text",
 ) -> list[str]:
-    args = ["--print", "--output-format", "text"]
+    args = ["--print"]
+    if output_format == "json":
+        # Claude Code requires --verbose alongside stream-json.
+        args.extend(["--output-format", "stream-json", "--verbose"])
+    else:
+        args.extend(["--output-format", "text"])
     if model:
         args.extend(["--model", model])
     if approval_mode in {"auto", "yolo"}:
@@ -51,6 +66,7 @@ def _build_codex_args(
     approval_mode: ApprovalMode,
     model: str | None,
     extra_args: Sequence[str],
+    output_format: OutputFormat = "text",
 ) -> list[str]:
     args = ["exec"]
     if model:
@@ -70,6 +86,7 @@ def _build_gemini_style_args(
     approval_mode: ApprovalMode,
     model: str | None,
     extra_args: Sequence[str],
+    output_format: OutputFormat = "text",
 ) -> list[str]:
     """Argument builder for gemini-cli and forks (e.g. Qwen Code)."""
     args: list[str] = []
@@ -88,6 +105,7 @@ def _build_aider_args(
     approval_mode: ApprovalMode,
     model: str | None,
     extra_args: Sequence[str],
+    output_format: OutputFormat = "text",
 ) -> list[str]:
     args: list[str] = []
     if model:
@@ -105,6 +123,7 @@ def _build_opencode_args(
     approval_mode: ApprovalMode,
     model: str | None,
     extra_args: Sequence[str],
+    output_format: OutputFormat = "text",
 ) -> list[str]:
     args = ["run"]
     if model:
@@ -120,6 +139,7 @@ def _build_cursor_agent_args(
     approval_mode: ApprovalMode,
     model: str | None,
     extra_args: Sequence[str],
+    output_format: OutputFormat = "text",
 ) -> list[str]:
     args = ["-p"]
     if model:
@@ -137,6 +157,7 @@ def _build_crush_args(
     approval_mode: ApprovalMode,
     model: str | None,
     extra_args: Sequence[str],
+    output_format: OutputFormat = "text",
 ) -> list[str]:
     args = ["run"]
     if model:
@@ -155,6 +176,7 @@ CODING_AGENT_SPECS: dict[str, CodingAgentSpec] = {
         default_binary="claude",
         npm_packages=("@anthropic-ai/claude-code",),
         build_args=_build_claude_args,
+        parse_events=parse_claude_stream_json_lines,
     ),
     "codex": CodingAgentSpec(
         id="codex",

--- a/prompture/infra/coding_agent_specs.py
+++ b/prompture/infra/coding_agent_specs.py
@@ -1,0 +1,126 @@
+"""Registry of supported local coding-agent CLIs.
+
+Each :class:`CodingAgentSpec` bundles the metadata needed to discover, verify,
+and invoke a coding-agent CLI. Adding a new agent is a single registration in
+:data:`CODING_AGENT_SPECS` — discovery (PATH + npm package entrypoints + health
+checks) and command construction read from this registry.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Callable, Sequence
+from typing import Literal
+
+ApprovalMode = Literal["default", "auto", "yolo"]
+
+BuildArgsFn = Callable[..., list[str]]
+
+
+@dataclasses.dataclass(frozen=True)
+class CodingAgentSpec:
+    """Static description of a supported coding-agent CLI."""
+
+    id: str
+    display_name: str
+    default_binary: str
+    npm_packages: tuple[str, ...]
+    build_args: BuildArgsFn
+
+
+def _build_claude_args(
+    task: str,
+    *,
+    approval_mode: ApprovalMode,
+    model: str | None,
+    extra_args: Sequence[str],
+) -> list[str]:
+    args = ["--print", "--output-format", "text"]
+    if model:
+        args.extend(["--model", model])
+    if approval_mode == "auto":
+        args.extend(["--permission-mode", "dontAsk"])
+    elif approval_mode == "yolo":
+        args.append("--dangerously-skip-permissions")
+    args.extend(extra_args)
+    args.append(task)
+    return args
+
+
+def _build_codex_args(
+    task: str,
+    *,
+    approval_mode: ApprovalMode,
+    model: str | None,
+    extra_args: Sequence[str],
+) -> list[str]:
+    args = ["exec"]
+    if model:
+        args.extend(["--model", model])
+    if approval_mode == "auto":
+        args.extend(["--sandbox", "workspace-write", "--ask-for-approval", "never"])
+    elif approval_mode == "yolo":
+        args.append("--dangerously-bypass-approvals-and-sandbox")
+    args.extend(extra_args)
+    args.append(task)
+    return args
+
+
+def _build_gemini_style_args(
+    task: str,
+    *,
+    approval_mode: ApprovalMode,
+    model: str | None,
+    extra_args: Sequence[str],
+) -> list[str]:
+    """Argument builder for gemini-cli and forks (e.g. Qwen Code)."""
+    args: list[str] = []
+    if model:
+        args.extend(["--model", model])
+    if approval_mode in {"auto", "yolo"}:
+        args.append("-y")
+    args.extend(extra_args)
+    args.append(task)
+    return args
+
+
+CODING_AGENT_SPECS: dict[str, CodingAgentSpec] = {
+    "claude": CodingAgentSpec(
+        id="claude",
+        display_name="Claude Code",
+        default_binary="claude",
+        npm_packages=("@anthropic-ai/claude-code",),
+        build_args=_build_claude_args,
+    ),
+    "codex": CodingAgentSpec(
+        id="codex",
+        display_name="Codex CLI",
+        default_binary="codex",
+        npm_packages=("@openai/codex",),
+        build_args=_build_codex_args,
+    ),
+    "gemini": CodingAgentSpec(
+        id="gemini",
+        display_name="Gemini CLI",
+        default_binary="gemini",
+        npm_packages=("@google/gemini-cli",),
+        build_args=_build_gemini_style_args,
+    ),
+    "qwen": CodingAgentSpec(
+        id="qwen",
+        display_name="Qwen Code",
+        default_binary="qwen",
+        npm_packages=("@qwen-code/qwen-code",),
+        build_args=_build_gemini_style_args,
+    ),
+}
+
+
+def get_spec(agent_id: str) -> CodingAgentSpec | None:
+    """Return the spec for ``agent_id`` or ``None`` if unknown."""
+    return CODING_AGENT_SPECS.get(agent_id)
+
+
+def supported_agent_ids() -> tuple[str, ...]:
+    """Return the tuple of registered agent ids."""
+    return tuple(CODING_AGENT_SPECS.keys())

--- a/prompture/infra/coding_agent_specs.py
+++ b/prompture/infra/coding_agent_specs.py
@@ -12,7 +12,11 @@ import dataclasses
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from typing import Literal
 
-from .coding_agent_events import CodingAgentEvent, parse_claude_stream_json_lines
+from .coding_agent_events import (
+    CodingAgentEvent,
+    parse_claude_stream_json_lines,
+    parse_codex_json_lines,
+)
 
 ApprovalMode = Literal["default", "auto", "yolo"]
 OutputFormat = Literal["text", "json"]
@@ -69,6 +73,8 @@ def _build_codex_args(
     output_format: OutputFormat = "text",
 ) -> list[str]:
     args = ["exec"]
+    if output_format == "json":
+        args.append("--json")
     if model:
         args.extend(["--model", model])
     if approval_mode == "auto":
@@ -184,6 +190,7 @@ CODING_AGENT_SPECS: dict[str, CodingAgentSpec] = {
         default_binary="codex",
         npm_packages=("@openai/codex",),
         build_args=_build_codex_args,
+        parse_events=parse_codex_json_lines,
     ),
     "gemini": CodingAgentSpec(
         id="gemini",

--- a/prompture/infra/coding_agent_specs.py
+++ b/prompture/infra/coding_agent_specs.py
@@ -38,9 +38,7 @@ def _build_claude_args(
     args = ["--print", "--output-format", "text"]
     if model:
         args.extend(["--model", model])
-    if approval_mode == "auto":
-        args.extend(["--permission-mode", "dontAsk"])
-    elif approval_mode == "yolo":
+    if approval_mode in {"auto", "yolo"}:
         args.append("--dangerously-skip-permissions")
     args.extend(extra_args)
     args.append(task)
@@ -84,6 +82,72 @@ def _build_gemini_style_args(
     return args
 
 
+def _build_aider_args(
+    task: str,
+    *,
+    approval_mode: ApprovalMode,
+    model: str | None,
+    extra_args: Sequence[str],
+) -> list[str]:
+    args: list[str] = []
+    if model:
+        args.extend(["--model", model])
+    if approval_mode in {"auto", "yolo"}:
+        args.append("--yes-always")
+    args.extend(extra_args)
+    args.extend(["--message", task])
+    return args
+
+
+def _build_opencode_args(
+    task: str,
+    *,
+    approval_mode: ApprovalMode,
+    model: str | None,
+    extra_args: Sequence[str],
+) -> list[str]:
+    args = ["run"]
+    if model:
+        args.extend(["--model", model])
+    args.extend(extra_args)
+    args.append(task)
+    return args
+
+
+def _build_cursor_agent_args(
+    task: str,
+    *,
+    approval_mode: ApprovalMode,
+    model: str | None,
+    extra_args: Sequence[str],
+) -> list[str]:
+    args = ["-p"]
+    if model:
+        args.extend(["--model", model])
+    if approval_mode in {"auto", "yolo"}:
+        args.append("--force")
+    args.extend(extra_args)
+    args.append(task)
+    return args
+
+
+def _build_crush_args(
+    task: str,
+    *,
+    approval_mode: ApprovalMode,
+    model: str | None,
+    extra_args: Sequence[str],
+) -> list[str]:
+    args = ["run"]
+    if model:
+        args.extend(["--model", model])
+    if approval_mode in {"auto", "yolo"}:
+        args.append("--yolo")
+    args.extend(extra_args)
+    args.append(task)
+    return args
+
+
 CODING_AGENT_SPECS: dict[str, CodingAgentSpec] = {
     "claude": CodingAgentSpec(
         id="claude",
@@ -112,6 +176,34 @@ CODING_AGENT_SPECS: dict[str, CodingAgentSpec] = {
         default_binary="qwen",
         npm_packages=("@qwen-code/qwen-code",),
         build_args=_build_gemini_style_args,
+    ),
+    "aider": CodingAgentSpec(
+        id="aider",
+        display_name="Aider",
+        default_binary="aider",
+        npm_packages=(),
+        build_args=_build_aider_args,
+    ),
+    "opencode": CodingAgentSpec(
+        id="opencode",
+        display_name="OpenCode",
+        default_binary="opencode",
+        npm_packages=("opencode-ai",),
+        build_args=_build_opencode_args,
+    ),
+    "cursor-agent": CodingAgentSpec(
+        id="cursor-agent",
+        display_name="Cursor Agent",
+        default_binary="cursor-agent",
+        npm_packages=(),
+        build_args=_build_cursor_agent_args,
+    ),
+    "crush": CodingAgentSpec(
+        id="crush",
+        display_name="Crush",
+        default_binary="crush",
+        npm_packages=(),
+        build_args=_build_crush_args,
     ),
 }
 

--- a/prompture/infra/coding_agents.py
+++ b/prompture/infra/coding_agents.py
@@ -18,7 +18,42 @@ from .discovery import (
     CodingAgentExecutable,
     resolve_coding_agent_executable,
 )
+from .session import UsageSession
 from .settings import settings as _global_settings
+
+
+def _record_into_session(
+    session: UsageSession,
+    *,
+    agent_id: str,
+    model: str | None,
+    cost_usd: float | None,
+    input_tokens: int | None,
+    output_tokens: int | None,
+    duration_seconds: float,
+) -> None:
+    """Feed a coding-agent run into an existing UsageSession.
+
+    Builds the response_info shape that ``UsageSession.record`` expects so
+    coding-agent calls show up in the same per-model summary as direct LLM
+    calls. ``driver`` is namespaced as ``coding-agent/<agent>[:model]``.
+    """
+    in_tok = int(input_tokens) if input_tokens is not None else 0
+    out_tok = int(output_tokens) if output_tokens is not None else 0
+    driver_name = f"coding-agent/{agent_id}"
+    if model:
+        driver_name = f"{driver_name}:{model}"
+    response_info = {
+        "driver": driver_name,
+        "meta": {
+            "prompt_tokens": in_tok,
+            "completion_tokens": out_tok,
+            "total_tokens": in_tok + out_tok,
+            "cost": float(cost_usd) if cost_usd is not None else 0.0,
+        },
+        "elapsed_ms": duration_seconds * 1000.0,
+    }
+    session.record(response_info)
 
 CodingAgentId = str
 ApprovalMode = Literal["default", "auto", "yolo"]
@@ -263,6 +298,7 @@ def run_coding_agent(
     verify_binary: bool = True,
     verify_timeout: int = 5,
     output_format: OutputFormat = "text",
+    session: UsageSession | None = None,
 ) -> CodingAgentRunResult:
     """Run a local coding-agent CLI and return its output.
 
@@ -369,6 +405,19 @@ def run_coding_agent(
     if len(output) > max_output_chars:
         output = output[:max_output_chars] + f"\n\n... (truncated at {max_output_chars} chars)"
 
+    elapsed = time.monotonic() - start
+
+    if session is not None and not timed_out:
+        _record_into_session(
+            session,
+            agent_id=agent_id,
+            model=model,
+            cost_usd=cost_usd,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            duration_seconds=elapsed,
+        )
+
     return CodingAgentRunResult(
         agent=command.agent,
         command=command.argv,
@@ -376,7 +425,7 @@ def run_coding_agent(
         returncode=returncode,
         output=output,
         timed_out=timed_out,
-        duration_seconds=time.monotonic() - start,
+        duration_seconds=elapsed,
         events=events,
         cost_usd=cost_usd,
         input_tokens=input_tokens,

--- a/prompture/infra/coding_agents.py
+++ b/prompture/infra/coding_agents.py
@@ -11,7 +11,10 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Literal
 
-from .discovery import resolve_coding_agent_binary
+from .discovery import (
+    CodingAgentExecutable,
+    resolve_coding_agent_executable,
+)
 
 CodingAgentId = Literal["claude", "codex", "gemini"]
 ApprovalMode = Literal["default", "auto", "yolo"]
@@ -160,28 +163,81 @@ def build_coding_agent_command(
     if not task_text:
         raise ValueError("task must not be empty")
 
-    path_overrides = agent_paths or {}
-    binary_name = binary or path_overrides.get(agent_id) or agent_id
-    resolved_binary = resolve_coding_agent_binary(binary_name)
-    if not resolved_binary:
+    executable = _resolve_executable(agent_id, binary=binary, agent_paths=agent_paths)
+    if not executable:
+        path_overrides = agent_paths or {}
+        binary_name = binary or path_overrides.get(agent_id) or agent_id
         raise RuntimeError(f"'{binary_name}' is not installed or not on PATH")
 
     cwd_str = _resolve_cwd(cwd)
     args_extra = list(extra_args or [])
 
+    return _build_command_from_executable(
+        agent_id,
+        task_text,
+        executable=executable,
+        cwd_str=cwd_str,
+        approval_mode=mode,
+        model=model,
+        extra_args=args_extra,
+    )
+
+
+def _resolve_executable(
+    agent_id: str,
+    *,
+    binary: str | None = None,
+    agent_paths: Mapping[str, str] | None = None,
+) -> CodingAgentExecutable | None:
+    path_overrides = agent_paths or {}
+    binary_name = binary or path_overrides.get(agent_id) or agent_id
+    executable, _healthy, _error = resolve_coding_agent_executable(agent_id, binary_name)
+    return executable
+
+
+def _resolve_healthy_executable(
+    agent_id: str,
+    *,
+    binary: str | None = None,
+    agent_paths: Mapping[str, str] | None = None,
+    verify_timeout: int = 5,
+) -> tuple[CodingAgentExecutable | None, str | None]:
+    path_overrides = agent_paths or {}
+    binary_name = binary or path_overrides.get(agent_id) or agent_id
+    executable, healthy, error = resolve_coding_agent_executable(
+        agent_id,
+        binary_name,
+        verify=True,
+        verify_timeout=verify_timeout,
+    )
+    if healthy:
+        return executable, None
+    return None, error
+
+
+def _build_command_from_executable(
+    agent_id: str,
+    task_text: str,
+    *,
+    executable: CodingAgentExecutable,
+    cwd_str: str,
+    approval_mode: ApprovalMode,
+    model: str | None,
+    extra_args: Sequence[str],
+) -> CodingAgentCommand:
     if agent_id == "claude":
-        args = _build_claude_args(task_text, approval_mode=mode, model=model, extra_args=args_extra)
+        args = _build_claude_args(task_text, approval_mode=approval_mode, model=model, extra_args=extra_args)
     elif agent_id == "codex":
-        args = _build_codex_args(task_text, approval_mode=mode, model=model, extra_args=args_extra)
+        args = _build_codex_args(task_text, approval_mode=approval_mode, model=model, extra_args=extra_args)
     else:
-        args = _build_gemini_args(task_text, approval_mode=mode, model=model, extra_args=args_extra)
+        args = _build_gemini_args(task_text, approval_mode=approval_mode, model=model, extra_args=extra_args)
 
     return CodingAgentCommand(
         agent=agent_id,
-        argv=[resolved_binary, *args],
-        binary=resolved_binary,
+        argv=[*executable.argv, *args],
+        binary=executable.binary,
         cwd=cwd_str,
-        approval_mode=mode,
+        approval_mode=approval_mode,
     )
 
 
@@ -203,26 +259,64 @@ def run_coding_agent(
     timeout: int = 600,
     max_output_chars: int = 50000,
     env: Mapping[str, str] | None = None,
+    verify_binary: bool = True,
+    verify_timeout: int = 5,
 ) -> CodingAgentRunResult:
     """Run a local coding-agent CLI and return its output.
 
     This is intentionally a thin subprocess wrapper. It does not sandbox the
     agent itself; use ``approval_mode="yolo"`` only inside an environment you
-    already trust to contain the blast radius.
+    already trust to contain the blast radius. By default, the resolved binary
+    is health-checked before the agent task starts so broken PATH shims fail
+    early with a clear message.
     """
-    command = build_coding_agent_command(
-        agent,
-        task,
-        cwd=cwd,
-        approval_mode=approval_mode,
-        binary=binary,
-        agent_paths=agent_paths,
-        model=model,
-        extra_args=extra_args,
-    )
+    agent_id = _normalize_agent(agent)
+    mode = _normalize_approval_mode(approval_mode)
+    task_text = task.strip()
+    if not task_text:
+        raise ValueError("task must not be empty")
+    cwd_str = _resolve_cwd(cwd)
+    args_extra = list(extra_args or [])
+    start = time.monotonic()
+
+    if verify_binary:
+        executable, error = _resolve_healthy_executable(
+            agent_id,
+            binary=binary,
+            agent_paths=agent_paths,
+            verify_timeout=verify_timeout,
+        )
+        if executable is None:
+            return CodingAgentRunResult(
+                agent=agent_id,
+                command=[],
+                cwd=cwd_str,
+                returncode=-1,
+                output=f"{agent_id} CLI health check failed: {error}",
+                duration_seconds=time.monotonic() - start,
+            )
+        command = _build_command_from_executable(
+            agent_id,
+            task_text,
+            executable=executable,
+            cwd_str=cwd_str,
+            approval_mode=mode,
+            model=model,
+            extra_args=args_extra,
+        )
+    else:
+        command = build_coding_agent_command(
+            agent_id,
+            task_text,
+            cwd=cwd_str,
+            approval_mode=mode,
+            binary=binary,
+            agent_paths=agent_paths,
+            model=model,
+            extra_args=args_extra,
+        )
 
     child_env = None if env is None else {**os.environ, **dict(env)}
-    start = time.monotonic()
     try:
         completed = subprocess.run(
             command.argv,

--- a/prompture/infra/coding_agents.py
+++ b/prompture/infra/coding_agents.py
@@ -11,15 +11,15 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Literal
 
+from .coding_agent_specs import CODING_AGENT_SPECS, get_spec
 from .discovery import (
     CodingAgentExecutable,
     resolve_coding_agent_executable,
 )
 
-CodingAgentId = Literal["claude", "codex", "gemini"]
+CodingAgentId = str
 ApprovalMode = Literal["default", "auto", "yolo"]
 
-_SUPPORTED_AGENTS = {"claude", "codex", "gemini"}
 _SUPPORTED_APPROVAL_MODES = {"default", "auto", "yolo"}
 
 
@@ -54,8 +54,8 @@ class CodingAgentRunResult:
 
 def _normalize_agent(agent: str) -> str:
     normalized = agent.strip().lower()
-    if normalized not in _SUPPORTED_AGENTS:
-        available = ", ".join(sorted(_SUPPORTED_AGENTS))
+    if normalized not in CODING_AGENT_SPECS:
+        available = ", ".join(sorted(CODING_AGENT_SPECS))
         raise ValueError(f"Unsupported coding agent '{agent}'. Available: {available}")
     return normalized
 
@@ -73,61 +73,6 @@ def _resolve_cwd(cwd: str | os.PathLike[str] | None) -> str:
     if not path.is_dir():
         raise ValueError(f"Working directory does not exist: {path}")
     return str(path)
-
-
-def _build_claude_args(
-    task: str,
-    *,
-    approval_mode: ApprovalMode,
-    model: str | None,
-    extra_args: Sequence[str],
-) -> list[str]:
-    args = ["--print", "--output-format", "text"]
-    if model:
-        args.extend(["--model", model])
-    if approval_mode == "auto":
-        args.extend(["--permission-mode", "dontAsk"])
-    elif approval_mode == "yolo":
-        args.append("--dangerously-skip-permissions")
-    args.extend(extra_args)
-    args.append(task)
-    return args
-
-
-def _build_codex_args(
-    task: str,
-    *,
-    approval_mode: ApprovalMode,
-    model: str | None,
-    extra_args: Sequence[str],
-) -> list[str]:
-    args = ["exec"]
-    if model:
-        args.extend(["--model", model])
-    if approval_mode == "auto":
-        args.extend(["--sandbox", "workspace-write", "--ask-for-approval", "never"])
-    elif approval_mode == "yolo":
-        args.append("--dangerously-bypass-approvals-and-sandbox")
-    args.extend(extra_args)
-    args.append(task)
-    return args
-
-
-def _build_gemini_args(
-    task: str,
-    *,
-    approval_mode: ApprovalMode,
-    model: str | None,
-    extra_args: Sequence[str],
-) -> list[str]:
-    args: list[str] = []
-    if model:
-        args.extend(["--model", model])
-    if approval_mode in {"auto", "yolo"}:
-        args.append("-y")
-    args.extend(extra_args)
-    args.append(task)
-    return args
 
 
 def build_coding_agent_command(
@@ -225,12 +170,10 @@ def _build_command_from_executable(
     model: str | None,
     extra_args: Sequence[str],
 ) -> CodingAgentCommand:
-    if agent_id == "claude":
-        args = _build_claude_args(task_text, approval_mode=approval_mode, model=model, extra_args=extra_args)
-    elif agent_id == "codex":
-        args = _build_codex_args(task_text, approval_mode=approval_mode, model=model, extra_args=extra_args)
-    else:
-        args = _build_gemini_args(task_text, approval_mode=approval_mode, model=model, extra_args=extra_args)
+    spec = get_spec(agent_id)
+    if spec is None:
+        raise ValueError(f"Unsupported coding agent '{agent_id}'")
+    args = spec.build_args(task_text, approval_mode=approval_mode, model=model, extra_args=extra_args)
 
     return CodingAgentCommand(
         agent=agent_id,

--- a/prompture/infra/coding_agents.py
+++ b/prompture/infra/coding_agents.py
@@ -95,6 +95,14 @@ class CodingAgentRunResult:
         """Whether the command completed successfully."""
         return self.returncode == 0 and not self.timed_out
 
+    @property
+    def asked_question(self) -> CodingAgentEvent | None:
+        """The last ``question`` event in the stream, if the agent paused to ask."""
+        for ev in reversed(self.events):
+            if ev.type == "question":
+                return ev
+        return None
+
 
 def _normalize_agent(agent: str) -> str:
     normalized = agent.strip().lower()

--- a/prompture/infra/coding_agents.py
+++ b/prompture/infra/coding_agents.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import dataclasses
 import os
 import subprocess
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import AsyncIterator, Mapping, Sequence
 from pathlib import Path
 from typing import Literal
 
@@ -361,3 +362,111 @@ def run_coding_agent(
 async def arun_coding_agent(*args: object, **kwargs: object) -> CodingAgentRunResult:
     """Async wrapper around :func:`run_coding_agent`."""
     return await asyncio.to_thread(run_coding_agent, *args, **kwargs)
+
+
+async def astream_coding_agent(
+    agent: str,
+    task: str,
+    *,
+    cwd: str | os.PathLike[str] | None = None,
+    approval_mode: ApprovalMode = "default",
+    binary: str | None = None,
+    agent_paths: Mapping[str, str] | None = None,
+    model: str | None = None,
+    extra_args: Sequence[str] | None = None,
+    env: Mapping[str, str] | None = None,
+    verify_binary: bool = True,
+    verify_timeout: int = 5,
+) -> AsyncIterator[CodingAgentEvent]:
+    """Stream :class:`CodingAgentEvent` instances from a coding-agent CLI as they arrive.
+
+    Only supports agents whose spec sets ``parse_events`` (Claude Code today).
+    Always uses ``output_format='json'`` because streaming raw text isn't
+    structured enough to be useful event-by-event.
+
+    Cancelling the generator (e.g. via ``async for`` break) terminates the
+    underlying subprocess.
+    """
+    agent_id = _normalize_agent(agent)
+    mode = _normalize_approval_mode(approval_mode)
+    fmt = _normalize_output_format(agent_id, "json")
+    task_text = task.strip()
+    if not task_text:
+        raise ValueError("task must not be empty")
+
+    spec = get_spec(agent_id)
+    parser = spec.parse_events if spec is not None else None
+    if parser is None:
+        raise ValueError(f"Streaming requires a structured-output parser; agent '{agent_id}' has none")
+
+    cwd_str = _resolve_cwd(cwd)
+    args_extra = list(extra_args or [])
+
+    if verify_binary:
+        executable, error = await asyncio.to_thread(
+            _resolve_healthy_executable,
+            agent_id,
+            binary=binary,
+            agent_paths=agent_paths,
+            verify_timeout=verify_timeout,
+        )
+        if executable is None:
+            yield CodingAgentEvent(
+                type="error",
+                error=f"{agent_id} CLI health check failed: {error}",
+            )
+            return
+    else:
+        executable = _resolve_executable(agent_id, binary=binary, agent_paths=agent_paths)
+        if executable is None:
+            path_overrides = agent_paths or {}
+            binary_name = binary or path_overrides.get(agent_id) or agent_id
+            yield CodingAgentEvent(
+                type="error",
+                error=f"'{binary_name}' is not installed or not on PATH",
+            )
+            return
+
+    command = _build_command_from_executable(
+        agent_id,
+        task_text,
+        executable=executable,
+        cwd_str=cwd_str,
+        approval_mode=mode,
+        model=model,
+        extra_args=args_extra,
+        output_format=fmt,
+    )
+
+    child_env = None if env is None else {**os.environ, **dict(env)}
+    proc = await asyncio.create_subprocess_exec(
+        *command.argv,
+        cwd=command.cwd,
+        env=child_env,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    assert proc.stdout is not None
+    try:
+        async for raw in proc.stdout:
+            line = raw.decode(errors="replace").rstrip()
+            if not line:
+                continue
+            for event in parser([line]):
+                yield event
+        rc = await proc.wait()
+        if rc != 0:
+            stderr_bytes = await proc.stderr.read() if proc.stderr is not None else b""
+            yield CodingAgentEvent(
+                type="error",
+                error=f"{agent_id} exited with code {rc}: {stderr_bytes.decode(errors='replace').strip()[:500]}",
+            )
+    finally:
+        if proc.returncode is None:
+            with contextlib.suppress(ProcessLookupError, OSError):
+                proc.terminate()
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=3)
+                except asyncio.TimeoutError:
+                    proc.kill()
+                    await proc.wait()

--- a/prompture/infra/coding_agents.py
+++ b/prompture/infra/coding_agents.py
@@ -11,6 +11,7 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Literal
 
+from .coding_agent_events import CodingAgentEvent
 from .coding_agent_specs import CODING_AGENT_SPECS, get_spec
 from .discovery import (
     CodingAgentExecutable,
@@ -19,8 +20,10 @@ from .discovery import (
 
 CodingAgentId = str
 ApprovalMode = Literal["default", "auto", "yolo"]
+OutputFormat = Literal["text", "json"]
 
 _SUPPORTED_APPROVAL_MODES = {"default", "auto", "yolo"}
+_SUPPORTED_OUTPUT_FORMATS = {"text", "json"}
 
 
 @dataclasses.dataclass(frozen=True)
@@ -45,6 +48,10 @@ class CodingAgentRunResult:
     output: str
     timed_out: bool = False
     duration_seconds: float = 0.0
+    events: tuple[CodingAgentEvent, ...] = ()
+    cost_usd: float | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
 
     @property
     def ok(self) -> bool:
@@ -68,6 +75,21 @@ def _normalize_approval_mode(approval_mode: str) -> ApprovalMode:
     return normalized  # type: ignore[return-value]
 
 
+def _normalize_output_format(agent_id: str, output_format: str) -> OutputFormat:
+    normalized = output_format.strip().lower()
+    if normalized not in _SUPPORTED_OUTPUT_FORMATS:
+        available = ", ".join(sorted(_SUPPORTED_OUTPUT_FORMATS))
+        raise ValueError(f"Unsupported output_format '{output_format}'. Available: {available}")
+    if normalized == "json":
+        spec = get_spec(agent_id)
+        if spec is None or not spec.supports_structured_output:
+            raise ValueError(
+                f"Agent '{agent_id}' does not support output_format='json' yet — "
+                f"only agents whose spec sets parse_events do."
+            )
+    return normalized  # type: ignore[return-value]
+
+
 def _resolve_cwd(cwd: str | os.PathLike[str] | None) -> str:
     path = Path(cwd or os.getcwd()).expanduser().resolve()
     if not path.is_dir():
@@ -85,6 +107,7 @@ def build_coding_agent_command(
     agent_paths: Mapping[str, str] | None = None,
     model: str | None = None,
     extra_args: Sequence[str] | None = None,
+    output_format: OutputFormat = "text",
 ) -> CodingAgentCommand:
     """Build the subprocess command for a local coding-agent CLI.
 
@@ -104,6 +127,7 @@ def build_coding_agent_command(
     """
     agent_id = _normalize_agent(agent)
     mode = _normalize_approval_mode(approval_mode)
+    fmt = _normalize_output_format(agent_id, output_format)
     task_text = task.strip()
     if not task_text:
         raise ValueError("task must not be empty")
@@ -125,6 +149,7 @@ def build_coding_agent_command(
         approval_mode=mode,
         model=model,
         extra_args=args_extra,
+        output_format=fmt,
     )
 
 
@@ -169,11 +194,18 @@ def _build_command_from_executable(
     approval_mode: ApprovalMode,
     model: str | None,
     extra_args: Sequence[str],
+    output_format: OutputFormat = "text",
 ) -> CodingAgentCommand:
     spec = get_spec(agent_id)
     if spec is None:
         raise ValueError(f"Unsupported coding agent '{agent_id}'")
-    args = spec.build_args(task_text, approval_mode=approval_mode, model=model, extra_args=extra_args)
+    args = spec.build_args(
+        task_text,
+        approval_mode=approval_mode,
+        model=model,
+        extra_args=extra_args,
+        output_format=output_format,
+    )
 
     return CodingAgentCommand(
         agent=agent_id,
@@ -204,6 +236,7 @@ def run_coding_agent(
     env: Mapping[str, str] | None = None,
     verify_binary: bool = True,
     verify_timeout: int = 5,
+    output_format: OutputFormat = "text",
 ) -> CodingAgentRunResult:
     """Run a local coding-agent CLI and return its output.
 
@@ -212,9 +245,15 @@ def run_coding_agent(
     already trust to contain the blast radius. By default, the resolved binary
     is health-checked before the agent task starts so broken PATH shims fail
     early with a clear message.
+
+    When ``output_format="json"`` is supported by the agent (Claude Code today)
+    the result's ``events`` field is populated with parsed
+    :class:`CodingAgentEvent` instances and ``cost_usd`` / ``input_tokens`` /
+    ``output_tokens`` are extracted from the final result event.
     """
     agent_id = _normalize_agent(agent)
     mode = _normalize_approval_mode(approval_mode)
+    fmt = _normalize_output_format(agent_id, output_format)
     task_text = task.strip()
     if not task_text:
         raise ValueError("task must not be empty")
@@ -246,6 +285,7 @@ def run_coding_agent(
             approval_mode=mode,
             model=model,
             extra_args=args_extra,
+            output_format=fmt,
         )
     else:
         command = build_coding_agent_command(
@@ -257,6 +297,7 @@ def run_coding_agent(
             agent_paths=agent_paths,
             model=model,
             extra_args=args_extra,
+            output_format=fmt,
         )
 
     child_env = None if env is None else {**os.environ, **dict(env)}
@@ -270,16 +311,35 @@ def run_coding_agent(
             timeout=timeout,
             check=False,
         )
-        output = _merge_output(completed.stdout, completed.stderr)
+        stdout = completed.stdout or ""
+        stderr = completed.stderr or ""
         timed_out = False
         returncode = completed.returncode
     except subprocess.TimeoutExpired as exc:
-        stdout = exc.stdout.decode(errors="replace") if isinstance(exc.stdout, bytes) else exc.stdout
-        stderr = exc.stderr.decode(errors="replace") if isinstance(exc.stderr, bytes) else exc.stderr
-        output = _merge_output(stdout, stderr) or f"{command.binary} timed out after {timeout}s"
+        stdout = exc.stdout.decode(errors="replace") if isinstance(exc.stdout, bytes) else (exc.stdout or "")
+        stderr = exc.stderr.decode(errors="replace") if isinstance(exc.stderr, bytes) else (exc.stderr or "")
+        if not stdout and not stderr:
+            stderr = f"{command.binary} timed out after {timeout}s"
         timed_out = True
         returncode = -1
 
+    events: tuple[CodingAgentEvent, ...] = ()
+    cost_usd: float | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    if fmt == "json":
+        spec = get_spec(agent_id)
+        parser = spec.parse_events if spec else None
+        if parser is not None:
+            events = tuple(parser(stdout.splitlines()))
+            for ev in events:
+                if ev.type == "done":
+                    cost_usd = ev.cost_usd
+                    input_tokens = ev.input_tokens
+                    output_tokens = ev.output_tokens
+                    break
+
+    output = _merge_output(stdout, stderr)
     if len(output) > max_output_chars:
         output = output[:max_output_chars] + f"\n\n... (truncated at {max_output_chars} chars)"
 
@@ -291,6 +351,10 @@ def run_coding_agent(
         output=output,
         timed_out=timed_out,
         duration_seconds=time.monotonic() - start,
+        events=events,
+        cost_usd=cost_usd,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
     )
 
 

--- a/prompture/infra/coding_agents.py
+++ b/prompture/infra/coding_agents.py
@@ -89,6 +89,7 @@ class CodingAgentRunResult:
     cost_usd: float | None = None
     input_tokens: int | None = None
     output_tokens: int | None = None
+    session_id: str | None = None
 
     @property
     def ok(self) -> bool:
@@ -177,6 +178,7 @@ def build_coding_agent_command(
     model: str | None = None,
     extra_args: Sequence[str] | None = None,
     output_format: OutputFormat = "text",
+    session_id: str | None = None,
 ) -> CodingAgentCommand:
     """Build the subprocess command for a local coding-agent CLI.
 
@@ -219,6 +221,7 @@ def build_coding_agent_command(
         model=model,
         extra_args=args_extra,
         output_format=fmt,
+        session_id=session_id,
     )
 
 
@@ -264,6 +267,7 @@ def _build_command_from_executable(
     model: str | None,
     extra_args: Sequence[str],
     output_format: OutputFormat = "text",
+    session_id: str | None = None,
 ) -> CodingAgentCommand:
     spec = get_spec(agent_id)
     if spec is None:
@@ -274,6 +278,7 @@ def _build_command_from_executable(
         model=model,
         extra_args=extra_args,
         output_format=output_format,
+        session_id=session_id,
     )
 
     return CodingAgentCommand(
@@ -307,6 +312,7 @@ def run_coding_agent(
     verify_timeout: int = 5,
     output_format: OutputFormat = "text",
     session: UsageSession | None = None,
+    session_id: str | None = None,
 ) -> CodingAgentRunResult:
     """Run a local coding-agent CLI and return its output.
 
@@ -356,6 +362,7 @@ def run_coding_agent(
             model=model,
             extra_args=args_extra,
             output_format=fmt,
+            session_id=session_id,
         )
     else:
         command = build_coding_agent_command(
@@ -368,6 +375,7 @@ def run_coding_agent(
             model=model,
             extra_args=args_extra,
             output_format=fmt,
+            session_id=session_id,
         )
 
     child_env = None if env is None else {**os.environ, **dict(env)}
@@ -397,17 +405,21 @@ def run_coding_agent(
     cost_usd: float | None = None
     input_tokens: int | None = None
     output_tokens: int | None = None
+    captured_session_id: str | None = session_id
     if fmt == "json":
         spec = get_spec(agent_id)
         parser = spec.parse_events if spec else None
         if parser is not None:
             events = tuple(parser(stdout.splitlines()))
             for ev in events:
+                if ev.session_id and captured_session_id is None:
+                    captured_session_id = ev.session_id
                 if ev.type == "done":
                     cost_usd = ev.cost_usd
                     input_tokens = ev.input_tokens
                     output_tokens = ev.output_tokens
-                    break
+                    if ev.session_id:
+                        captured_session_id = ev.session_id
 
     output = _merge_output(stdout, stderr)
     if len(output) > max_output_chars:
@@ -438,6 +450,7 @@ def run_coding_agent(
         cost_usd=cost_usd,
         input_tokens=input_tokens,
         output_tokens=output_tokens,
+        session_id=captured_session_id,
     )
 
 
@@ -459,6 +472,7 @@ async def astream_coding_agent(
     env: Mapping[str, str] | None = None,
     verify_binary: bool = True,
     verify_timeout: int = 5,
+    session_id: str | None = None,
 ) -> AsyncIterator[CodingAgentEvent]:
     """Stream :class:`CodingAgentEvent` instances from a coding-agent CLI as they arrive.
 
@@ -518,6 +532,7 @@ async def astream_coding_agent(
         model=model,
         extra_args=args_extra,
         output_format=fmt,
+        session_id=session_id,
     )
 
     child_env = None if env is None else {**os.environ, **dict(env)}

--- a/prompture/infra/coding_agents.py
+++ b/prompture/infra/coding_agents.py
@@ -1,0 +1,262 @@
+"""Helpers for discovering and running local coding-agent CLIs."""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import os
+import subprocess
+import time
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Literal
+
+from .discovery import resolve_coding_agent_binary
+
+CodingAgentId = Literal["claude", "codex", "gemini"]
+ApprovalMode = Literal["default", "auto", "yolo"]
+
+_SUPPORTED_AGENTS = {"claude", "codex", "gemini"}
+_SUPPORTED_APPROVAL_MODES = {"default", "auto", "yolo"}
+
+
+@dataclasses.dataclass(frozen=True)
+class CodingAgentCommand:
+    """Resolved command for a local coding-agent CLI."""
+
+    agent: str
+    argv: list[str]
+    binary: str
+    cwd: str
+    approval_mode: ApprovalMode
+
+
+@dataclasses.dataclass(frozen=True)
+class CodingAgentRunResult:
+    """Result from running a local coding-agent CLI."""
+
+    agent: str
+    command: list[str]
+    cwd: str
+    returncode: int
+    output: str
+    timed_out: bool = False
+    duration_seconds: float = 0.0
+
+    @property
+    def ok(self) -> bool:
+        """Whether the command completed successfully."""
+        return self.returncode == 0 and not self.timed_out
+
+
+def _normalize_agent(agent: str) -> str:
+    normalized = agent.strip().lower()
+    if normalized not in _SUPPORTED_AGENTS:
+        available = ", ".join(sorted(_SUPPORTED_AGENTS))
+        raise ValueError(f"Unsupported coding agent '{agent}'. Available: {available}")
+    return normalized
+
+
+def _normalize_approval_mode(approval_mode: str) -> ApprovalMode:
+    normalized = approval_mode.strip().lower()
+    if normalized not in _SUPPORTED_APPROVAL_MODES:
+        available = ", ".join(sorted(_SUPPORTED_APPROVAL_MODES))
+        raise ValueError(f"Unsupported approval_mode '{approval_mode}'. Available: {available}")
+    return normalized  # type: ignore[return-value]
+
+
+def _resolve_cwd(cwd: str | os.PathLike[str] | None) -> str:
+    path = Path(cwd or os.getcwd()).expanduser().resolve()
+    if not path.is_dir():
+        raise ValueError(f"Working directory does not exist: {path}")
+    return str(path)
+
+
+def _build_claude_args(
+    task: str,
+    *,
+    approval_mode: ApprovalMode,
+    model: str | None,
+    extra_args: Sequence[str],
+) -> list[str]:
+    args = ["--print", "--output-format", "text"]
+    if model:
+        args.extend(["--model", model])
+    if approval_mode == "auto":
+        args.extend(["--permission-mode", "dontAsk"])
+    elif approval_mode == "yolo":
+        args.append("--dangerously-skip-permissions")
+    args.extend(extra_args)
+    args.append(task)
+    return args
+
+
+def _build_codex_args(
+    task: str,
+    *,
+    approval_mode: ApprovalMode,
+    model: str | None,
+    extra_args: Sequence[str],
+) -> list[str]:
+    args = ["exec"]
+    if model:
+        args.extend(["--model", model])
+    if approval_mode == "auto":
+        args.extend(["--sandbox", "workspace-write", "--ask-for-approval", "never"])
+    elif approval_mode == "yolo":
+        args.append("--dangerously-bypass-approvals-and-sandbox")
+    args.extend(extra_args)
+    args.append(task)
+    return args
+
+
+def _build_gemini_args(
+    task: str,
+    *,
+    approval_mode: ApprovalMode,
+    model: str | None,
+    extra_args: Sequence[str],
+) -> list[str]:
+    args: list[str] = []
+    if model:
+        args.extend(["--model", model])
+    if approval_mode in {"auto", "yolo"}:
+        args.append("-y")
+    args.extend(extra_args)
+    args.append(task)
+    return args
+
+
+def build_coding_agent_command(
+    agent: str,
+    task: str,
+    *,
+    cwd: str | os.PathLike[str] | None = None,
+    approval_mode: ApprovalMode = "default",
+    binary: str | None = None,
+    agent_paths: Mapping[str, str] | None = None,
+    model: str | None = None,
+    extra_args: Sequence[str] | None = None,
+) -> CodingAgentCommand:
+    """Build the subprocess command for a local coding-agent CLI.
+
+    Args:
+        agent: ``"claude"``, ``"codex"``, or ``"gemini"``.
+        task: Prompt/task to hand to the coding agent.
+        cwd: Working directory for the coding agent. Defaults to the current
+            process directory.
+        approval_mode: ``"default"`` uses the CLI defaults, ``"auto"`` avoids
+            repeated approval prompts while preserving a workspace-oriented
+            mode where the CLI supports it, and ``"yolo"`` enables each CLI's
+            dangerous bypass flag.
+        binary: Optional explicit binary path for this call.
+        agent_paths: Optional per-agent binary path overrides.
+        model: Optional model flag passed to CLIs that support model selection.
+        extra_args: Extra CLI flags inserted before the task.
+    """
+    agent_id = _normalize_agent(agent)
+    mode = _normalize_approval_mode(approval_mode)
+    task_text = task.strip()
+    if not task_text:
+        raise ValueError("task must not be empty")
+
+    path_overrides = agent_paths or {}
+    binary_name = binary or path_overrides.get(agent_id) or agent_id
+    resolved_binary = resolve_coding_agent_binary(binary_name)
+    if not resolved_binary:
+        raise RuntimeError(f"'{binary_name}' is not installed or not on PATH")
+
+    cwd_str = _resolve_cwd(cwd)
+    args_extra = list(extra_args or [])
+
+    if agent_id == "claude":
+        args = _build_claude_args(task_text, approval_mode=mode, model=model, extra_args=args_extra)
+    elif agent_id == "codex":
+        args = _build_codex_args(task_text, approval_mode=mode, model=model, extra_args=args_extra)
+    else:
+        args = _build_gemini_args(task_text, approval_mode=mode, model=model, extra_args=args_extra)
+
+    return CodingAgentCommand(
+        agent=agent_id,
+        argv=[resolved_binary, *args],
+        binary=resolved_binary,
+        cwd=cwd_str,
+        approval_mode=mode,
+    )
+
+
+def _merge_output(stdout: str | None, stderr: str | None) -> str:
+    chunks = [part for part in (stdout, stderr) if part]
+    return "\n".join(chunks).strip()
+
+
+def run_coding_agent(
+    agent: str,
+    task: str,
+    *,
+    cwd: str | os.PathLike[str] | None = None,
+    approval_mode: ApprovalMode = "default",
+    binary: str | None = None,
+    agent_paths: Mapping[str, str] | None = None,
+    model: str | None = None,
+    extra_args: Sequence[str] | None = None,
+    timeout: int = 600,
+    max_output_chars: int = 50000,
+    env: Mapping[str, str] | None = None,
+) -> CodingAgentRunResult:
+    """Run a local coding-agent CLI and return its output.
+
+    This is intentionally a thin subprocess wrapper. It does not sandbox the
+    agent itself; use ``approval_mode="yolo"`` only inside an environment you
+    already trust to contain the blast radius.
+    """
+    command = build_coding_agent_command(
+        agent,
+        task,
+        cwd=cwd,
+        approval_mode=approval_mode,
+        binary=binary,
+        agent_paths=agent_paths,
+        model=model,
+        extra_args=extra_args,
+    )
+
+    child_env = None if env is None else {**os.environ, **dict(env)}
+    start = time.monotonic()
+    try:
+        completed = subprocess.run(
+            command.argv,
+            cwd=command.cwd,
+            env=child_env,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        output = _merge_output(completed.stdout, completed.stderr)
+        timed_out = False
+        returncode = completed.returncode
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout.decode(errors="replace") if isinstance(exc.stdout, bytes) else exc.stdout
+        stderr = exc.stderr.decode(errors="replace") if isinstance(exc.stderr, bytes) else exc.stderr
+        output = _merge_output(stdout, stderr) or f"{command.binary} timed out after {timeout}s"
+        timed_out = True
+        returncode = -1
+
+    if len(output) > max_output_chars:
+        output = output[:max_output_chars] + f"\n\n... (truncated at {max_output_chars} chars)"
+
+    return CodingAgentRunResult(
+        agent=command.agent,
+        command=command.argv,
+        cwd=command.cwd,
+        returncode=returncode,
+        output=output,
+        timed_out=timed_out,
+        duration_seconds=time.monotonic() - start,
+    )
+
+
+async def arun_coding_agent(*args: object, **kwargs: object) -> CodingAgentRunResult:
+    """Async wrapper around :func:`run_coding_agent`."""
+    return await asyncio.to_thread(run_coding_agent, *args, **kwargs)

--- a/prompture/infra/coding_agents.py
+++ b/prompture/infra/coding_agents.py
@@ -18,6 +18,7 @@ from .discovery import (
     CodingAgentExecutable,
     resolve_coding_agent_executable,
 )
+from .settings import settings as _global_settings
 
 CodingAgentId = str
 ApprovalMode = Literal["default", "auto", "yolo"]
@@ -91,6 +92,30 @@ def _normalize_output_format(agent_id: str, output_format: str) -> OutputFormat:
     return normalized  # type: ignore[return-value]
 
 
+def _settings_agent_paths() -> dict[str, str]:
+    """Read ``coding_agent_bin_<id>`` settings (with underscore for hyphenated ids)."""
+    result: dict[str, str] = {}
+    for agent_id in CODING_AGENT_SPECS:
+        attr = f"coding_agent_bin_{agent_id.replace('-', '_')}"
+        value = getattr(_global_settings, attr, None)
+        if isinstance(value, str) and value:
+            result[agent_id] = value
+    return result
+
+
+def _merge_agent_paths(
+    explicit: Mapping[str, str] | None,
+) -> Mapping[str, str]:
+    """Combine settings/env-derived defaults with caller-supplied overrides.
+
+    Explicit kwargs win over settings; settings win over PATH lookup.
+    """
+    defaults = _settings_agent_paths()
+    if not explicit:
+        return defaults
+    return {**defaults, **dict(explicit)}
+
+
 def _resolve_cwd(cwd: str | os.PathLike[str] | None) -> str:
     path = Path(cwd or os.getcwd()).expanduser().resolve()
     if not path.is_dir():
@@ -135,7 +160,7 @@ def build_coding_agent_command(
 
     executable = _resolve_executable(agent_id, binary=binary, agent_paths=agent_paths)
     if not executable:
-        path_overrides = agent_paths or {}
+        path_overrides = _merge_agent_paths(agent_paths)
         binary_name = binary or path_overrides.get(agent_id) or agent_id
         raise RuntimeError(f"'{binary_name}' is not installed or not on PATH")
 
@@ -160,7 +185,7 @@ def _resolve_executable(
     binary: str | None = None,
     agent_paths: Mapping[str, str] | None = None,
 ) -> CodingAgentExecutable | None:
-    path_overrides = agent_paths or {}
+    path_overrides = _merge_agent_paths(agent_paths)
     binary_name = binary or path_overrides.get(agent_id) or agent_id
     executable, _healthy, _error = resolve_coding_agent_executable(agent_id, binary_name)
     return executable
@@ -173,7 +198,7 @@ def _resolve_healthy_executable(
     agent_paths: Mapping[str, str] | None = None,
     verify_timeout: int = 5,
 ) -> tuple[CodingAgentExecutable | None, str | None]:
-    path_overrides = agent_paths or {}
+    path_overrides = _merge_agent_paths(agent_paths)
     binary_name = binary or path_overrides.get(agent_id) or agent_id
     executable, healthy, error = resolve_coding_agent_executable(
         agent_id,
@@ -419,7 +444,7 @@ async def astream_coding_agent(
     else:
         executable = _resolve_executable(agent_id, binary=binary, agent_paths=agent_paths)
         if executable is None:
-            path_overrides = agent_paths or {}
+            path_overrides = _merge_agent_paths(agent_paths)
             binary_name = binary or path_overrides.get(agent_id) or agent_id
             yield CodingAgentEvent(
                 type="error",

--- a/prompture/infra/coding_agents.py
+++ b/prompture/infra/coding_agents.py
@@ -183,7 +183,10 @@ def build_coding_agent_command(
     """Build the subprocess command for a local coding-agent CLI.
 
     Args:
-        agent: ``"claude"``, ``"codex"``, or ``"gemini"``.
+        agent: Any agent id registered in
+            :data:`prompture.infra.CODING_AGENT_SPECS` — Claude Code, Codex,
+            Gemini, Qwen, Aider, OpenCode, Cursor Agent, Crush today, plus
+            anything callers have registered.
         task: Prompt/task to hand to the coding agent.
         cwd: Working directory for the coding agent. Defaults to the current
             process directory.

--- a/prompture/infra/discovery.py
+++ b/prompture/infra/discovery.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import dataclasses
 import hashlib
+import json
 import logging
 import os
 import platform
 import shutil
+import subprocess
 import sys
 from collections.abc import Mapping
+from contextlib import suppress
+from pathlib import Path
 from typing import Any, Literal, overload
 
 from ..drivers.provider_descriptors import PROVIDER_DESCRIPTOR_MAP, ProviderDescriptor, _resolve_cls
@@ -100,6 +104,20 @@ class CodingAgentInfo:
     available: bool
     binary: str
     custom_path: bool = False
+    source: str | None = None
+    verified: bool = False
+    healthy: bool | None = None
+    error: str | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class CodingAgentExecutable:
+    """A concrete way to invoke a coding-agent CLI."""
+
+    binary: str
+    argv: tuple[str, ...]
+    display: str
+    source: str = "PATH"
 
 
 _CODING_AGENT_SPECS: dict[str, tuple[str, str]] = {
@@ -109,6 +127,19 @@ _CODING_AGENT_SPECS: dict[str, tuple[str, str]] = {
 }
 
 _WINDOWS_CLI_EXTENSIONS = (".cmd", ".ps1", ".bat")
+_WINDOWS_CMD_EXTENSIONS = (".cmd", ".bat")
+_CODING_AGENT_HEALTH_TIMEOUT = 5
+_CODING_AGENT_NPM_PACKAGES: dict[str, tuple[str, ...]] = {
+    "claude": ("@anthropic-ai/claude-code",),
+    "codex": ("@openai/codex",),
+    "gemini": ("@google/gemini-cli",),
+}
+_NODE_CLI_ENTRYPOINT_FALLBACKS = (
+    Path("dist") / "index.js",
+    Path("bin") / "cli.js",
+    Path("cli.js"),
+    Path("index.js"),
+)
 
 
 def resolve_coding_agent_binary(binary: str) -> str | None:
@@ -135,10 +166,454 @@ def resolve_coding_agent_binary(binary: str) -> str | None:
     return None
 
 
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            out.append(value)
+    return out
+
+
+def _looks_like_path(value: str) -> bool:
+    return (
+        os.path.sep in value
+        or (os.path.altsep is not None and os.path.altsep in value)
+        or (len(value) > 2 and value[1] == ":" and value[2] in "\\/")
+    )
+
+
+def _manual_windows_to_wsl_path(value: str) -> str:
+    if len(value) > 2 and value[1] == ":" and value[2] in "\\/":
+        drive = value[0].lower()
+        rest = value[3:].replace("\\", "/")
+        return f"/mnt/{drive}/{rest}"
+    return value
+
+
+def _manual_wsl_to_windows_path(value: Path) -> str:
+    text = str(value)
+    if text.startswith("/mnt/") and len(text) > 6 and text[6] == "/":
+        drive = text[5].upper()
+        rest = text[7:].replace("/", "\\")
+        return f"{drive}:\\{rest}"
+    return text
+
+
+def _path_for_windows_executable(path: Path) -> str:
+    """Convert WSL /mnt paths for Windows executables when possible."""
+    if shutil.which("wslpath"):
+        try:
+            completed = subprocess.run(
+                ["wslpath", "-w", str(path)],
+                capture_output=True,
+                text=True,
+                timeout=1,
+                check=False,
+            )
+            if completed.returncode == 0 and completed.stdout.strip():
+                return completed.stdout.strip()
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+    return _manual_wsl_to_windows_path(path)
+
+
+def _path_for_windows_node(path: Path) -> str:
+    return _path_for_windows_executable(path)
+
+
+def _quote_windows_cmd_path(value: str) -> str:
+    if any(char.isspace() for char in value):
+        return f'"{value}"'
+    return value
+
+
+def _command_name_variants(binary: str) -> list[str]:
+    if _looks_like_path(binary):
+        return [os.path.expanduser(os.path.expandvars(binary))]
+
+    variants = [binary]
+    root, ext = os.path.splitext(binary)
+    if not ext:
+        variants.extend(f"{root}{suffix}" for suffix in _WINDOWS_CLI_EXTENSIONS)
+    return _dedupe(variants)
+
+
+def _existing_path(value: str) -> str | None:
+    expanded = _manual_windows_to_wsl_path(os.path.expanduser(os.path.expandvars(value)))
+    path = Path(expanded)
+    if path.is_file():
+        return str(path)
+    return None
+
+
+def _resolved_paths_for_binary(binary: str) -> list[str]:
+    paths: list[str] = []
+    for variant in _command_name_variants(binary):
+        if existing := _existing_path(variant):
+            paths.append(existing)
+        if found := shutil.which(variant):
+            paths.append(found)
+    return _dedupe(paths)
+
+
+def _npm_global_prefixes() -> list[Path]:
+    prefixes: list[Path] = []
+    for npm_binary in _resolved_paths_for_binary("npm"):
+        try:
+            completed = subprocess.run(
+                [npm_binary, "prefix", "-g"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        if completed.returncode != 0:
+            continue
+        prefix = completed.stdout.strip()
+        if prefix:
+            prefixes.append(Path(_manual_windows_to_wsl_path(prefix)))
+    return list(dict.fromkeys(prefixes))
+
+
+def _package_path(package_name: str) -> Path:
+    return Path(*package_name.split("/"))
+
+
+def _package_command_name(package_name: str) -> str:
+    return package_name.rsplit("/", 1)[-1]
+
+
+def _npm_package_dir_candidates(base_dir: Path, package_name: str) -> list[Path]:
+    package_path = _package_path(package_name)
+    bases = [base_dir]
+    try:
+        resolved = base_dir.resolve()
+    except OSError:
+        resolved = base_dir
+    bases.append(resolved)
+
+    candidates: list[Path] = []
+    for base in dict.fromkeys(bases):
+        candidates.extend(
+            [
+                base / "node_modules" / package_path,
+                base / "lib" / "node_modules" / package_path,
+                base.parent / "node_modules" / package_path,
+                base.parent / "lib" / "node_modules" / package_path,
+            ]
+        )
+    return [path for path in dict.fromkeys(candidates) if path.is_dir()]
+
+
+def _npm_package_entrypoints(
+    package_dir: Path,
+    *,
+    command_name: str,
+    package_name: str,
+) -> list[Path]:
+    rel_paths: list[Path] = []
+    package_json = package_dir / "package.json"
+    if package_json.is_file():
+        try:
+            metadata = json.loads(package_json.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            metadata = {}
+        bin_spec = metadata.get("bin") if isinstance(metadata, dict) else None
+        if isinstance(bin_spec, str):
+            rel_paths.append(Path(bin_spec))
+        elif isinstance(bin_spec, dict):
+            preferred_names = [
+                command_name,
+                package_name,
+                _package_command_name(package_name),
+            ]
+            for name in preferred_names:
+                entry = bin_spec.get(name)
+                if isinstance(entry, str):
+                    rel_paths.append(Path(entry))
+            rel_paths.extend(Path(entry) for entry in bin_spec.values() if isinstance(entry, str))
+
+    rel_paths.extend(_NODE_CLI_ENTRYPOINT_FALLBACKS)
+
+    candidates = [path if path.is_absolute() else package_dir / path for path in dict.fromkeys(rel_paths)]
+    return [path for path in candidates if path.is_file()]
+
+
+def _node_binary_candidates_for_dir(base_dir: Path) -> list[str]:
+    node_paths = [
+        str(base_dir / "node"),
+        str(base_dir / "node.exe"),
+        str(base_dir / "bin" / "node"),
+        str(base_dir / "bin" / "node.exe"),
+        *_resolved_paths_for_binary("node"),
+        *_resolved_paths_for_binary("node.exe"),
+    ]
+    try:
+        resolved = base_dir.resolve()
+    except OSError:
+        resolved = base_dir
+    node_paths.extend(
+        [
+            str(resolved / "node"),
+            str(resolved / "node.exe"),
+            str(resolved / "bin" / "node"),
+            str(resolved / "bin" / "node.exe"),
+        ]
+    )
+
+    return [node for node in _dedupe(node_paths) if Path(node).is_file() or shutil.which(node) is not None]
+
+
+def _node_package_candidates_from_dir(
+    agent_id: str,
+    base_dir: Path,
+) -> list[CodingAgentExecutable]:
+    executables: list[CodingAgentExecutable] = []
+    packages = _CODING_AGENT_NPM_PACKAGES.get(agent_id, ())
+    if not packages:
+        return executables
+
+    node_paths = _node_binary_candidates_for_dir(base_dir)
+    if not node_paths:
+        return executables
+
+    command_name = _CODING_AGENT_SPECS.get(agent_id, (agent_id, agent_id))[1]
+    for package_name in packages:
+        package_dirs = _npm_package_dir_candidates(base_dir, package_name)
+        if not package_dirs:
+            continue
+        for package_dir in package_dirs:
+            entrypoints = _npm_package_entrypoints(
+                package_dir,
+                command_name=command_name,
+                package_name=package_name,
+            )
+            for node in node_paths:
+                is_windows_node = node.lower().endswith(".exe")
+                for entrypoint in entrypoints:
+                    entry_arg = _path_for_windows_node(entrypoint) if is_windows_node else str(entrypoint)
+                    argv = (node, "--no-warnings=DEP0040", entry_arg)
+                    executables.append(
+                        CodingAgentExecutable(
+                            binary=node,
+                            argv=argv,
+                            display=" ".join(argv),
+                            source=f"npm:{package_name}",
+                        )
+                    )
+    return executables
+
+
+def _node_package_candidates_from_shim(
+    agent_id: str,
+    shim_path: str,
+) -> list[CodingAgentExecutable]:
+    path = Path(shim_path)
+    bases = [path.parent]
+    with suppress(OSError):
+        bases.append(path.resolve().parent)
+
+    candidates: list[CodingAgentExecutable] = []
+    for base in dict.fromkeys(bases):
+        candidates.extend(_node_package_candidates_from_dir(agent_id, base))
+    return candidates
+
+
+def _windows_cmd_wrapper_candidates(path: str) -> list[CodingAgentExecutable]:
+    """Return cmd.exe-based candidates for Windows npm .cmd/.bat wrappers."""
+    if not path.lower().endswith(_WINDOWS_CMD_EXTENSIONS):
+        return []
+
+    cmd_paths = _resolved_paths_for_binary("cmd.exe")
+    if not cmd_paths and (cmd := shutil.which("cmd.exe")):
+        cmd_paths = [cmd]
+
+    windows_path = _quote_windows_cmd_path(_path_for_windows_executable(Path(path)))
+    return [
+        CodingAgentExecutable(
+            binary=cmd,
+            argv=(cmd, "/d", "/s", "/c", windows_path),
+            display=f"{cmd} /d /s /c {windows_path}",
+            source="windows-cmd",
+        )
+        for cmd in cmd_paths
+    ]
+
+
+def _is_windows_wrapper_path(path: str) -> bool:
+    return path.lower().endswith(_WINDOWS_CLI_EXTENSIONS)
+
+
+def _is_windows_npm_shim_path(path: str, all_paths: list[str]) -> bool:
+    lower = path.lower()
+    if not lower.startswith("/mnt/"):
+        return False
+    return any(other.lower() in {f"{lower}.cmd", f"{lower}.bat"} for other in all_paths)
+
+
+def _extra_node_package_candidates(
+    agent_id: str,
+    binary: str,
+) -> list[CodingAgentExecutable]:
+    candidates: list[CodingAgentExecutable] = []
+    if _looks_like_path(binary):
+        path = Path(_manual_windows_to_wsl_path(os.path.expanduser(os.path.expandvars(binary))))
+        bases = [path.parent if path.is_file() or path.suffix else path]
+        for base in bases:
+            candidates.extend(_node_package_candidates_from_dir(agent_id, base))
+        return candidates
+
+    for prefix in _npm_global_prefixes():
+        candidates.extend(_node_package_candidates_from_dir(agent_id, prefix))
+        candidates.extend(_node_package_candidates_from_dir(agent_id, prefix / "bin"))
+    return candidates
+
+
+def _dedupe_executables(candidates: list[CodingAgentExecutable]) -> list[CodingAgentExecutable]:
+    seen: set[tuple[str, ...]] = set()
+    unique: list[CodingAgentExecutable] = []
+    for candidate in candidates:
+        if candidate.argv not in seen:
+            seen.add(candidate.argv)
+            unique.append(candidate)
+    return unique
+
+
+# Backwards-compatible internal helpers kept for tests and downstream users
+# that reached into this private module during the first implementation.
+def _gemini_node_candidates_from_dir(base_dir: Path) -> list[CodingAgentExecutable]:
+    return _node_package_candidates_from_dir("gemini", base_dir)
+
+
+def _gemini_node_candidates_from_shim(shim_path: str) -> list[CodingAgentExecutable]:
+    return _node_package_candidates_from_shim("gemini", shim_path)
+
+
+def get_coding_agent_executable_candidates(
+    agent_id: str,
+    binary: str,
+) -> list[CodingAgentExecutable]:
+    """Return candidate executable forms for a coding-agent CLI."""
+    paths = _resolved_paths_for_binary(binary)
+    candidates: list[CodingAgentExecutable] = []
+    late_direct_candidates: list[CodingAgentExecutable] = []
+
+    for path in paths:
+        direct = CodingAgentExecutable(binary=path, argv=(path,), display=path)
+        if _is_windows_wrapper_path(path) or _is_windows_npm_shim_path(path, paths):
+            late_direct_candidates.append(direct)
+        else:
+            candidates.append(direct)
+
+    for path in paths:
+        candidates.extend(_windows_cmd_wrapper_candidates(path))
+
+    candidates.extend(late_direct_candidates)
+
+    for path in paths:
+        candidates.extend(_node_package_candidates_from_shim(agent_id, path))
+    candidates.extend(_extra_node_package_candidates(agent_id, binary))
+
+    return _dedupe_executables(candidates)
+
+
+def _summarize_health_error(output: str) -> str:
+    """Return a compact single-line health-check failure reason."""
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
+    if not lines:
+        return "health check failed with no output"
+    return lines[0][:240]
+
+
+def verify_coding_agent_binary(
+    agent_id: str,
+    binary: str,
+    *,
+    timeout: int = _CODING_AGENT_HEALTH_TIMEOUT,
+) -> tuple[bool, str | None]:
+    """Run a lightweight health check for a resolved coding-agent binary."""
+    try:
+        completed = subprocess.run(
+            [binary, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return False, f"{agent_id} health check timed out after {timeout}s"
+    except OSError as exc:
+        return False, f"{agent_id} could not start: {exc}"
+
+    if completed.returncode == 0:
+        return True, None
+
+    output = "\n".join(part for part in (completed.stderr, completed.stdout) if part)
+    return False, _summarize_health_error(output)
+
+
+def verify_coding_agent_executable(
+    agent_id: str,
+    executable: CodingAgentExecutable,
+    *,
+    timeout: int = _CODING_AGENT_HEALTH_TIMEOUT,
+) -> tuple[bool, str | None]:
+    """Run a lightweight health check for a candidate executable."""
+    try:
+        completed = subprocess.run(
+            [*executable.argv, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return False, f"{agent_id} health check timed out after {timeout}s"
+    except OSError as exc:
+        return False, f"{agent_id} could not start: {exc}"
+
+    if completed.returncode == 0:
+        return True, None
+
+    output = "\n".join(part for part in (completed.stderr, completed.stdout) if part)
+    return False, _summarize_health_error(output)
+
+
+def resolve_coding_agent_executable(
+    agent_id: str,
+    binary: str,
+    *,
+    verify: bool = False,
+    verify_timeout: int = _CODING_AGENT_HEALTH_TIMEOUT,
+) -> tuple[CodingAgentExecutable | None, bool | None, str | None]:
+    """Resolve a coding-agent executable, optionally picking the first healthy candidate."""
+    candidates = get_coding_agent_executable_candidates(agent_id, binary)
+    if not candidates:
+        return None, False if verify else None, f"'{binary}' is not installed or not on PATH"
+
+    if not verify:
+        return candidates[0], None, None
+
+    last_error: str | None = None
+    for candidate in candidates:
+        healthy, error = verify_coding_agent_executable(agent_id, candidate, timeout=verify_timeout)
+        if healthy:
+            return candidate, True, None
+        last_error = error
+
+    return candidates[0], False, last_error
+
+
 def get_available_coding_agents(
     *,
     agent_paths: Mapping[str, str] | None = None,
     include_unavailable: bool = True,
+    verify: bool = False,
+    verify_timeout: int = _CODING_AGENT_HEALTH_TIMEOUT,
 ) -> list[CodingAgentInfo]:
     """Auto-detect installed coding-agent CLIs.
 
@@ -149,6 +624,9 @@ def get_available_coding_agents(
         include_unavailable: When ``True`` (default), return all known agents
             with ``available=False`` for missing CLIs. When ``False``, return
             only discovered agents.
+        verify: When ``True``, run ``--version`` for resolved binaries and
+            mark CLIs unavailable when the executable shim fails.
+        verify_timeout: Timeout in seconds for each health check.
 
     Returns:
         A list of :class:`CodingAgentInfo` entries suitable for app settings,
@@ -160,18 +638,31 @@ def get_available_coding_agents(
     for agent_id, (display_name, default_binary) in _CODING_AGENT_SPECS.items():
         custom_binary = configured_paths.get(agent_id, "")
         binary_name = custom_binary or default_binary
-        resolved = resolve_coding_agent_binary(binary_name)
+        executable, healthy, error = resolve_coding_agent_executable(
+            agent_id,
+            binary_name,
+            verify=verify,
+            verify_timeout=verify_timeout,
+        )
 
-        if resolved is None and not include_unavailable:
+        available = executable is not None and (healthy is not False)
+
+        if not available and not include_unavailable:
             continue
 
+        binary_display = executable.display if executable is not None else binary_name
+        source = executable.source if executable is not None else None
         agents.append(
             CodingAgentInfo(
                 id=agent_id,
                 name=display_name,
-                available=resolved is not None,
-                binary=resolved or binary_name,
+                available=available,
+                binary=binary_display,
                 custom_path=bool(custom_binary),
+                source=source,
+                verified=verify,
+                healthy=healthy,
+                error=error,
             )
         )
 

--- a/prompture/infra/discovery.py
+++ b/prompture/infra/discovery.py
@@ -18,6 +18,7 @@ from typing import Any, Literal, overload
 
 from ..drivers.provider_descriptors import PROVIDER_DESCRIPTOR_MAP, ProviderDescriptor, _resolve_cls
 from .cache import MemoryCacheBackend
+from .coding_agent_specs import CODING_AGENT_SPECS, get_spec
 from .provider_env import ProviderEnvironment
 from .settings import settings
 
@@ -120,20 +121,9 @@ class CodingAgentExecutable:
     source: str = "PATH"
 
 
-_CODING_AGENT_SPECS: dict[str, tuple[str, str]] = {
-    "claude": ("Claude Code", "claude"),
-    "codex": ("Codex CLI", "codex"),
-    "gemini": ("Gemini CLI", "gemini"),
-}
-
 _WINDOWS_CLI_EXTENSIONS = (".cmd", ".ps1", ".bat")
 _WINDOWS_CMD_EXTENSIONS = (".cmd", ".bat")
 _CODING_AGENT_HEALTH_TIMEOUT = 5
-_CODING_AGENT_NPM_PACKAGES: dict[str, tuple[str, ...]] = {
-    "claude": ("@anthropic-ai/claude-code",),
-    "codex": ("@openai/codex",),
-    "gemini": ("@google/gemini-cli",),
-}
 _NODE_CLI_ENTRYPOINT_FALLBACKS = (
     Path("dist") / "index.js",
     Path("bin") / "cli.js",
@@ -373,7 +363,8 @@ def _node_package_candidates_from_dir(
     base_dir: Path,
 ) -> list[CodingAgentExecutable]:
     executables: list[CodingAgentExecutable] = []
-    packages = _CODING_AGENT_NPM_PACKAGES.get(agent_id, ())
+    spec = get_spec(agent_id)
+    packages = spec.npm_packages if spec else ()
     if not packages:
         return executables
 
@@ -381,7 +372,7 @@ def _node_package_candidates_from_dir(
     if not node_paths:
         return executables
 
-    command_name = _CODING_AGENT_SPECS.get(agent_id, (agent_id, agent_id))[1]
+    command_name = spec.default_binary if spec else agent_id
     for package_name in packages:
         package_dirs = _npm_package_dir_candidates(base_dir, package_name)
         if not package_dirs:
@@ -635,7 +626,9 @@ def get_available_coding_agents(
     configured_paths = agent_paths or {}
     agents: list[CodingAgentInfo] = []
 
-    for agent_id, (display_name, default_binary) in _CODING_AGENT_SPECS.items():
+    for agent_id, spec in CODING_AGENT_SPECS.items():
+        display_name = spec.display_name
+        default_binary = spec.default_binary
         custom_binary = configured_paths.get(agent_id, "")
         binary_name = custom_binary or default_binary
         executable, healthy, error = resolve_coding_agent_executable(

--- a/prompture/infra/discovery.py
+++ b/prompture/infra/discovery.py
@@ -6,7 +6,10 @@ import dataclasses
 import hashlib
 import logging
 import os
+import platform
+import shutil
 import sys
+from collections.abc import Mapping
 from typing import Any, Literal, overload
 
 from ..drivers.provider_descriptors import PROVIDER_DESCRIPTOR_MAP, ProviderDescriptor, _resolve_cls
@@ -86,6 +89,93 @@ _SOURCE_LABELS: dict[str, str] = {
     "static": "known",
     "catalog": "catalog",
 }
+
+
+@dataclasses.dataclass(frozen=True)
+class CodingAgentInfo:
+    """Availability metadata for an installed coding-agent CLI."""
+
+    id: str
+    name: str
+    available: bool
+    binary: str
+    custom_path: bool = False
+
+
+_CODING_AGENT_SPECS: dict[str, tuple[str, str]] = {
+    "claude": ("Claude Code", "claude"),
+    "codex": ("Codex CLI", "codex"),
+    "gemini": ("Gemini CLI", "gemini"),
+}
+
+_WINDOWS_CLI_EXTENSIONS = (".cmd", ".ps1", ".bat")
+
+
+def resolve_coding_agent_binary(binary: str) -> str | None:
+    """Resolve a coding-agent CLI binary from PATH.
+
+    On Windows, npm-installed CLIs often ship an extensionless shim beside a
+    real ``.cmd`` wrapper. Prefer the wrapper extensions before falling back to
+    the bare command, matching CachiBot's runtime behavior.
+    """
+    if not binary:
+        return None
+
+    expanded = os.path.expanduser(os.path.expandvars(binary))
+    candidates: list[str] = []
+    if platform.system() == "Windows":
+        root, ext = os.path.splitext(expanded)
+        if not ext:
+            candidates.extend(f"{root}{suffix}" for suffix in _WINDOWS_CLI_EXTENSIONS)
+    candidates.append(expanded)
+
+    for candidate in candidates:
+        if path := shutil.which(candidate):
+            return path
+    return None
+
+
+def get_available_coding_agents(
+    *,
+    agent_paths: Mapping[str, str] | None = None,
+    include_unavailable: bool = True,
+) -> list[CodingAgentInfo]:
+    """Auto-detect installed coding-agent CLIs.
+
+    Args:
+        agent_paths: Optional explicit binary paths by agent id. Supported ids
+            are ``"claude"``, ``"codex"``, and ``"gemini"``. Explicit paths
+            override PATH discovery for that agent.
+        include_unavailable: When ``True`` (default), return all known agents
+            with ``available=False`` for missing CLIs. When ``False``, return
+            only discovered agents.
+
+    Returns:
+        A list of :class:`CodingAgentInfo` entries suitable for app settings,
+        command autocomplete, or local capability checks.
+    """
+    configured_paths = agent_paths or {}
+    agents: list[CodingAgentInfo] = []
+
+    for agent_id, (display_name, default_binary) in _CODING_AGENT_SPECS.items():
+        custom_binary = configured_paths.get(agent_id, "")
+        binary_name = custom_binary or default_binary
+        resolved = resolve_coding_agent_binary(binary_name)
+
+        if resolved is None and not include_unavailable:
+            continue
+
+        agents.append(
+            CodingAgentInfo(
+                id=agent_id,
+                name=display_name,
+                available=resolved is not None,
+                binary=resolved or binary_name,
+                custom_path=bool(custom_binary),
+            )
+        )
+
+    return agents
 
 
 def _config_via(desc: ProviderDescriptor) -> str:

--- a/prompture/infra/discovery.py
+++ b/prompture/infra/discovery.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import functools
 import hashlib
 import json
 import logging
@@ -248,7 +249,16 @@ def _resolved_paths_for_binary(binary: str) -> list[str]:
     return _dedupe(paths)
 
 
-def _npm_global_prefixes() -> list[Path]:
+@functools.lru_cache(maxsize=1)
+def _npm_global_prefixes_cached() -> tuple[Path, ...]:
+    """Shell out to ``npm prefix -g`` at most once per process.
+
+    Discovery is invoked many times across a process lifetime (CLI command,
+    health-check loop, server endpoint), and the npm global prefix is stable
+    inside a single process. Cache the result so we don't re-spawn npm for
+    every coding-agent lookup. Callers can :meth:`cache_clear` if they ever
+    need to force a refresh.
+    """
     prefixes: list[Path] = []
     for npm_binary in _resolved_paths_for_binary("npm"):
         try:
@@ -266,7 +276,11 @@ def _npm_global_prefixes() -> list[Path]:
         prefix = completed.stdout.strip()
         if prefix:
             prefixes.append(Path(_manual_windows_to_wsl_path(prefix)))
-    return list(dict.fromkeys(prefixes))
+    return tuple(dict.fromkeys(prefixes))
+
+
+def _npm_global_prefixes() -> list[Path]:
+    return list(_npm_global_prefixes_cached())
 
 
 def _package_path(package_name: str) -> Path:
@@ -403,6 +417,10 @@ def _node_package_candidates_from_shim(
     agent_id: str,
     shim_path: str,
 ) -> list[CodingAgentExecutable]:
+    spec = get_spec(agent_id)
+    if spec is None or not spec.npm_packages:
+        return []
+
     path = Path(shim_path)
     bases = [path.parent]
     with suppress(OSError):
@@ -450,6 +468,13 @@ def _extra_node_package_candidates(
     agent_id: str,
     binary: str,
 ) -> list[CodingAgentExecutable]:
+    # Skip the entire npm-prefix probe for agents that don't ship via npm
+    # (aider via pip, cursor-agent from the Cursor installer, crush from
+    # brew/scoop, etc.). Avoids an `npm prefix -g` subprocess per resolution.
+    spec = get_spec(agent_id)
+    if spec is None or not spec.npm_packages:
+        return []
+
     candidates: list[CodingAgentExecutable] = []
     if _looks_like_path(binary):
         path = Path(_manual_windows_to_wsl_path(os.path.expanduser(os.path.expandvars(binary))))
@@ -609,9 +634,11 @@ def get_available_coding_agents(
     """Auto-detect installed coding-agent CLIs.
 
     Args:
-        agent_paths: Optional explicit binary paths by agent id. Supported ids
-            are ``"claude"``, ``"codex"``, and ``"gemini"``. Explicit paths
-            override PATH discovery for that agent.
+        agent_paths: Optional explicit binary paths by agent id. Any id
+            registered in :data:`CODING_AGENT_SPECS` is accepted (Claude,
+            Codex, Gemini, Qwen, Aider, OpenCode, Cursor Agent, Crush today,
+            plus anything callers have added). Explicit paths override PATH
+            discovery for that agent.
         include_unavailable: When ``True`` (default), return all known agents
             with ``available=False`` for missing CLIs. When ``False``, return
             only discovered agents.

--- a/prompture/infra/settings.py
+++ b/prompture/infra/settings.py
@@ -233,6 +233,16 @@ class Settings(BaseSettings):
     brave_search_api_key: Optional[str] = None
     searxng_endpoint: Optional[str] = None
 
+    # Coding-agent CLI binary overrides (env var: CODING_AGENT_BIN_<UPPER>)
+    coding_agent_bin_claude: Optional[str] = None
+    coding_agent_bin_codex: Optional[str] = None
+    coding_agent_bin_gemini: Optional[str] = None
+    coding_agent_bin_qwen: Optional[str] = None
+    coding_agent_bin_aider: Optional[str] = None
+    coding_agent_bin_opencode: Optional[str] = None
+    coding_agent_bin_cursor_agent: Optional[str] = None
+    coding_agent_bin_crush: Optional[str] = None
+
     # Document ingestion
     ingest_max_file_size: int = 52428800  # 50 MB
     ingest_pdf_backend: str = "pdfplumber"  # "pdfplumber" | "pypdf" | "pymupdf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,4 +174,8 @@ ignore_missing_imports = true
 
 [tool.bandit]
 exclude_dirs = ["tests", "examples"]
-skips = ["B101", "B104", "B110", "B112", "B615"]
+# B404/B603/B607 are noisy for legitimate subprocess usage. The coding-agent
+# runner shells out to CLI binaries whose argv comes from the curated
+# CODING_AGENT_SPECS registry and resolved-path executables, not from raw
+# user input. shell=False is already in use (which B603 paradoxically flags).
+skips = ["B101", "B104", "B110", "B112", "B404", "B603", "B607", "B615"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,10 @@ indent-style = "space"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]
-markers = ["integration: marks tests that use real LLM APIs"]
+markers = [
+    "integration: marks tests that use real LLM APIs",
+    "coding_agent_live: marks tests that shell out to a real coding-agent CLI",
+]
 addopts = "-v"
 asyncio_mode = "auto"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,12 @@ def pytest_addoption(parser):
         default=False,
         help="Run tests marked with @pytest.mark.integration (requires live LLM access)",
     )
+    parser.addoption(
+        "--run-coding-agent-live",
+        action="store_true",
+        default=False,
+        help="Run tests marked with @pytest.mark.coding_agent_live (shells out to real CLIs)",
+    )
 
 
 @pytest.fixture
@@ -70,6 +76,10 @@ def integration_driver(request):
 def pytest_configure(config):
     """Configure pytest markers."""
     config.addinivalue_line("markers", "integration: marks tests that use real LLM APIs")
+    config.addinivalue_line(
+        "markers",
+        "coding_agent_live: marks tests that shell out to a real coding-agent CLI",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -79,14 +89,17 @@ def pytest_collection_modifyitems(config, items):
         "true",
         "yes",
     }
+    run_coding_agent_live = config.getoption("--run-coding-agent-live") or os.getenv(
+        "RUN_CODING_AGENT_LIVE_TESTS", ""
+    ).lower() in {"1", "true", "yes"}
 
-    if run_integration:
-        return
-
-    skip_marker = pytest.mark.skip(reason="use --run-integration to run these tests")
+    skip_integration = pytest.mark.skip(reason="use --run-integration to run these tests")
+    skip_live = pytest.mark.skip(reason="use --run-coding-agent-live to shell out to real CLIs")
     for item in items:
-        if "integration" in item.keywords:
-            item.add_marker(skip_marker)
+        if "integration" in item.keywords and not run_integration:
+            item.add_marker(skip_integration)
+        if "coding_agent_live" in item.keywords and not run_coding_agent_live:
+            item.add_marker(skip_live)
 
 
 def assert_valid_usage_metadata(meta: dict[str, Any]):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 from prompture.cli.cli import cli
+from prompture.infra.discovery import CodingAgentExecutable
 
 
 @pytest.mark.integration
@@ -73,10 +74,32 @@ def test_coding_agents_command_lists_agents():
     assert "gemini" in result.output
 
 
+def test_coding_agents_command_can_verify_health():
+    """The coding-agents command can show health-check errors."""
+    runner = CliRunner()
+    with (
+        patch(
+            "prompture.infra.discovery.shutil.which",
+            side_effect=lambda binary: "/usr/local/bin/codex" if binary == "codex" else None,
+        ),
+        patch("prompture.infra.discovery.verify_coding_agent_executable", return_value=(False, "node: not found")),
+    ):
+        result = runner.invoke(cli, ["coding-agents", "--verify"])
+
+    assert result.exit_code == 0
+    assert "failed" in result.output
+    assert "node: not found" in result.output
+
+
 def test_code_agent_dry_run_auto_approve(tmp_path):
     """Dry-run shows the resolved coding-agent command without executing it."""
     runner = CliRunner()
-    with patch("prompture.infra.coding_agents.resolve_coding_agent_binary", return_value="/usr/local/bin/codex"):
+    executable = CodingAgentExecutable(
+        binary="/usr/local/bin/codex",
+        argv=("/usr/local/bin/codex",),
+        display="/usr/local/bin/codex",
+    )
+    with patch("prompture.infra.coding_agents.resolve_coding_agent_executable", return_value=(executable, None, None)):
         result = runner.invoke(
             cli,
             [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import json
 import os
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
@@ -59,3 +60,38 @@ def test_run_command(tmp_path):
     # Additional assertions on the structure of the output data could be added
     # For example:
     assert "results" in output_data
+
+
+def test_coding_agents_command_lists_agents():
+    """The coding-agents command prints discovery results."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["coding-agents"])
+
+    assert result.exit_code == 0
+    assert "claude" in result.output
+    assert "codex" in result.output
+    assert "gemini" in result.output
+
+
+def test_code_agent_dry_run_auto_approve(tmp_path):
+    """Dry-run shows the resolved coding-agent command without executing it."""
+    runner = CliRunner()
+    with patch("prompture.infra.coding_agents.resolve_coding_agent_binary", return_value="/usr/local/bin/codex"):
+        result = runner.invoke(
+            cli,
+            [
+                "code-agent",
+                "codex",
+                "--cwd",
+                str(tmp_path),
+                "--auto-approve",
+                "--dry-run",
+                "fix",
+                "the",
+                "tests",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert "/usr/local/bin/codex exec" in result.output
+    assert "--ask-for-approval never" in result.output

--- a/tests/test_coding_agent_events.py
+++ b/tests/test_coding_agent_events.py
@@ -331,3 +331,124 @@ class TestCodexJSONParser:
     def test_envelope_without_msg_is_dropped(self):
         events = list(parse_codex_json_lines(_lines({"id": "1"})))
         assert events == []
+
+
+class TestQuestionDetection:
+    def test_simple_question_mark_triggers(self):
+        from prompture.infra.coding_agent_events import detect_question
+
+        is_q, choices = detect_question("Should we proceed with option A?")
+        assert is_q is True
+        assert choices is None
+
+    def test_phrase_trigger_without_question_mark(self):
+        from prompture.infra.coding_agent_events import detect_question
+
+        is_q, _ = detect_question("Let me know which one you'd prefer.")
+        assert is_q is True
+
+    def test_numbered_choices_extracted(self):
+        from prompture.infra.coding_agent_events import detect_question
+
+        text = (
+            "Which approach do you want?\n"
+            "1. Refactor the whole module\n"
+            "2. Add a thin wrapper\n"
+            "3. Leave it as-is"
+        )
+        is_q, choices = detect_question(text)
+        assert is_q is True
+        assert choices == (
+            "Refactor the whole module",
+            "Add a thin wrapper",
+            "Leave it as-is",
+        )
+
+    def test_bulleted_choices_extracted(self):
+        from prompture.infra.coding_agent_events import detect_question
+
+        text = "Do you want me to:\n- delete the file\n- archive it instead\n- skip it"
+        is_q, choices = detect_question(text)
+        assert is_q is True
+        assert choices == ("delete the file", "archive it instead", "skip it")
+
+    def test_no_question_when_just_a_statement(self):
+        from prompture.infra.coding_agent_events import detect_question
+
+        is_q, choices = detect_question("Updated the README and ran the tests.")
+        assert is_q is False
+        assert choices is None
+
+    def test_single_bullet_is_not_choices(self):
+        from prompture.infra.coding_agent_events import detect_question
+
+        # One bullet alone doesn't count — needs at least two consecutive.
+        is_q, choices = detect_question("Should I proceed?\n- yes")
+        assert is_q is True
+        assert choices is None
+
+    def test_empty_text_returns_false(self):
+        from prompture.infra.coding_agent_events import detect_question
+
+        assert detect_question("") == (False, None)
+        assert detect_question(None) == (False, None)
+
+    def test_claude_message_with_question_emits_question_event(self):
+        from prompture.infra.coding_agent_events import parse_claude_stream_json_lines
+
+        events = list(
+            parse_claude_stream_json_lines(
+                _lines(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "Which file would you like me to start with?",
+                                }
+                            ]
+                        },
+                    }
+                )
+            )
+        )
+        assert [e.type for e in events] == ["message", "question"]
+        assert events[1].text == "Which file would you like me to start with?"
+
+    def test_codex_message_with_choices_emits_question_with_choices(self):
+        events = list(
+            parse_codex_json_lines(
+                _lines(
+                    {
+                        "msg": {
+                            "type": "agent_message",
+                            "message": (
+                                "Do you want me to:\n"
+                                "1. Update the schema\n"
+                                "2. Skip the migration"
+                            ),
+                        }
+                    }
+                )
+            )
+        )
+        assert [e.type for e in events] == ["message", "question"]
+        assert events[1].choices == ("Update the schema", "Skip the migration")
+
+    def test_claude_done_text_question_emits_after_done(self):
+        from prompture.infra.coding_agent_events import parse_claude_stream_json_lines
+
+        events = list(
+            parse_claude_stream_json_lines(
+                _lines(
+                    {
+                        "type": "result",
+                        "is_error": False,
+                        "result": "Should I commit these changes?",
+                        "total_cost_usd": 0.001,
+                    }
+                )
+            )
+        )
+        assert [e.type for e in events] == ["done", "question"]

--- a/tests/test_coding_agent_events.py
+++ b/tests/test_coding_agent_events.py
@@ -7,6 +7,7 @@ import json
 from prompture.infra.coding_agent_events import (
     CodingAgentEvent,
     parse_claude_stream_json_lines,
+    parse_codex_json_lines,
 )
 
 
@@ -242,3 +243,91 @@ class TestClaudeStreamJSONParser:
         assert done.cost_usd == 0.001
         assert done.input_tokens == 10
         assert done.output_tokens == 5
+
+
+class TestCodexJSONParser:
+    def test_task_started_is_system_event(self):
+        events = list(parse_codex_json_lines(_lines({"id": "1", "msg": {"type": "task_started", "model": "gpt-5"}})))
+        assert [e.type for e in events] == ["system"]
+
+    def test_agent_message_emits_message_event(self):
+        events = list(
+            parse_codex_json_lines(_lines({"msg": {"type": "agent_message", "message": "hello"}}))
+        )
+        assert events == [CodingAgentEvent(type="message", text="hello", raw=events[0].raw)]
+
+    def test_agent_message_delta_emits_partial_message(self):
+        events = list(
+            parse_codex_json_lines(_lines({"msg": {"type": "agent_message_delta", "delta": "Hel"}}))
+        )
+        assert [e.type for e in events] == ["message"]
+        assert events[0].text == "Hel"
+
+    def test_empty_delta_is_skipped(self):
+        events = list(
+            parse_codex_json_lines(_lines({"msg": {"type": "agent_message_delta", "delta": ""}}))
+        )
+        assert events == []
+
+    def test_exec_command_begin_is_tool_call(self):
+        events = list(
+            parse_codex_json_lines(
+                _lines({"msg": {"type": "exec_command_begin", "call_id": "c1", "command": ["ls", "-la"]}})
+            )
+        )
+        assert events[0].type == "tool_call"
+        assert events[0].tool_name == "exec"
+        assert events[0].tool_input == {"command": ["ls", "-la"]}
+
+    def test_exec_command_end_merges_stdout_stderr(self):
+        events = list(
+            parse_codex_json_lines(
+                _lines(
+                    {
+                        "msg": {
+                            "type": "exec_command_end",
+                            "call_id": "c1",
+                            "exit_code": 0,
+                            "stdout": "file1",
+                            "stderr": "warn",
+                        }
+                    }
+                )
+            )
+        )
+        assert events[0].type == "tool_result"
+        assert events[0].tool_output == "file1\nwarn"
+
+    def test_task_complete_emits_done_with_tokens(self):
+        events = list(
+            parse_codex_json_lines(
+                _lines(
+                    {
+                        "msg": {
+                            "type": "task_complete",
+                            "last_agent_message": "All done.",
+                            "token_usage": {"input_tokens": 100, "output_tokens": 200},
+                        }
+                    }
+                )
+            )
+        )
+        assert events[0].type == "done"
+        assert events[0].text == "All done."
+        assert events[0].input_tokens == 100
+        assert events[0].output_tokens == 200
+
+    def test_explicit_error_event(self):
+        events = list(
+            parse_codex_json_lines(_lines({"msg": {"type": "error", "message": "rate limit"}}))
+        )
+        assert events[0].type == "error"
+        assert events[0].error == "rate limit"
+
+    def test_unknown_type_is_dropped(self):
+        events = list(parse_codex_json_lines(_lines({"msg": {"type": "heartbeat"}})))
+        assert events == []
+
+    def test_envelope_without_msg_is_dropped(self):
+        events = list(parse_codex_json_lines(_lines({"id": "1"})))
+        assert events == []

--- a/tests/test_coding_agent_events.py
+++ b/tests/test_coding_agent_events.py
@@ -1,0 +1,244 @@
+"""Tests for coding-agent structured event parsing."""
+
+from __future__ import annotations
+
+import json
+
+from prompture.infra.coding_agent_events import (
+    CodingAgentEvent,
+    parse_claude_stream_json_lines,
+)
+
+
+def _lines(*objs: dict) -> list[str]:
+    return [json.dumps(o) for o in objs]
+
+
+class TestClaudeStreamJSONParser:
+    def test_emits_system_init_event(self):
+        events = list(
+            parse_claude_stream_json_lines(
+                _lines({"type": "system", "subtype": "init", "session_id": "abc"})
+            )
+        )
+        assert len(events) == 1
+        assert events[0].type == "system"
+        assert events[0].raw == {"type": "system", "subtype": "init", "session_id": "abc"}
+
+    def test_emits_assistant_text_message(self):
+        events = list(
+            parse_claude_stream_json_lines(
+                _lines(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": "Hello world"}],
+                        },
+                    }
+                )
+            )
+        )
+        assert events == [
+            CodingAgentEvent(type="message", text="Hello world", raw=events[0].raw),
+        ]
+
+    def test_emits_tool_call_with_input(self):
+        events = list(
+            parse_claude_stream_json_lines(
+                _lines(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [
+                                {
+                                    "type": "tool_use",
+                                    "id": "t1",
+                                    "name": "Bash",
+                                    "input": {"command": "ls"},
+                                }
+                            ]
+                        },
+                    }
+                )
+            )
+        )
+        assert len(events) == 1
+        assert events[0].type == "tool_call"
+        assert events[0].tool_name == "Bash"
+        assert events[0].tool_input == {"command": "ls"}
+
+    def test_emits_tool_result_flattened_text(self):
+        events = list(
+            parse_claude_stream_json_lines(
+                _lines(
+                    {
+                        "type": "user",
+                        "message": {
+                            "content": [
+                                {
+                                    "type": "tool_result",
+                                    "tool_use_id": "t1",
+                                    "content": [
+                                        {"type": "text", "text": "file1"},
+                                        {"type": "text", "text": "file2"},
+                                    ],
+                                }
+                            ]
+                        },
+                    }
+                )
+            )
+        )
+        assert len(events) == 1
+        assert events[0].type == "tool_result"
+        assert events[0].tool_output == "file1\nfile2"
+
+    def test_tool_result_with_string_content(self):
+        events = list(
+            parse_claude_stream_json_lines(
+                _lines(
+                    {
+                        "type": "user",
+                        "message": {
+                            "content": [
+                                {
+                                    "type": "tool_result",
+                                    "tool_use_id": "t1",
+                                    "content": "raw stdout",
+                                }
+                            ]
+                        },
+                    }
+                )
+            )
+        )
+        assert events[0].tool_output == "raw stdout"
+
+    def test_emits_done_with_cost_and_tokens(self):
+        events = list(
+            parse_claude_stream_json_lines(
+                _lines(
+                    {
+                        "type": "result",
+                        "subtype": "success",
+                        "is_error": False,
+                        "duration_ms": 12345,
+                        "total_cost_usd": 0.0341,
+                        "result": "Done",
+                        "usage": {"input_tokens": 100, "output_tokens": 50},
+                    }
+                )
+            )
+        )
+        assert events == [
+            CodingAgentEvent(
+                type="done",
+                text="Done",
+                cost_usd=0.0341,
+                input_tokens=100,
+                output_tokens=50,
+                duration_ms=12345,
+                raw=events[0].raw,
+            )
+        ]
+
+    def test_done_with_error_flag_records_error_text(self):
+        events = list(
+            parse_claude_stream_json_lines(
+                _lines(
+                    {
+                        "type": "result",
+                        "is_error": True,
+                        "result": "rate limited",
+                    }
+                )
+            )
+        )
+        assert events[0].type == "done"
+        assert events[0].error == "rate limited"
+
+    def test_skips_blank_lines_and_yields_error_on_bad_json(self):
+        events = list(
+            parse_claude_stream_json_lines(
+                [
+                    "",
+                    "   ",
+                    "not-json{",
+                    json.dumps({"type": "system"}),
+                ]
+            )
+        )
+        assert [e.type for e in events] == ["error", "system"]
+        assert "invalid JSON" in (events[0].error or "")
+
+    def test_multi_part_assistant_content_emits_multiple_events(self):
+        events = list(
+            parse_claude_stream_json_lines(
+                _lines(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [
+                                {"type": "text", "text": "Let me check."},
+                                {"type": "tool_use", "name": "Read", "input": {"path": "x"}},
+                            ]
+                        },
+                    }
+                )
+            )
+        )
+        assert [e.type for e in events] == ["message", "tool_call"]
+        assert events[0].text == "Let me check."
+        assert events[1].tool_name == "Read"
+
+    def test_unknown_event_type_is_silently_dropped(self):
+        events = list(parse_claude_stream_json_lines(_lines({"type": "heartbeat"})))
+        assert events == []
+
+    def test_full_session_replay(self):
+        events = list(
+            parse_claude_stream_json_lines(
+                _lines(
+                    {"type": "system", "subtype": "init", "session_id": "s1"},
+                    {
+                        "type": "assistant",
+                        "message": {"content": [{"type": "text", "text": "Reading..."}]},
+                    },
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [
+                                {"type": "tool_use", "name": "Read", "input": {"path": "a.py"}}
+                            ]
+                        },
+                    },
+                    {
+                        "type": "user",
+                        "message": {
+                            "content": [
+                                {"type": "tool_result", "tool_use_id": "1", "content": "print('hi')"}
+                            ]
+                        },
+                    },
+                    {
+                        "type": "result",
+                        "is_error": False,
+                        "result": "Done",
+                        "total_cost_usd": 0.001,
+                        "usage": {"input_tokens": 10, "output_tokens": 5},
+                    },
+                )
+            )
+        )
+        assert [e.type for e in events] == [
+            "system",
+            "message",
+            "tool_call",
+            "tool_result",
+            "done",
+        ]
+        done = events[-1]
+        assert done.cost_usd == 0.001
+        assert done.input_tokens == 10
+        assert done.output_tokens == 5

--- a/tests/test_coding_agent_events.py
+++ b/tests/test_coding_agent_events.py
@@ -452,3 +452,38 @@ class TestQuestionDetection:
             )
         )
         assert [e.type for e in events] == ["done", "question"]
+
+
+class TestSessionIdExtraction:
+    def test_claude_system_event_extracts_session_id(self):
+        events = list(
+            parse_claude_stream_json_lines(
+                _lines({"type": "system", "subtype": "init", "session_id": "abc-123"})
+            )
+        )
+        assert events[0].session_id == "abc-123"
+
+    def test_claude_result_event_extracts_session_id(self):
+        events = list(
+            parse_claude_stream_json_lines(
+                _lines({"type": "result", "is_error": False, "result": "ok", "session_id": "abc-123"})
+            )
+        )
+        assert events[0].type == "done"
+        assert events[0].session_id == "abc-123"
+
+    def test_codex_task_started_extracts_session_id_from_msg(self):
+        events = list(
+            parse_codex_json_lines(
+                _lines({"msg": {"type": "task_started", "model": "gpt-5", "session_id": "codex-1"}})
+            )
+        )
+        assert events[0].session_id == "codex-1"
+
+    def test_codex_session_configured_extracts_envelope_session_id(self):
+        events = list(
+            parse_codex_json_lines(
+                _lines({"session_id": "codex-2", "msg": {"type": "session_configured"}})
+            )
+        )
+        assert events[0].session_id == "codex-2"

--- a/tests/test_coding_agents.py
+++ b/tests/test_coding_agents.py
@@ -617,3 +617,90 @@ class TestStreaming:
 
         with pytest.raises(ValueError, match="output_format='json'"):
             asyncio.run(_run())
+
+
+class TestSettingsAgentPaths:
+    """Tests for picking up agent binary paths from settings/env."""
+
+    @patch("prompture.infra.coding_agents.resolve_coding_agent_executable")
+    def test_settings_binary_is_used_when_no_explicit_path(self, mock_resolve, tmp_path):
+        """A coding_agent_bin_<id> setting is honoured by resolve when no kwarg given."""
+        from prompture.infra import build_coding_agent_command
+        from prompture.infra.settings import settings as _s
+
+        exe = CodingAgentExecutable(
+            binary="/opt/aider/aider",
+            argv=("/opt/aider/aider",),
+            display="/opt/aider/aider",
+        )
+        mock_resolve.return_value = (exe, True, None)
+
+        original = _s.coding_agent_bin_aider
+        _s.coding_agent_bin_aider = "/opt/aider/aider"
+        try:
+            command = build_coding_agent_command(
+                "aider",
+                "do a thing",
+                cwd=tmp_path,
+                approval_mode="auto",
+            )
+        finally:
+            _s.coding_agent_bin_aider = original
+
+        # Resolver was asked for the path the user configured in settings.
+        assert mock_resolve.call_args.args[1] == "/opt/aider/aider"
+        assert command.argv[0] == "/opt/aider/aider"
+
+    @patch("prompture.infra.coding_agents.resolve_coding_agent_executable")
+    def test_explicit_kwarg_overrides_settings(self, mock_resolve, tmp_path):
+        """An explicit agent_paths kwarg wins over the settings default."""
+        from prompture.infra import build_coding_agent_command
+        from prompture.infra.settings import settings as _s
+
+        exe = CodingAgentExecutable(
+            binary="/from/kwarg/aider",
+            argv=("/from/kwarg/aider",),
+            display="/from/kwarg/aider",
+        )
+        mock_resolve.return_value = (exe, True, None)
+
+        original = _s.coding_agent_bin_aider
+        _s.coding_agent_bin_aider = "/from/settings/aider"
+        try:
+            build_coding_agent_command(
+                "aider",
+                "task",
+                cwd=tmp_path,
+                approval_mode="auto",
+                agent_paths={"aider": "/from/kwarg/aider"},
+            )
+        finally:
+            _s.coding_agent_bin_aider = original
+
+        assert mock_resolve.call_args.args[1] == "/from/kwarg/aider"
+
+    @patch("prompture.infra.coding_agents.resolve_coding_agent_executable")
+    def test_cursor_agent_hyphen_id_maps_to_underscore_setting(self, mock_resolve, tmp_path):
+        from prompture.infra import build_coding_agent_command
+        from prompture.infra.settings import settings as _s
+
+        exe = CodingAgentExecutable(
+            binary="/opt/cursor-agent",
+            argv=("/opt/cursor-agent",),
+            display="/opt/cursor-agent",
+        )
+        mock_resolve.return_value = (exe, True, None)
+
+        original = _s.coding_agent_bin_cursor_agent
+        _s.coding_agent_bin_cursor_agent = "/opt/cursor-agent"
+        try:
+            build_coding_agent_command(
+                "cursor-agent",
+                "task",
+                cwd=tmp_path,
+                approval_mode="auto",
+            )
+        finally:
+            _s.coding_agent_bin_cursor_agent = original
+
+        assert mock_resolve.call_args.args[1] == "/opt/cursor-agent"

--- a/tests/test_coding_agents.py
+++ b/tests/test_coding_agents.py
@@ -55,7 +55,11 @@ class TestCodingAgentCommands:
         return_value=_executable("/usr/local/bin/claude"),
     )
     def test_claude_auto_and_model_command(self, _mock_resolve, tmp_path):
-        """Claude auto mode runs non-interactively with dontAsk permissions."""
+        """Claude auto mode skips permission prompts via the dangerous flag.
+
+        Claude Code does not expose an intermediate non-interactive mode — the
+        only way to suppress approval prompts is --dangerously-skip-permissions.
+        """
         command = build_coding_agent_command(
             "claude",
             "review this repository",
@@ -71,8 +75,7 @@ class TestCodingAgentCommands:
             "text",
             "--model",
             "sonnet",
-            "--permission-mode",
-            "dontAsk",
+            "--dangerously-skip-permissions",
             "review this repository",
         ]
 
@@ -133,21 +136,117 @@ class TestCodingAgentCommands:
         import pytest
 
         with pytest.raises(ValueError, match="Unsupported coding agent"):
-            build_coding_agent_command("aider", "do a thing", cwd=tmp_path)
+            build_coding_agent_command("nonesuch", "do a thing", cwd=tmp_path)
+
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/aider"),
+    )
+    def test_aider_auto_and_model_command(self, _mock_resolve, tmp_path):
+        """Aider takes the task via --message and skips prompts with --yes-always."""
+        command = build_coding_agent_command(
+            "aider",
+            "rename foo to bar",
+            cwd=tmp_path,
+            approval_mode="auto",
+            model="gpt-4o",
+        )
+
+        assert command.argv == [
+            "/usr/local/bin/aider",
+            "--model",
+            "gpt-4o",
+            "--yes-always",
+            "--message",
+            "rename foo to bar",
+        ]
+
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/opencode"),
+    )
+    def test_opencode_run_subcommand(self, _mock_resolve, tmp_path):
+        """OpenCode uses the `run` subcommand for non-interactive execution."""
+        command = build_coding_agent_command(
+            "opencode",
+            "add a CHANGELOG entry",
+            cwd=tmp_path,
+            approval_mode="auto",
+            model="anthropic/claude-sonnet-4",
+        )
+
+        assert command.argv == [
+            "/usr/local/bin/opencode",
+            "run",
+            "--model",
+            "anthropic/claude-sonnet-4",
+            "add a CHANGELOG entry",
+        ]
+
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/cursor-agent"),
+    )
+    def test_cursor_agent_print_mode(self, _mock_resolve, tmp_path):
+        """Cursor Agent uses -p for non-interactive print mode."""
+        command = build_coding_agent_command(
+            "cursor-agent",
+            "explain main.py",
+            cwd=tmp_path,
+            approval_mode="auto",
+        )
+
+        assert command.argv == [
+            "/usr/local/bin/cursor-agent",
+            "-p",
+            "--force",
+            "explain main.py",
+        ]
+
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/crush"),
+    )
+    def test_crush_yolo_command(self, _mock_resolve, tmp_path):
+        """Crush exposes an explicit --yolo flag for full auto mode."""
+        command = build_coding_agent_command(
+            "crush",
+            "tidy this module",
+            cwd=tmp_path,
+            approval_mode="yolo",
+        )
+
+        assert "run" in command.argv
+        assert "--yolo" in command.argv
+        assert command.argv[-1] == "tidy this module"
 
 
 class TestCodingAgentSpecs:
     """Registry-level sanity checks."""
 
-    def test_registry_includes_qwen(self):
+    def test_registry_includes_all_quick_wins(self):
         from prompture.infra import CODING_AGENT_SPECS, get_coding_agent_spec
 
-        assert "qwen" in CODING_AGENT_SPECS
+        for agent_id in ("claude", "codex", "gemini", "qwen", "aider", "opencode", "cursor-agent", "crush"):
+            assert agent_id in CODING_AGENT_SPECS, f"missing spec: {agent_id}"
+            assert get_coding_agent_spec(agent_id) is not None
+
+    def test_qwen_uses_gemini_npm_package_shape(self):
+        from prompture.infra import get_coding_agent_spec
+
         spec = get_coding_agent_spec("qwen")
         assert spec is not None
         assert spec.display_name == "Qwen Code"
-        assert spec.default_binary == "qwen"
         assert spec.npm_packages == ("@qwen-code/qwen-code",)
+
+    def test_pip_only_agents_have_no_npm_package(self):
+        """Aider, Cursor Agent, and Crush are not distributed via npm."""
+        from prompture.infra import get_coding_agent_spec
+
+        for agent_id in ("aider", "cursor-agent", "crush"):
+            spec = get_coding_agent_spec(agent_id)
+            assert spec is not None
+            assert spec.npm_packages == ()
 
     def test_get_spec_returns_none_for_unknown(self):
         from prompture.infra import get_coding_agent_spec

--- a/tests/test_coding_agents.py
+++ b/tests/test_coding_agents.py
@@ -2,12 +2,20 @@ import subprocess
 from unittest.mock import patch
 
 from prompture.infra import build_coding_agent_command, run_coding_agent
+from prompture.infra.discovery import CodingAgentExecutable
+
+
+def _executable(path: str) -> tuple[CodingAgentExecutable, bool, None]:
+    return CodingAgentExecutable(binary=path, argv=(path,), display=path), True, None
 
 
 class TestCodingAgentCommands:
     """Tests for coding-agent command construction."""
 
-    @patch("prompture.infra.coding_agents.resolve_coding_agent_binary", return_value="/usr/local/bin/codex")
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/codex"),
+    )
     def test_codex_auto_approve_command(self, _mock_resolve, tmp_path):
         """Codex auto mode uses non-interactive exec with workspace approvals disabled."""
         command = build_coding_agent_command(
@@ -27,7 +35,10 @@ class TestCodingAgentCommands:
             "fix the tests",
         ]
 
-    @patch("prompture.infra.coding_agents.resolve_coding_agent_binary", return_value="/usr/local/bin/codex")
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/codex"),
+    )
     def test_codex_yolo_command(self, _mock_resolve, tmp_path):
         """Codex yolo mode uses the explicit dangerous bypass flag."""
         command = build_coding_agent_command(
@@ -39,7 +50,10 @@ class TestCodingAgentCommands:
 
         assert "--dangerously-bypass-approvals-and-sandbox" in command.argv
 
-    @patch("prompture.infra.coding_agents.resolve_coding_agent_binary", return_value="/usr/local/bin/claude")
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/claude"),
+    )
     def test_claude_auto_and_model_command(self, _mock_resolve, tmp_path):
         """Claude auto mode runs non-interactively with dontAsk permissions."""
         command = build_coding_agent_command(
@@ -62,7 +76,10 @@ class TestCodingAgentCommands:
             "review this repository",
         ]
 
-    @patch("prompture.infra.coding_agents.resolve_coding_agent_binary", return_value="/usr/local/bin/claude")
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/claude"),
+    )
     def test_claude_yolo_command(self, _mock_resolve, tmp_path):
         """Claude yolo mode uses Claude Code's dangerous skip-permissions flag."""
         command = build_coding_agent_command(
@@ -74,7 +91,10 @@ class TestCodingAgentCommands:
 
         assert "--dangerously-skip-permissions" in command.argv
 
-    @patch("prompture.infra.coding_agents.resolve_coding_agent_binary", return_value="/usr/local/bin/gemini")
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/gemini"),
+    )
     def test_gemini_auto_command(self, _mock_resolve, tmp_path):
         """Gemini auto mode passes yes mode through to the CLI."""
         command = build_coding_agent_command(
@@ -91,7 +111,10 @@ class TestCodingAgentRunner:
     """Tests for running coding-agent commands without invoking real CLIs."""
 
     @patch("prompture.infra.coding_agents.subprocess.run")
-    @patch("prompture.infra.coding_agents.resolve_coding_agent_binary", return_value="/usr/local/bin/codex")
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/codex"),
+    )
     def test_run_coding_agent_returns_result(self, _mock_resolve, mock_run, tmp_path):
         """Runner captures subprocess output and metadata."""
         mock_run.return_value = subprocess.CompletedProcess(
@@ -107,4 +130,42 @@ class TestCodingAgentRunner:
         assert result.agent == "codex"
         assert result.output == "done"
         assert result.returncode == 0
+        mock_run.assert_called_once()
+
+    @patch("prompture.infra.coding_agents.subprocess.run")
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=(
+            None,
+            False,
+            "node: not found",
+        ),
+    )
+    def test_run_coding_agent_verifies_before_running_task(self, _mock_resolve, mock_run, tmp_path):
+        """Runner fails early when PATH resolves to a broken CLI shim."""
+        result = run_coding_agent("gemini", "fix bug", cwd=tmp_path, approval_mode="auto")
+
+        assert result.ok is False
+        assert result.returncode == -1
+        assert result.output == "gemini CLI health check failed: node: not found"
+        mock_run.assert_not_called()
+
+    @patch("prompture.infra.coding_agents.subprocess.run")
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/codex"),
+    )
+    def test_run_coding_agent_can_skip_verification(self, _mock_resolve, mock_run, tmp_path):
+        """Callers can skip the preflight check when they need raw subprocess behavior."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["/usr/local/bin/codex"],
+            returncode=0,
+            stdout="done",
+            stderr="",
+        )
+
+        result = run_coding_agent("codex", "fix bug", cwd=tmp_path, verify_binary=False)
+
+        assert result.ok is True
+        assert result.output == "done"
         mock_run.assert_called_once()

--- a/tests/test_coding_agents.py
+++ b/tests/test_coding_agents.py
@@ -812,3 +812,80 @@ class TestSessionCapture:
         assert sess.call_count == 1
         assert sess.cost == 0.0
         assert sess.total_tokens == 0
+
+
+class TestAskedQuestionProperty:
+    @patch("prompture.infra.coding_agents.subprocess.run")
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/claude"),
+    )
+    def test_asked_question_surfaces_last_question_event(self, _mock_resolve, mock_run, tmp_path):
+        import json as _json
+
+        stream = "\n".join(
+            [
+                _json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [
+                                {"type": "text", "text": "Which approach do you want?\n1. Foo\n2. Bar"}
+                            ]
+                        },
+                    }
+                ),
+                _json.dumps(
+                    {
+                        "type": "result",
+                        "is_error": False,
+                        "result": "I need a decision before continuing.",
+                    }
+                ),
+            ]
+        )
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["/usr/local/bin/claude"], returncode=0, stdout=stream, stderr=""
+        )
+
+        result = run_coding_agent(
+            "claude",
+            "do a thing",
+            cwd=tmp_path,
+            approval_mode="auto",
+            output_format="json",
+        )
+
+        q = result.asked_question
+        assert q is not None
+        assert q.type == "question"
+        assert q.choices == ("Foo", "Bar")
+
+    @patch("prompture.infra.coding_agents.subprocess.run")
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/claude"),
+    )
+    def test_asked_question_is_none_when_no_question(self, _mock_resolve, mock_run, tmp_path):
+        import json as _json
+
+        stream = _json.dumps(
+            {
+                "type": "result",
+                "is_error": False,
+                "result": "Done.",
+            }
+        )
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["/usr/local/bin/claude"], returncode=0, stdout=stream, stderr=""
+        )
+
+        result = run_coding_agent(
+            "claude",
+            "task",
+            cwd=tmp_path,
+            approval_mode="auto",
+            output_format="json",
+        )
+
+        assert result.asked_question is None

--- a/tests/test_coding_agents.py
+++ b/tests/test_coding_agents.py
@@ -889,3 +889,86 @@ class TestAskedQuestionProperty:
         )
 
         assert result.asked_question is None
+
+
+class TestSessionContinuity:
+    """Tests for resuming a previous coding-agent session."""
+
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/claude"),
+    )
+    def test_claude_resume_flag_emitted(self, _mock_resolve, tmp_path):
+        command = build_coding_agent_command(
+            "claude",
+            "follow up",
+            cwd=tmp_path,
+            approval_mode="auto",
+            session_id="sess-abc",
+        )
+        assert "--resume" in command.argv
+        idx = command.argv.index("--resume")
+        assert command.argv[idx + 1] == "sess-abc"
+
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/codex"),
+    )
+    def test_codex_resume_subcommand(self, _mock_resolve, tmp_path):
+        command = build_coding_agent_command(
+            "codex",
+            "follow up",
+            cwd=tmp_path,
+            approval_mode="auto",
+            session_id="sess-xyz",
+        )
+        # codex exec resume <id> ...
+        assert command.argv[1:4] == ["exec", "resume", "sess-xyz"]
+
+    @patch("prompture.infra.coding_agents.subprocess.run")
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/claude"),
+    )
+    def test_result_captures_session_id_from_system_event(self, _mock_resolve, mock_run, tmp_path):
+        import json as _json
+
+        stream = "\n".join(
+            [
+                _json.dumps({"type": "system", "subtype": "init", "session_id": "captured-1"}),
+                _json.dumps({"type": "result", "is_error": False, "result": "ok"}),
+            ]
+        )
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["/usr/local/bin/claude"], returncode=0, stdout=stream, stderr=""
+        )
+
+        result = run_coding_agent(
+            "claude",
+            "task",
+            cwd=tmp_path,
+            approval_mode="auto",
+            output_format="json",
+        )
+
+        assert result.session_id == "captured-1"
+
+    @patch("prompture.infra.coding_agents.subprocess.run")
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/claude"),
+    )
+    def test_supplied_session_id_preserved_when_no_init_event(self, _mock_resolve, mock_run, tmp_path):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["/usr/local/bin/claude"], returncode=0, stdout="plain text", stderr=""
+        )
+
+        result = run_coding_agent(
+            "claude",
+            "follow up",
+            cwd=tmp_path,
+            approval_mode="auto",
+            session_id="from-caller",
+        )
+
+        assert result.session_id == "from-caller"

--- a/tests/test_coding_agents.py
+++ b/tests/test_coding_agents.py
@@ -277,20 +277,38 @@ class TestStructuredOutput:
 
     @patch(
         "prompture.infra.coding_agents.resolve_coding_agent_executable",
-        return_value=_executable("/usr/local/bin/codex"),
+        return_value=_executable("/usr/local/bin/gemini"),
     )
     def test_json_mode_rejected_for_unsupported_agent(self, _mock_resolve, tmp_path):
+        """Gemini has no parse_events yet, so requesting json should fail loudly."""
         import pytest
 
         from prompture.infra import build_coding_agent_command
 
         with pytest.raises(ValueError, match="does not support output_format='json'"):
             build_coding_agent_command(
-                "codex",
+                "gemini",
                 "do a thing",
                 cwd=tmp_path,
                 output_format="json",
             )
+
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/codex"),
+    )
+    def test_codex_json_mode_adds_json_flag(self, _mock_resolve, tmp_path):
+        from prompture.infra import build_coding_agent_command
+
+        command = build_coding_agent_command(
+            "codex",
+            "do a thing",
+            cwd=tmp_path,
+            approval_mode="auto",
+            output_format="json",
+        )
+        assert "--json" in command.argv
+        assert command.argv[-1] == "do a thing"
 
     @patch("prompture.infra.coding_agents.subprocess.run")
     @patch(
@@ -586,6 +604,7 @@ class TestStreaming:
         assert "health check failed" in (events[0].error or "")
 
     def test_astream_rejects_unsupported_agent(self, tmp_path):
+        """Agents without a parser (e.g. gemini today) cannot be streamed."""
         import asyncio
 
         import pytest
@@ -593,7 +612,7 @@ class TestStreaming:
         from prompture.infra import astream_coding_agent
 
         async def _run():
-            async for _ev in astream_coding_agent("codex", "x", cwd=tmp_path):
+            async for _ev in astream_coding_agent("gemini", "x", cwd=tmp_path):
                 pass
 
         with pytest.raises(ValueError, match="output_format='json'"):

--- a/tests/test_coding_agents.py
+++ b/tests/test_coding_agents.py
@@ -313,11 +313,7 @@ class TestStructuredOutput:
                 _json.dumps(
                     {
                         "type": "assistant",
-                        "message": {
-                            "content": [
-                                {"type": "tool_use", "name": "Read", "input": {"path": "a.py"}}
-                            ]
-                        },
+                        "message": {"content": [{"type": "tool_use", "name": "Read", "input": {"path": "a.py"}}]},
                     }
                 ),
                 _json.dumps(
@@ -438,3 +434,167 @@ class TestCodingAgentRunner:
         assert result.ok is True
         assert result.output == "done"
         mock_run.assert_called_once()
+
+
+class TestStreaming:
+    """Tests for astream_coding_agent."""
+
+    @staticmethod
+    def _fake_proc(stdout_lines: list[str], returncode: int = 0, stderr: bytes = b""):
+        class _FakeStdout:
+            def __init__(self, lines):
+                self._iter = iter(lines)
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                try:
+                    return next(self._iter)
+                except StopIteration:
+                    raise StopAsyncIteration from None
+
+        class _FakeStderr:
+            def __init__(self, data: bytes):
+                self._data = data
+
+            async def read(self) -> bytes:
+                return self._data
+
+        class _FakeProc:
+            def __init__(self):
+                self.stdout = _FakeStdout([(line + "\n").encode() for line in stdout_lines])
+                self.stderr = _FakeStderr(stderr)
+                self.returncode = None
+                self._rc = returncode
+
+            async def wait(self):
+                self.returncode = self._rc
+                return self._rc
+
+            def terminate(self):
+                pass
+
+            def kill(self):
+                pass
+
+        async def _factory(*args, **kwargs):
+            return _FakeProc()
+
+        return _factory
+
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/claude"),
+    )
+    def test_astream_yields_typed_events(self, _mock_resolve, tmp_path):
+        import asyncio
+        import json as _json
+
+        from prompture.infra import astream_coding_agent
+
+        lines = [
+            _json.dumps({"type": "system", "subtype": "init", "session_id": "s1"}),
+            _json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": "Hi"}]},
+                }
+            ),
+            _json.dumps(
+                {
+                    "type": "result",
+                    "is_error": False,
+                    "result": "ok",
+                    "total_cost_usd": 0.002,
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                }
+            ),
+        ]
+
+        async def _run():
+            collected = []
+            with patch(
+                "prompture.infra.coding_agents.asyncio.create_subprocess_exec",
+                side_effect=self._fake_proc(lines),
+            ):
+                async for ev in astream_coding_agent(
+                    "claude",
+                    "hi",
+                    cwd=tmp_path,
+                    approval_mode="auto",
+                ):
+                    collected.append(ev)
+            return collected
+
+        events = asyncio.run(_run())
+
+        assert [e.type for e in events] == ["system", "message", "done"]
+        assert events[-1].cost_usd == 0.002
+
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/claude"),
+    )
+    def test_astream_yields_error_on_nonzero_exit(self, _mock_resolve, tmp_path):
+        import asyncio
+
+        from prompture.infra import astream_coding_agent
+
+        async def _run():
+            collected = []
+            with patch(
+                "prompture.infra.coding_agents.asyncio.create_subprocess_exec",
+                side_effect=self._fake_proc([], returncode=1, stderr=b"boom"),
+            ):
+                async for ev in astream_coding_agent(
+                    "claude",
+                    "x",
+                    cwd=tmp_path,
+                    approval_mode="auto",
+                ):
+                    collected.append(ev)
+            return collected
+
+        events = asyncio.run(_run())
+        assert len(events) == 1
+        assert events[0].type == "error"
+        assert "exited with code 1" in (events[0].error or "")
+
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=(None, False, "node: not found"),
+    )
+    def test_astream_yields_error_on_health_check_failure(self, _mock_resolve, tmp_path):
+        import asyncio
+
+        from prompture.infra import astream_coding_agent
+
+        async def _run():
+            collected = []
+            async for ev in astream_coding_agent(
+                "claude",
+                "x",
+                cwd=tmp_path,
+                approval_mode="auto",
+            ):
+                collected.append(ev)
+            return collected
+
+        events = asyncio.run(_run())
+        assert [e.type for e in events] == ["error"]
+        assert "health check failed" in (events[0].error or "")
+
+    def test_astream_rejects_unsupported_agent(self, tmp_path):
+        import asyncio
+
+        import pytest
+
+        from prompture.infra import astream_coding_agent
+
+        async def _run():
+            async for _ev in astream_coding_agent("codex", "x", cwd=tmp_path):
+                pass
+
+        with pytest.raises(ValueError, match="output_format='json'"):
+            asyncio.run(_run())

--- a/tests/test_coding_agents.py
+++ b/tests/test_coding_agents.py
@@ -106,6 +106,54 @@ class TestCodingAgentCommands:
 
         assert command.argv == ["/usr/local/bin/gemini", "-y", "summarize the repo"]
 
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/qwen"),
+    )
+    def test_qwen_auto_and_model_command(self, _mock_resolve, tmp_path):
+        """Qwen Code is a gemini-cli fork and uses the same arg shape."""
+        command = build_coding_agent_command(
+            "qwen",
+            "explain this file",
+            cwd=tmp_path,
+            approval_mode="auto",
+            model="qwen3-coder-plus",
+        )
+
+        assert command.argv == [
+            "/usr/local/bin/qwen",
+            "--model",
+            "qwen3-coder-plus",
+            "-y",
+            "explain this file",
+        ]
+
+    def test_unknown_agent_rejected(self, tmp_path):
+        """Unknown agent ids fail fast with a helpful list of valid options."""
+        import pytest
+
+        with pytest.raises(ValueError, match="Unsupported coding agent"):
+            build_coding_agent_command("aider", "do a thing", cwd=tmp_path)
+
+
+class TestCodingAgentSpecs:
+    """Registry-level sanity checks."""
+
+    def test_registry_includes_qwen(self):
+        from prompture.infra import CODING_AGENT_SPECS, get_coding_agent_spec
+
+        assert "qwen" in CODING_AGENT_SPECS
+        spec = get_coding_agent_spec("qwen")
+        assert spec is not None
+        assert spec.display_name == "Qwen Code"
+        assert spec.default_binary == "qwen"
+        assert spec.npm_packages == ("@qwen-code/qwen-code",)
+
+    def test_get_spec_returns_none_for_unknown(self):
+        from prompture.infra import get_coding_agent_spec
+
+        assert get_coding_agent_spec("nonesuch") is None
+
 
 class TestCodingAgentRunner:
     """Tests for running coding-agent commands without invoking real CLIs."""

--- a/tests/test_coding_agents.py
+++ b/tests/test_coding_agents.py
@@ -254,6 +254,128 @@ class TestCodingAgentSpecs:
         assert get_coding_agent_spec("nonesuch") is None
 
 
+class TestStructuredOutput:
+    """Tests for output_format='json' wiring."""
+
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/claude"),
+    )
+    def test_claude_json_mode_adds_stream_json_flags(self, _mock_resolve, tmp_path):
+        from prompture.infra import build_coding_agent_command
+
+        command = build_coding_agent_command(
+            "claude",
+            "summarize this file",
+            cwd=tmp_path,
+            output_format="json",
+        )
+        assert "--output-format" in command.argv
+        idx = command.argv.index("--output-format")
+        assert command.argv[idx + 1] == "stream-json"
+        assert "--verbose" in command.argv
+
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/codex"),
+    )
+    def test_json_mode_rejected_for_unsupported_agent(self, _mock_resolve, tmp_path):
+        import pytest
+
+        from prompture.infra import build_coding_agent_command
+
+        with pytest.raises(ValueError, match="does not support output_format='json'"):
+            build_coding_agent_command(
+                "codex",
+                "do a thing",
+                cwd=tmp_path,
+                output_format="json",
+            )
+
+    @patch("prompture.infra.coding_agents.subprocess.run")
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/claude"),
+    )
+    def test_claude_json_mode_parses_events_and_cost(self, _mock_resolve, mock_run, tmp_path):
+        """run_coding_agent with output_format='json' populates events + cost."""
+        import json as _json
+
+        stream_lines = "\n".join(
+            [
+                _json.dumps({"type": "system", "subtype": "init", "session_id": "s1"}),
+                _json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {"content": [{"type": "text", "text": "Looking at this..."}]},
+                    }
+                ),
+                _json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [
+                                {"type": "tool_use", "name": "Read", "input": {"path": "a.py"}}
+                            ]
+                        },
+                    }
+                ),
+                _json.dumps(
+                    {
+                        "type": "result",
+                        "is_error": False,
+                        "result": "Summarised the file.",
+                        "total_cost_usd": 0.0123,
+                        "duration_ms": 4500,
+                        "usage": {"input_tokens": 1500, "output_tokens": 800},
+                    }
+                ),
+            ]
+        )
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["/usr/local/bin/claude"],
+            returncode=0,
+            stdout=stream_lines,
+            stderr="",
+        )
+
+        result = run_coding_agent(
+            "claude",
+            "summarize a.py",
+            cwd=tmp_path,
+            approval_mode="auto",
+            output_format="json",
+        )
+
+        assert result.ok is True
+        assert result.cost_usd == 0.0123
+        assert result.input_tokens == 1500
+        assert result.output_tokens == 800
+        types = [e.type for e in result.events]
+        assert types == ["system", "message", "tool_call", "done"]
+
+    @patch("prompture.infra.coding_agents.subprocess.run")
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/claude"),
+    )
+    def test_text_mode_leaves_events_empty(self, _mock_resolve, mock_run, tmp_path):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["/usr/local/bin/claude"],
+            returncode=0,
+            stdout="plain text reply",
+            stderr="",
+        )
+
+        result = run_coding_agent("claude", "hi", cwd=tmp_path, approval_mode="auto")
+
+        assert result.events == ()
+        assert result.cost_usd is None
+        assert result.input_tokens is None
+        assert result.output_tokens is None
+        assert result.output == "plain text reply"
+
+
 class TestCodingAgentRunner:
     """Tests for running coding-agent commands without invoking real CLIs."""
 

--- a/tests/test_coding_agents.py
+++ b/tests/test_coding_agents.py
@@ -1,0 +1,110 @@
+import subprocess
+from unittest.mock import patch
+
+from prompture.infra import build_coding_agent_command, run_coding_agent
+
+
+class TestCodingAgentCommands:
+    """Tests for coding-agent command construction."""
+
+    @patch("prompture.infra.coding_agents.resolve_coding_agent_binary", return_value="/usr/local/bin/codex")
+    def test_codex_auto_approve_command(self, _mock_resolve, tmp_path):
+        """Codex auto mode uses non-interactive exec with workspace approvals disabled."""
+        command = build_coding_agent_command(
+            "codex",
+            "fix the tests",
+            cwd=tmp_path,
+            approval_mode="auto",
+        )
+
+        assert command.argv == [
+            "/usr/local/bin/codex",
+            "exec",
+            "--sandbox",
+            "workspace-write",
+            "--ask-for-approval",
+            "never",
+            "fix the tests",
+        ]
+
+    @patch("prompture.infra.coding_agents.resolve_coding_agent_binary", return_value="/usr/local/bin/codex")
+    def test_codex_yolo_command(self, _mock_resolve, tmp_path):
+        """Codex yolo mode uses the explicit dangerous bypass flag."""
+        command = build_coding_agent_command(
+            "codex",
+            "refactor this module",
+            cwd=tmp_path,
+            approval_mode="yolo",
+        )
+
+        assert "--dangerously-bypass-approvals-and-sandbox" in command.argv
+
+    @patch("prompture.infra.coding_agents.resolve_coding_agent_binary", return_value="/usr/local/bin/claude")
+    def test_claude_auto_and_model_command(self, _mock_resolve, tmp_path):
+        """Claude auto mode runs non-interactively with dontAsk permissions."""
+        command = build_coding_agent_command(
+            "claude",
+            "review this repository",
+            cwd=tmp_path,
+            approval_mode="auto",
+            model="sonnet",
+        )
+
+        assert command.argv == [
+            "/usr/local/bin/claude",
+            "--print",
+            "--output-format",
+            "text",
+            "--model",
+            "sonnet",
+            "--permission-mode",
+            "dontAsk",
+            "review this repository",
+        ]
+
+    @patch("prompture.infra.coding_agents.resolve_coding_agent_binary", return_value="/usr/local/bin/claude")
+    def test_claude_yolo_command(self, _mock_resolve, tmp_path):
+        """Claude yolo mode uses Claude Code's dangerous skip-permissions flag."""
+        command = build_coding_agent_command(
+            "claude",
+            "make the requested edits",
+            cwd=tmp_path,
+            approval_mode="yolo",
+        )
+
+        assert "--dangerously-skip-permissions" in command.argv
+
+    @patch("prompture.infra.coding_agents.resolve_coding_agent_binary", return_value="/usr/local/bin/gemini")
+    def test_gemini_auto_command(self, _mock_resolve, tmp_path):
+        """Gemini auto mode passes yes mode through to the CLI."""
+        command = build_coding_agent_command(
+            "gemini",
+            "summarize the repo",
+            cwd=tmp_path,
+            approval_mode="auto",
+        )
+
+        assert command.argv == ["/usr/local/bin/gemini", "-y", "summarize the repo"]
+
+
+class TestCodingAgentRunner:
+    """Tests for running coding-agent commands without invoking real CLIs."""
+
+    @patch("prompture.infra.coding_agents.subprocess.run")
+    @patch("prompture.infra.coding_agents.resolve_coding_agent_binary", return_value="/usr/local/bin/codex")
+    def test_run_coding_agent_returns_result(self, _mock_resolve, mock_run, tmp_path):
+        """Runner captures subprocess output and metadata."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["/usr/local/bin/codex"],
+            returncode=0,
+            stdout="done",
+            stderr="",
+        )
+
+        result = run_coding_agent("codex", "fix bug", cwd=tmp_path, approval_mode="auto")
+
+        assert result.ok is True
+        assert result.agent == "codex"
+        assert result.output == "done"
+        assert result.returncode == 0
+        mock_run.assert_called_once()

--- a/tests/test_coding_agents.py
+++ b/tests/test_coding_agents.py
@@ -704,3 +704,111 @@ class TestSettingsAgentPaths:
             _s.coding_agent_bin_cursor_agent = original
 
         assert mock_resolve.call_args.args[1] == "/opt/cursor-agent"
+
+
+class TestSessionCapture:
+    """Tests for recording coding-agent runs into UsageSession."""
+
+    @patch("prompture.infra.coding_agents.subprocess.run")
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/claude"),
+    )
+    def test_session_receives_cost_and_tokens(self, _mock_resolve, mock_run, tmp_path):
+        import json as _json
+
+        from prompture.infra import UsageSession
+
+        stream = "\n".join(
+            [
+                _json.dumps({"type": "system", "subtype": "init"}),
+                _json.dumps(
+                    {
+                        "type": "result",
+                        "is_error": False,
+                        "result": "ok",
+                        "total_cost_usd": 0.05,
+                        "duration_ms": 1000,
+                        "usage": {"input_tokens": 200, "output_tokens": 80},
+                    }
+                ),
+            ]
+        )
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["/usr/local/bin/claude"],
+            returncode=0,
+            stdout=stream,
+            stderr="",
+        )
+
+        sess = UsageSession()
+        result = run_coding_agent(
+            "claude",
+            "do a thing",
+            cwd=tmp_path,
+            approval_mode="auto",
+            output_format="json",
+            model="sonnet",
+            session=sess,
+        )
+
+        assert result.ok is True
+        assert sess.call_count == 1
+        assert sess.prompt_tokens == 200
+        assert sess.completion_tokens == 80
+        assert sess.total_tokens == 280
+        assert sess.cost == 0.05
+        # Per-model bucket uses the namespaced driver key.
+        assert any(k.startswith("coding-agent/claude") for k in sess.summary()["per_model"])
+
+    @patch("prompture.infra.coding_agents.subprocess.run")
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/claude"),
+    )
+    def test_session_skipped_on_timeout(self, _mock_resolve, mock_run, tmp_path):
+        """A timed-out run should not pollute the session counters."""
+        import subprocess as _sp
+
+        from prompture.infra import UsageSession
+
+        mock_run.side_effect = _sp.TimeoutExpired(cmd=["claude"], timeout=1)
+
+        sess = UsageSession()
+        result = run_coding_agent(
+            "claude",
+            "x",
+            cwd=tmp_path,
+            approval_mode="auto",
+            session=sess,
+        )
+
+        assert result.timed_out is True
+        assert sess.call_count == 0
+        assert sess.cost == 0.0
+
+    @patch("prompture.infra.coding_agents.subprocess.run")
+    @patch(
+        "prompture.infra.coding_agents.resolve_coding_agent_executable",
+        return_value=_executable("/usr/local/bin/claude"),
+    )
+    def test_session_records_zero_for_text_mode(self, _mock_resolve, mock_run, tmp_path):
+        """A text-mode call still bumps call_count but with zero tokens/cost."""
+        from prompture.infra import UsageSession
+
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["/usr/local/bin/claude"], returncode=0, stdout="hi", stderr=""
+        )
+
+        sess = UsageSession()
+        run_coding_agent(
+            "claude",
+            "x",
+            cwd=tmp_path,
+            approval_mode="auto",
+            session=sess,
+        )
+
+        assert sess.call_count == 1
+        assert sess.cost == 0.0
+        assert sess.total_tokens == 0

--- a/tests/test_coding_agents_live.py
+++ b/tests/test_coding_agents_live.py
@@ -1,0 +1,87 @@
+"""Live integration tests for coding-agent CLIs.
+
+Opt-in via ``pytest --run-coding-agent-live`` (or
+``RUN_CODING_AGENT_LIVE_TESTS=1``). Each test is skipped automatically when
+the matching CLI isn't installed locally, so this suite is safe to enable on
+CI even if only a subset of agents are available.
+
+These tests guard against:
+
+- Flag-shape drift when a CLI vendor renames or removes a flag (the original
+  ``--permission-mode dontAsk`` bug would have been caught here).
+- npm shim breakage on Windows / WSL — discovery falling back to the package
+  entrypoint is exercised on the real binary.
+- The CodingAgentSpec registry going out of sync with what each CLI actually
+  understands when ``--version`` is invoked.
+
+They deliberately do NOT run a task that requires API credentials — every
+test calls ``<binary> --version`` only.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from prompture.infra import (
+    CODING_AGENT_SPECS,
+    get_available_coding_agents,
+)
+from prompture.infra.discovery import (
+    resolve_coding_agent_executable,
+    verify_coding_agent_executable,
+)
+
+pytestmark = pytest.mark.coding_agent_live
+
+
+AGENT_IDS = tuple(CODING_AGENT_SPECS.keys())
+
+
+def _installed(agent_id: str) -> bool:
+    spec = CODING_AGENT_SPECS[agent_id]
+    return shutil.which(spec.default_binary) is not None
+
+
+@pytest.mark.parametrize("agent_id", AGENT_IDS)
+def test_version_check_passes_on_installed_cli(agent_id: str) -> None:
+    """The resolver must produce a healthy executable for an installed CLI.
+
+    Goes through the same code path the runner uses (executable candidates +
+    health check) so npm/.cmd wrappers and Windows shims behave correctly.
+    """
+    if not _installed(agent_id):
+        pytest.skip(f"{agent_id} CLI not installed locally")
+    spec = CODING_AGENT_SPECS[agent_id]
+    executable, healthy, error = resolve_coding_agent_executable(
+        agent_id,
+        spec.default_binary,
+        verify=True,
+        verify_timeout=10,
+    )
+    assert executable is not None, f"{agent_id} did not resolve any executable"
+    if not healthy:
+        # As a fallback, exercise the candidate directly so we get a richer error.
+        ok, exec_err = verify_coding_agent_executable(agent_id, executable, timeout=10)
+        assert ok, f"{agent_id} --version failed: {exec_err or error}"
+
+
+@pytest.mark.parametrize("agent_id", AGENT_IDS)
+def test_resolve_finds_executable_for_installed_cli(agent_id: str) -> None:
+    """The resolver must return a callable executable for any agent on PATH."""
+    if not _installed(agent_id):
+        pytest.skip(f"{agent_id} CLI not installed locally")
+    spec = CODING_AGENT_SPECS[agent_id]
+    executable, _healthy, _error = resolve_coding_agent_executable(agent_id, spec.default_binary)
+    assert executable is not None
+    assert executable.argv  # non-empty argv
+
+
+def test_at_least_one_agent_present():
+    """Smoke test: when --run-coding-agent-live is on, at least one CLI should resolve."""
+    available = [a for a in get_available_coding_agents(verify=True) if a.available]
+    if not available:
+        pytest.skip("No coding-agent CLIs installed on this host — nothing to verify")
+    # If we got here we have at least one; the parametrized tests above carry the load.
+    assert available

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -7,11 +7,14 @@ from prompture.drivers.elevenlabs_stt_driver import ElevenLabsSTTDriver
 from prompture.drivers.elevenlabs_tts_driver import ElevenLabsTTSDriver
 from prompture.drivers.ollama_driver import OllamaDriver
 from prompture.infra.discovery import (
+    CodingAgentInfo,
     _discovery_cache,
     clear_discovery_cache,
     display_available_models,
     get_available_audio_models,
+    get_available_coding_agents,
     get_available_models,
+    resolve_coding_agent_binary,
 )
 
 
@@ -59,6 +62,62 @@ class TestDiscovery:
         models = get_available_models()
         # Should not crash, just not include ollama models (unless some other provider is active)
         assert not any(m.startswith("ollama/") for m in models)
+
+
+class TestCodingAgentDiscovery:
+    """Tests for local coding-agent CLI discovery."""
+
+    @patch("prompture.infra.discovery.shutil.which")
+    def test_detects_known_agent_binaries(self, mock_which):
+        """Claude and Codex are marked available when their CLIs resolve."""
+        paths = {
+            "claude": "/usr/local/bin/claude",
+            "codex": "/usr/local/bin/codex",
+        }
+        mock_which.side_effect = lambda binary: paths.get(binary)
+
+        agents = get_available_coding_agents()
+        by_id = {agent.id: agent for agent in agents}
+
+        assert isinstance(by_id["claude"], CodingAgentInfo)
+        assert by_id["claude"].available is True
+        assert by_id["claude"].binary == "/usr/local/bin/claude"
+        assert by_id["codex"].available is True
+        assert by_id["gemini"].available is False
+        assert by_id["gemini"].binary == "gemini"
+
+    @patch("prompture.infra.discovery.shutil.which")
+    def test_can_return_only_available_agents(self, mock_which):
+        """Unavailable CLIs are omitted when requested."""
+        mock_which.side_effect = lambda binary: "/usr/local/bin/codex" if binary == "codex" else None
+
+        agents = get_available_coding_agents(include_unavailable=False)
+
+        assert [agent.id for agent in agents] == ["codex"]
+
+    @patch("prompture.infra.discovery.shutil.which")
+    def test_custom_agent_paths_override_default_binaries(self, mock_which):
+        """Explicit paths are resolved and marked as custom."""
+        mock_which.side_effect = lambda binary: binary if binary == "/opt/claude/bin/claude" else None
+
+        agents = get_available_coding_agents(agent_paths={"claude": "/opt/claude/bin/claude"})
+        by_id = {agent.id: agent for agent in agents}
+
+        assert by_id["claude"].available is True
+        assert by_id["claude"].binary == "/opt/claude/bin/claude"
+        assert by_id["claude"].custom_path is True
+        assert by_id["codex"].custom_path is False
+
+    @patch("prompture.infra.discovery.platform.system", return_value="Windows")
+    @patch("prompture.infra.discovery.shutil.which")
+    def test_resolve_coding_agent_binary_prefers_windows_wrappers(self, mock_which, _mock_system):
+        """Windows resolution checks npm wrapper extensions before the bare shim."""
+        mock_which.side_effect = lambda binary: f"C:/tools/{binary}" if binary == "codex.cmd" else None
+
+        resolved = resolve_coding_agent_binary("codex")
+
+        assert resolved == "C:/tools/codex.cmd"
+        mock_which.assert_called_once_with("codex.cmd")
 
 
 class TestAudioDiscovery:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,4 +1,6 @@
 import os
+import subprocess
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -14,7 +16,9 @@ from prompture.infra.discovery import (
     get_available_audio_models,
     get_available_coding_agents,
     get_available_models,
+    get_coding_agent_executable_candidates,
     resolve_coding_agent_binary,
+    resolve_coding_agent_executable,
 )
 
 
@@ -118,6 +122,149 @@ class TestCodingAgentDiscovery:
 
         assert resolved == "C:/tools/codex.cmd"
         mock_which.assert_called_once_with("codex.cmd")
+
+    @patch("prompture.infra.discovery._path_for_windows_executable", return_value="C:\\tools\\gemini.cmd")
+    @patch("prompture.infra.discovery._resolved_paths_for_binary")
+    def test_discovers_windows_cmd_wrapper_candidate(self, mock_paths, _mock_windows_path, tmp_path):
+        """Windows npm wrappers can be invoked through cmd.exe from WSL."""
+        wrapper = tmp_path / "gemini.cmd"
+        wrapper.write_text("@ECHO off\r\n", encoding="utf-8")
+        cmd = "/mnt/c/Windows/System32/cmd.exe"
+        mock_paths.side_effect = lambda binary: (
+            [str(wrapper)] if binary == "gemini" else [cmd] if binary == "cmd.exe" else []
+        )
+
+        candidates = get_coding_agent_executable_candidates("gemini", "gemini")
+
+        assert candidates[0].source == "windows-cmd"
+        assert candidates[0].argv == (cmd, "/d", "/s", "/c", "C:\\tools\\gemini.cmd")
+
+    @patch("prompture.infra.discovery.subprocess.run")
+    @patch("prompture.infra.discovery.shutil.which")
+    def test_verify_marks_working_cli_healthy(self, mock_which, mock_run):
+        """verify=True records a successful health check."""
+        mock_which.side_effect = lambda binary: "/usr/local/bin/codex" if binary == "codex" else None
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["/usr/local/bin/codex", "--version"],
+            returncode=0,
+            stdout="codex 1.0.0",
+            stderr="",
+        )
+
+        agents = get_available_coding_agents(verify=True)
+        by_id = {agent.id: agent for agent in agents}
+
+        assert by_id["codex"].available is True
+        assert by_id["codex"].verified is True
+        assert by_id["codex"].healthy is True
+        assert by_id["codex"].error is None
+
+    @patch("prompture.infra.discovery.subprocess.run")
+    @patch("prompture.infra.discovery.shutil.which")
+    def test_verify_marks_broken_cli_unavailable(self, mock_which, mock_run):
+        """A resolved PATH shim is unavailable when the health check fails."""
+        mock_which.side_effect = lambda binary: "/usr/local/bin/gemini" if binary == "gemini" else None
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["/usr/local/bin/gemini", "--version"],
+            returncode=127,
+            stdout="",
+            stderr="node: not found\n",
+        )
+
+        agents = get_available_coding_agents(verify=True)
+        by_id = {agent.id: agent for agent in agents}
+
+        assert by_id["gemini"].available is False
+        assert by_id["gemini"].verified is True
+        assert by_id["gemini"].healthy is False
+        assert by_id["gemini"].error == "node: not found"
+
+    @patch("prompture.infra.discovery.subprocess.run")
+    @patch("prompture.infra.discovery.shutil.which")
+    def test_verify_include_unavailable_false_omits_broken_cli(self, mock_which, mock_run):
+        """include_unavailable=False returns only health-checked usable CLIs."""
+        mock_which.side_effect = lambda binary: "/usr/local/bin/gemini" if binary == "gemini" else None
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["/usr/local/bin/gemini", "--version"],
+            returncode=127,
+            stdout="",
+            stderr="node: not found\n",
+        )
+
+        agents = get_available_coding_agents(verify=True, include_unavailable=False)
+
+        assert agents == []
+
+    @pytest.mark.parametrize(
+        ("agent_id", "package_name", "command_name"),
+        [
+            ("claude", "@anthropic-ai/claude-code", "claude"),
+            ("codex", "@openai/codex", "codex"),
+            ("gemini", "@google/gemini-cli", "gemini"),
+        ],
+    )
+    @patch("prompture.infra.discovery._resolved_paths_for_binary")
+    def test_discovers_node_package_entrypoints_for_supported_agents(
+        self,
+        mock_paths,
+        tmp_path,
+        agent_id,
+        package_name,
+        command_name,
+    ):
+        """Supported agents can use an npm package entrypoint, not only the shim."""
+        shim = tmp_path / command_name
+        shim.write_text("#!/bin/sh\nexec node cli.js\n", encoding="utf-8")
+        node = tmp_path / "node"
+        node.write_text("#!/bin/sh\n", encoding="utf-8")
+        package_dir = tmp_path / "node_modules" / Path(*package_name.split("/"))
+        package_entry = package_dir / "dist" / "index.js"
+        package_entry.parent.mkdir(parents=True)
+        package_entry.write_text("console.log('gemini')\n", encoding="utf-8")
+        (package_dir / "package.json").write_text(
+            f'{{"bin": {{"{command_name}": "dist/index.js"}}}}',
+            encoding="utf-8",
+        )
+        mock_paths.side_effect = lambda binary: (
+            [str(shim)] if binary == command_name else [str(node)] if binary == "node" else []
+        )
+
+        candidates = get_coding_agent_executable_candidates(agent_id, command_name)
+
+        assert any(candidate.argv[0] == str(shim) for candidate in candidates)
+        assert any(
+            candidate.argv[:3] == (str(node), "--no-warnings=DEP0040", str(package_entry))
+            and candidate.source == f"npm:{package_name}"
+            for candidate in candidates
+        )
+
+    @patch("prompture.infra.discovery.subprocess.run")
+    @patch("prompture.infra.discovery._resolved_paths_for_binary")
+    def test_resolve_coding_agent_executable_picks_first_healthy_candidate(self, mock_paths, mock_run, tmp_path):
+        """Verified resolution skips a broken shim and returns a healthy fallback."""
+        shim = tmp_path / "gemini"
+        shim.write_text("#!/bin/sh\nexec node cli.js\n", encoding="utf-8")
+        node = tmp_path / "node"
+        node.write_text("#!/bin/sh\n", encoding="utf-8")
+        package_entry = tmp_path / "node_modules" / "@google" / "gemini-cli" / "dist" / "index.js"
+        package_entry.parent.mkdir(parents=True)
+        package_entry.write_text("console.log('gemini')\n", encoding="utf-8")
+        mock_paths.side_effect = lambda binary: (
+            [str(shim)] if binary == "gemini" else [str(node)] if binary == "node" else []
+        )
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(
+                args=[str(shim), "--version"], returncode=127, stdout="", stderr="node: not found\n"
+            ),
+            subprocess.CompletedProcess(args=[str(node), "--version"], returncode=0, stdout="0.35.3\n", stderr=""),
+        ]
+
+        executable, healthy, error = resolve_coding_agent_executable("gemini", "gemini", verify=True)
+
+        assert healthy is True
+        assert error is None
+        assert executable is not None
+        assert executable.argv[0] == str(node)
 
 
 class TestAudioDiscovery:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -194,3 +194,85 @@ class TestCodingAgentsEndpoint:
 
         assert resp.status_code == 200
         mock_discovery.assert_called_once_with(verify=False)
+
+
+class TestCodingAgentRunEndpoint:
+    def test_run_endpoint_returns_result_payload(self, client):
+        """POST /v1/coding-agents/run returns the serialized CodingAgentRunResult."""
+        from prompture.infra.coding_agents import CodingAgentRunResult
+
+        fake_result = CodingAgentRunResult(
+            agent="claude",
+            command=["claude", "--print", "hi"],
+            cwd="/tmp",
+            returncode=0,
+            output="hello",
+            duration_seconds=1.5,
+            cost_usd=0.002,
+            input_tokens=10,
+            output_tokens=5,
+        )
+
+        async def _fake_arun(*args, **kwargs):
+            return fake_result
+
+        with patch("prompture.infra.coding_agents.arun_coding_agent", side_effect=_fake_arun):
+            resp = client.post(
+                "/v1/coding-agents/run",
+                json={"agent": "claude", "task": "say hi"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["object"] == "coding_agent_run"
+        assert data["agent"] == "claude"
+        assert data["output"] == "hello"
+        assert data["cost_usd"] == 0.002
+
+    def test_run_endpoint_validation_error_returns_400(self, client):
+        async def _raise(*args, **kwargs):
+            raise ValueError("bad agent")
+
+        with patch("prompture.infra.coding_agents.arun_coding_agent", side_effect=_raise):
+            resp = client.post(
+                "/v1/coding-agents/run",
+                json={"agent": "nonesuch", "task": "x"},
+            )
+
+        assert resp.status_code == 400
+        assert "bad agent" in resp.json()["detail"]
+
+    def test_run_endpoint_missing_binary_returns_404(self, client):
+        async def _raise(*args, **kwargs):
+            raise RuntimeError("'claude' is not installed or not on PATH")
+
+        with patch("prompture.infra.coding_agents.arun_coding_agent", side_effect=_raise):
+            resp = client.post(
+                "/v1/coding-agents/run",
+                json={"agent": "claude", "task": "x"},
+            )
+
+        assert resp.status_code == 404
+        assert "not installed" in resp.json()["detail"]
+
+    def test_run_endpoint_streams_sse_events(self, client):
+        """When stream=true, the endpoint emits SSE-framed events."""
+        from prompture.infra.coding_agent_events import CodingAgentEvent
+
+        async def _fake_stream(*args, **kwargs):
+            yield CodingAgentEvent(type="system", raw={"hi": "there"})
+            yield CodingAgentEvent(type="message", text="hello")
+            yield CodingAgentEvent(type="done", cost_usd=0.001, input_tokens=4, output_tokens=2)
+
+        with patch("prompture.infra.coding_agents.astream_coding_agent", side_effect=_fake_stream):
+            resp = client.post(
+                "/v1/coding-agents/run",
+                json={"agent": "claude", "task": "hi", "stream": True},
+            )
+
+        assert resp.status_code == 200
+        body = resp.text
+        assert "type" in body
+        assert '"message"' in body
+        assert '"done"' in body
+        assert "stream_end" in body

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,6 +15,7 @@ pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 from prompture.cli.server import create_app
+from prompture.infra.discovery import CodingAgentInfo
 
 # ---------------------------------------------------------------------------
 # Mock async driver
@@ -158,3 +159,38 @@ class TestModelsEndpoint:
         data = resp.json()
         assert "models" in data
         assert isinstance(data["models"], list)
+
+
+class TestCodingAgentsEndpoint:
+    def test_list_coding_agents(self, client):
+        """The server exposes verified coding-agent discovery."""
+        with patch(
+            "prompture.infra.discovery.get_available_coding_agents",
+            return_value=[
+                CodingAgentInfo(
+                    id="codex",
+                    name="Codex CLI",
+                    available=True,
+                    binary="/usr/local/bin/codex",
+                    verified=True,
+                    healthy=True,
+                )
+            ],
+        ) as mock_discovery:
+            resp = client.get("/v1/coding-agents")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["object"] == "list"
+        assert data["coding_agents"] == ["codex"]
+        assert data["data"][0]["object"] == "coding_agent"
+        assert data["data"][0]["id"] == "codex"
+        mock_discovery.assert_called_once_with(verify=True)
+
+    def test_list_coding_agents_can_skip_verification(self, client):
+        """Apps can request cheap PATH-only discovery when needed."""
+        with patch("prompture.infra.discovery.get_available_coding_agents", return_value=[]) as mock_discovery:
+            resp = client.get("/v1/coding-agents?verify=false")
+
+        assert resp.status_code == 200
+        mock_discovery.assert_called_once_with(verify=False)


### PR DESCRIPTION
Prompture now speaks fluent coding-agent — the same library that wrangles LLM JSON can also drive Claude Code, Codex, Aider, and friends from your shell. This PR introduces local CLI discovery, a unified runner with structured event streaming, session resume, and an HTTP/SSE server endpoint, all backed by a pluggable agent spec registry.

### Highlights

- Detects installed coding-agent CLIs on your machine (Claude Code, Codex, Aider, OpenCode, Cursor Agent, Crush, Qwen Code) with version and health checks
- Run any supported agent from Python or the `prompture` CLI with a single call, capturing tokens, cost, and clarifying questions
- Live event streaming via `astream_coding_agent` and an SSE-powered `POST /v1/coding-agents/run` server endpoint
- Resume prior agent sessions by `session_id` to continue multi-turn work
- Override agent binary paths through `.env` / settings for non-standard installs
- New structured example script and an opt-in live test suite that exercises real CLIs when available

<details>
<summary>Technical changes</summary>

- Added `prompture/infra/coding_agents.py` with `run_coding_agent`, `arun_coding_agent`, and `astream_coding_agent` — subprocess orchestration with stdout/stderr capture, timeout handling, and per-agent argv assembly
- Added `prompture/infra/coding_agent_specs.py` containing the `CodingAgentSpec` registry (Claude Code, Codex, Aider, OpenCode, Cursor Agent, Crush, Qwen Code) with binary names, version flags, and per-agent argv builders
- Added `prompture/infra/coding_agent_events.py` with `CodingAgentEvent` dataclass plus Claude `stream-json` and Codex `--json` line parsers, including clarifying-question detection heuristics
- Extended `prompture/infra/discovery.py` with `discover_coding_agents`, health-check probes, and version parsing across all supported CLIs
- Added `POST /v1/coding-agents/run` to `prompture/cli/server.py` with SSE streaming of `CodingAgentEvent`s, including a non-streaming JSON mode
- Wired `output_format='json'` into `run_coding_agent` to opt Claude Code into stream-json mode and surface tokens/cost into the returned result
- Captured agent token usage and cost into `UsageSession` when one is passed in, mirroring the existing LLM driver pattern
- Added `session_id` plumbing through `coding_agent_specs` argv builders and the server endpoint, so resumable agents (Claude Code, Codex) can continue prior sessions
- Added binary-path override settings in `prompture/infra/settings.py` and `.env.copy` (e.g. `CLAUDE_CODE_BIN`, `CODEX_BIN`, `AIDER_BIN`, …) consumed by the runner before falling back to `PATH` lookup
- Added `prompture` CLI subcommands for listing/discovering agents and running an agent end-to-end
- Refactored coding-agent registry out of `coding_agents.py` into the dedicated `coding_agent_specs` module to keep runner logic separate from per-agent metadata
- Added `examples/coding_agents_example.py` and `examples/coding_agents_structured_example.py` demonstrating run + streaming usage
- Added `tests/test_coding_agents.py`, `tests/test_coding_agent_events.py`, `tests/test_discovery.py` additions, `tests/test_cli.py` additions, and `tests/test_server.py` additions covering registry, argv assembly, event parsing, session resume, usage capture, binary overrides, and SSE behavior
- Added `tests/test_coding_agents_live.py` gated by a new `live_coding_agents` pytest marker in `pyproject.toml` to optionally exercise real CLI binaries
- README rewritten with a new coding-agent section covering discovery, run, streaming, server endpoint, and session resume

</details>
