### PR TITLE
Expose Assistant internals and stream ReviewLoop events

### DIFF
--- a/examples/assistant_example.py
+++ b/examples/assistant_example.py
@@ -117,14 +117,10 @@ async def demo_review_loop() -> None:
     )
 
     result = await loop.arun(
-        "Build an /about page for a small coffee shop. One hero section, "
-        "a 'Our Story' paragraph, and a contact link.",
+        "Build an /about page for a small coffee shop. One hero section, a 'Our Story' paragraph, and a contact link.",
         coder_kwargs={"page_type": "about"},
     )
-    print(
-        f"\n=== Review loop done — iterations={result.iterations} "
-        f"approved={result.approved} ==="
-    )
+    print(f"\n=== Review loop done — iterations={result.iterations} approved={result.approved} ===")
     extracted = extract_html_document(result.output)
     if extracted.found:
         print(f"Salvaged HTML ({len(extracted.html)} chars).")
@@ -146,10 +142,7 @@ def demo_capability_picker() -> None:
         verify=True,
     )
     if chosen is None:
-        print(
-            "[info] No installed coding-agent CLI supports session resume on "
-            "this machine."
-        )
+        print("[info] No installed coding-agent CLI supports session resume on this machine.")
         return
     print(f"[info] Best CLI for session resume: {chosen.id} ({chosen.binary})")
 
@@ -173,13 +166,8 @@ async def demo_cli_assistant() -> None:
         coding_agent="auto",  # picks the first healthy installed CLI
         coding_agent_options={"approval_mode": "auto"},
     )
-    result = await cli_dev.arun(
-        "Write /about.html for a coffee shop. Return the file contents."
-    )
-    print(
-        f"\n=== CLI assistant ran on '{result.raw.agent}' "
-        f"(cost=${result.cost_usd or 0:.4f}) ==="
-    )
+    result = await cli_dev.arun("Write /about.html for a coffee shop. Return the file contents.")
+    print(f"\n=== CLI assistant ran on '{result.raw.agent}' (cost=${result.cost_usd or 0:.4f}) ===")
     print(result.output[:400])
 
 

--- a/examples/coding_agents_structured_example.py
+++ b/examples/coding_agents_structured_example.py
@@ -73,7 +73,7 @@ def demo_structured_output() -> str | None:
                 for i, c in enumerate(ev.choices, 1):
                     print(f"       {i}. {c}")
 
-    if (q := result.asked_question):
+    if q := result.asked_question:
         print(f"\nAgent asked a clarifying question:\n  {q.text}")
 
     print(f"\nSession summary: {session.summary()['formatted']}")

--- a/prompture/agents/__init__.py
+++ b/prompture/agents/__init__.py
@@ -38,7 +38,13 @@ from .persona import (
     reset_persona_registry,
     reset_trait_registry,
 )
-from .review_loop import AsyncReviewLoop, ReviewLoopIteration, ReviewLoopResult
+from .review_loop import (
+    AsyncReviewLoop,
+    ReviewLoopEvent,
+    ReviewLoopEventType,
+    ReviewLoopIteration,
+    ReviewLoopResult,
+)
 from .skills import (
     SKILLS,
     SkillInfo,
@@ -97,6 +103,8 @@ __all__ = [
     "GuardrailError",
     "ModelRetry",
     "Persona",
+    "ReviewLoopEvent",
+    "ReviewLoopEventType",
     "ReviewLoopIteration",
     "ReviewLoopResult",
     "RunContext",

--- a/prompture/agents/assistant.py
+++ b/prompture/agents/assistant.py
@@ -190,8 +190,7 @@ class Assistant:
             )
         if self.enable_planning and not self.model:
             raise ValueError(
-                "enable_planning=True only applies to the LLM backend "
-                "(set `model=...`, not `coding_agent=...`)."
+                "enable_planning=True only applies to the LLM backend (set `model=...`, not `coding_agent=...`)."
             )
 
     # ----- composition ---------------------------------------------------
@@ -211,10 +210,7 @@ class Assistant:
         persona = self.persona
 
         for skill in self.skills:
-            block = (
-                f"## Skill: {skill.name}\n"
-                f"{skill.description}\n\n{skill.instructions}".rstrip()
-            )
+            block = f"## Skill: {skill.name}\n{skill.description}\n\n{skill.instructions}".rstrip()
             persona = persona.extend(block)
 
         # Push merged variables back so render() (called by AsyncAgent)
@@ -485,9 +481,7 @@ def clear_assistant_registry() -> None:
 def _from_registry(cls: type[Assistant], name: str) -> Assistant:
     found = get_assistant(name)
     if found is None:
-        raise KeyError(
-            f"No Assistant registered as {name!r}. Known: {get_assistant_names()}"
-        )
+        raise KeyError(f"No Assistant registered as {name!r}. Known: {get_assistant_names()}")
     return found
 
 

--- a/prompture/agents/assistant.py
+++ b/prompture/agents/assistant.py
@@ -162,6 +162,7 @@ class Assistant:
     variables: dict[str, Any] = dataclasses.field(default_factory=dict)
     enable_planning: bool = False
     output_type: Any = None
+    output_key: str | None = None
     options: dict[str, Any] = dataclasses.field(default_factory=dict)
     coding_agent_options: dict[str, Any] = dataclasses.field(default_factory=dict)
 
@@ -275,6 +276,37 @@ class Assistant:
 
     # ----- LLM backend ---------------------------------------------------
 
+    def build_async_agent(self, **vars: Any) -> Any:
+        """Construct the underlying ``AsyncAgent`` (or ``AsyncDeepAgent``).
+
+        Use this when you want the Assistant as a *configuration* bundle
+        (persona + skills + tools + model + options) but need to drive
+        the underlying agent yourself — through a group, a streaming
+        callback machinery, or any other orchestration layer that
+        operates on :class:`AsyncAgent` directly.
+
+        Args:
+            **vars: Per-call template variables merged into the persona
+                before rendering.  Equivalent to the per-call kwargs of
+                :meth:`arun` / :meth:`astream`, but applied at
+                construction time.
+
+        Returns:
+            An :class:`AsyncAgent` when ``enable_planning=False``,
+            otherwise an :class:`AsyncDeepAgent`.
+
+        Raises:
+            ValueError: When this Assistant is configured with a
+                ``coding_agent`` backend (it shells out to a CLI and has
+                no in-process agent to expose).
+        """
+        if self.coding_agent:
+            raise ValueError(
+                "build_async_agent() is only available for the LLM backend; "
+                f"this Assistant uses coding_agent={self.coding_agent!r}."
+            )
+        return self._build_async_agent(call_vars=vars)
+
     def _build_async_agent(self, *, call_vars: dict[str, Any]) -> Any:
         persona = self._composed_persona(call_vars)
         if self.enable_planning:
@@ -297,6 +329,7 @@ class Assistant:
             system_prompt=persona,
             tools=list(self.tools) or None,
             output_type=self.output_type,
+            output_key=self.output_key,
             name=self.name,
             description=self.description,
             options=dict(self.options) or None,

--- a/prompture/agents/assistant.py
+++ b/prompture/agents/assistant.py
@@ -62,7 +62,7 @@ import asyncio
 import dataclasses
 import logging
 import threading
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator
 from typing import Any
 
 from .persona import Persona
@@ -155,7 +155,9 @@ class Assistant:
     name: str
     persona: Persona
     skills: tuple[SkillInfo, ...] = ()
-    tools: tuple[Callable[..., Any], ...] = ()
+    # Either a tuple of Python callables OR a ToolRegistry — both are
+    # accepted by the underlying AsyncAgent.
+    tools: Any = ()
     model: str | None = None
     coding_agent: str | None = None
     description: str = ""
@@ -165,15 +167,19 @@ class Assistant:
     output_key: str | None = None
     options: dict[str, Any] = dataclasses.field(default_factory=dict)
     coding_agent_options: dict[str, Any] = dataclasses.field(default_factory=dict)
+    # Extra kwargs forwarded to AsyncDeepAgent when enable_planning=True
+    # (e.g. {"enable_vfs": False, "enable_summarization": False}).
+    deep_agent_options: dict[str, Any] = dataclasses.field(default_factory=dict)
 
     # ----- construction --------------------------------------------------
 
     def __post_init__(self) -> None:
-        # Normalise iterable args to immutable tuples so the dataclass
-        # stays hashable + frozen-friendly.
+        # Normalise skills to an immutable tuple.  Tools may be either a
+        # tuple of callables OR a ToolRegistry — both are passed
+        # through to AsyncAgent unchanged.
         if not isinstance(self.skills, tuple):
             object.__setattr__(self, "skills", tuple(self.skills))
-        if not isinstance(self.tools, tuple):
+        if isinstance(self.tools, (list, set)):
             object.__setattr__(self, "tools", tuple(self.tools))
 
         if bool(self.model) == bool(self.coding_agent):
@@ -309,17 +315,19 @@ class Assistant:
 
     def _build_async_agent(self, *, call_vars: dict[str, Any]) -> Any:
         persona = self._composed_persona(call_vars)
+        tools_arg = self._tools_for_agent()
         if self.enable_planning:
             from .async_deep_agent import AsyncDeepAgent
 
             return AsyncDeepAgent(
                 self.model or "",
                 system_prompt=persona,
-                tools=list(self.tools) or None,
+                tools=tools_arg,
                 name=self.name,
                 description=self.description,
                 enable_planning=True,
                 options=dict(self.options) or None,
+                **dict(self.deep_agent_options),
             )
 
         from .async_agent import AsyncAgent
@@ -327,13 +335,28 @@ class Assistant:
         return AsyncAgent(
             self.model or "",
             system_prompt=persona,
-            tools=list(self.tools) or None,
+            tools=tools_arg,
             output_type=self.output_type,
             output_key=self.output_key,
             name=self.name,
             description=self.description,
             options=dict(self.options) or None,
         )
+
+    def _tools_for_agent(self) -> Any:
+        """Coerce ``self.tools`` into the shape ``AsyncAgent`` expects.
+
+        Returns ``None`` when nothing is configured, the underlying
+        ``ToolRegistry`` when one was passed in directly, or a list of
+        callables otherwise.
+        """
+        if not self.tools:
+            return None
+        # Tuples / lists of callables → list (AsyncAgent expects a list).
+        if isinstance(self.tools, tuple):
+            return list(self.tools) or None
+        # Any other object (e.g. ToolRegistry) is passed through verbatim.
+        return self.tools
 
     async def _run_llm(
         self,

--- a/prompture/agents/assistant.py
+++ b/prompture/agents/assistant.py
@@ -145,11 +145,25 @@ class Assistant:
         output_type: Optional Pydantic model passed to ``AsyncAgent`` for
             structured-output parsing.  Ignored for the coding-agent
             backend.
-        options: Driver options merged into the underlying agent (e.g.
-            ``{"max_tokens": 8000, "timeout": 600}``).
+        options: Driver options forwarded to the underlying agent's
+            ``options`` kwarg (driver-level settings like
+            ``{"max_tokens": 8000, "timeout": 600}``). Distinct from
+            ``agent_options`` below, which targets the agent constructor
+            itself.
+        agent_options: Extra kwargs spread into ``AsyncAgent.__init__``
+            when ``enable_planning=False``. Use this for budget controls
+            and other agent-level settings the Assistant doesn't expose
+            as first-class fields, e.g.
+            ``{"max_iterations": 5, "max_cost": 0.50,
+            "budget_policy": "hard_stop",
+            "fallback_models": ["openai/gpt-4o-mini"]}``.
         coding_agent_options: Extra kwargs forwarded to
             ``run_coding_agent`` / ``astream_coding_agent`` (e.g.
             ``approval_mode``, ``cwd``, ``timeout``).
+        deep_agent_options: Extra kwargs spread into
+            ``AsyncDeepAgent.__init__`` when ``enable_planning=True``
+            (e.g. ``{"enable_vfs": False, "enable_summarization": False,
+            "max_iterations": 30}``).
     """
 
     name: str
@@ -167,6 +181,12 @@ class Assistant:
     output_key: str | None = None
     options: dict[str, Any] = dataclasses.field(default_factory=dict)
     coding_agent_options: dict[str, Any] = dataclasses.field(default_factory=dict)
+    # Extra kwargs forwarded to AsyncAgent.__init__ when enable_planning is
+    # False (e.g. {"max_iterations": 5, "max_cost": 0.50,
+    # "budget_policy": "hard_stop", "fallback_models": ["openai/gpt-4o-mini"]}).
+    # Anything AsyncAgent accepts works here — see its signature for the
+    # full list (max_tokens, persistent_conversation, output_key, ...).
+    agent_options: dict[str, Any] = dataclasses.field(default_factory=dict)
     # Extra kwargs forwarded to AsyncDeepAgent when enable_planning=True
     # (e.g. {"enable_vfs": False, "enable_summarization": False}).
     deep_agent_options: dict[str, Any] = dataclasses.field(default_factory=dict)
@@ -337,6 +357,7 @@ class Assistant:
             name=self.name,
             description=self.description,
             options=dict(self.options) or None,
+            **dict(self.agent_options),
         )
 
     def _tools_for_agent(self) -> Any:

--- a/prompture/agents/review_loop.py
+++ b/prompture/agents/review_loop.py
@@ -214,9 +214,7 @@ class AsyncReviewLoop:
     review_prompt: Callable[[str], str] = dataclasses.field(
         default=lambda code: f"Review this work and give feedback:\n\n{code}"
     )
-    feedback_prompt: Callable[[str, ReviewLoopIteration], str] = (
-        _default_feedback_prompt
-    )
+    feedback_prompt: Callable[[str, ReviewLoopIteration], str] = _default_feedback_prompt
 
     def __post_init__(self) -> None:
         if self.max_iters < 1:
@@ -291,9 +289,7 @@ class AsyncReviewLoop:
                 code_result=code_result,
             )
 
-            review_result = await self.reviewer.arun(
-                self.review_prompt(code_text), **reviewer_kwargs
-            )
+            review_result = await self.reviewer.arun(self.review_prompt(code_text), **reviewer_kwargs)
             review_text = getattr(review_result, "output", "") or ""
             approved = bool(self.approve_when(review_result))
             yield ReviewLoopEvent(

--- a/prompture/agents/review_loop.py
+++ b/prompture/agents/review_loop.py
@@ -50,8 +50,8 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-from collections.abc import Callable
-from typing import Any, Protocol, runtime_checkable
+from collections.abc import AsyncIterator, Callable
+from typing import Any, Literal, Protocol, runtime_checkable
 
 logger = logging.getLogger("prompture.review_loop")
 
@@ -94,6 +94,53 @@ class ReviewLoopIteration:
     approved: bool
     code_result: Any = None  # raw coder result for backend-specific fields
     review_result: Any = None
+
+
+ReviewLoopEventType = Literal[
+    "iteration_started",
+    "coder_done",
+    "reviewer_done",
+    "approved",
+    "rejected",
+    "done",
+]
+
+
+@dataclasses.dataclass(frozen=True)
+class ReviewLoopEvent:
+    """Event yielded by :meth:`AsyncReviewLoop.astream`.
+
+    Field meaning per ``type``:
+
+    * ``iteration_started`` — emitted before each coder run.  ``index``
+      is the 0-based iteration number; ``prompt`` is the exact text the
+      coder will receive (for the first iteration this is the user
+      prompt; for later iterations it is ``feedback_prompt(...)``
+      output).
+    * ``coder_done`` — coder finished.  ``code_output`` populated;
+      ``code_result`` carries the raw coder return value (e.g.
+      :class:`AssistantResult` or :class:`AgentResult`) for backend-
+      specific fields like cost.
+    * ``reviewer_done`` — reviewer finished.  ``review_output`` +
+      ``review_result`` populated; ``approved`` reflects the
+      ``approve_when`` verdict for this iteration.
+    * ``approved`` — terminal: the loop is about to exit because the
+      latest iteration was approved.
+    * ``rejected`` — terminal: the loop is about to exit because
+      ``max_iters`` was hit without approval.
+    * ``done`` — emitted last, always.  ``result`` carries the same
+      :class:`ReviewLoopResult` that :meth:`arun` would return.
+    """
+
+    type: ReviewLoopEventType
+    index: int = -1  # iteration index; -1 for the terminal "done" event
+    prompt: str = ""  # only on iteration_started
+    code_output: str = ""  # populated from coder_done onwards
+    review_output: str = ""  # populated from reviewer_done onwards
+    approved: bool = False
+    code_result: Any = None
+    review_result: Any = None
+    result: Any = None  # only on the final "done" event
 
 
 @dataclasses.dataclass(frozen=True)
@@ -182,7 +229,10 @@ class AsyncReviewLoop:
         coder_kwargs: dict[str, Any] | None = None,
         reviewer_kwargs: dict[str, Any] | None = None,
     ) -> ReviewLoopResult:
-        """Run the loop to completion.
+        """Run the loop to completion and return the final result.
+
+        Equivalent to consuming :meth:`astream` and returning its final
+        ``done`` event's ``result``.
 
         Args:
             prompt: The initial task for the coder.
@@ -191,21 +241,71 @@ class AsyncReviewLoop:
             reviewer_kwargs: Extra kwargs forwarded to every
                 ``reviewer.arun`` call.
         """
+        final: ReviewLoopResult | None = None
+        async for event in self.astream(
+            prompt,
+            coder_kwargs=coder_kwargs,
+            reviewer_kwargs=reviewer_kwargs,
+        ):
+            if event.type == "done":
+                final = event.result
+        assert final is not None  # astream always emits a done event
+        return final
+
+    async def astream(
+        self,
+        prompt: str,
+        *,
+        coder_kwargs: dict[str, Any] | None = None,
+        reviewer_kwargs: dict[str, Any] | None = None,
+    ) -> AsyncIterator[ReviewLoopEvent]:
+        """Run the loop and yield :class:`ReviewLoopEvent` events live.
+
+        The sequence per iteration is:
+        ``iteration_started`` → ``coder_done`` → ``reviewer_done``.
+        After the final iteration, ``approved`` or ``rejected`` fires,
+        followed by a single ``done`` event carrying the full
+        :class:`ReviewLoopResult`.
+
+        UI consumers can re-emit each event onto their own transport
+        (WebSocket, SSE, log line) without buffering the whole run.
+        """
         coder_kwargs = coder_kwargs or {}
         reviewer_kwargs = reviewer_kwargs or {}
         history: list[ReviewLoopIteration] = []
         current_prompt = prompt
 
         for i in range(self.max_iters):
+            yield ReviewLoopEvent(
+                type="iteration_started",
+                index=i,
+                prompt=current_prompt,
+            )
+
             code_result = await self.coder.arun(current_prompt, **coder_kwargs)
             code_text = getattr(code_result, "output", "") or ""
+            yield ReviewLoopEvent(
+                type="coder_done",
+                index=i,
+                code_output=code_text,
+                code_result=code_result,
+            )
 
             review_result = await self.reviewer.arun(
                 self.review_prompt(code_text), **reviewer_kwargs
             )
             review_text = getattr(review_result, "output", "") or ""
-
             approved = bool(self.approve_when(review_result))
+            yield ReviewLoopEvent(
+                type="reviewer_done",
+                index=i,
+                code_output=code_text,
+                review_output=review_text,
+                approved=approved,
+                code_result=code_result,
+                review_result=review_result,
+            )
+
             iteration = ReviewLoopIteration(
                 index=i,
                 code_output=code_text,
@@ -227,16 +327,38 @@ class AsyncReviewLoop:
             current_prompt = self.feedback_prompt(prompt, iteration)
 
         last = history[-1]
-        return ReviewLoopResult(
+        result = ReviewLoopResult(
             output=last.code_output,
             approved=last.approved,
             iterations=len(history),
             history=tuple(history),
         )
 
+        yield ReviewLoopEvent(
+            type="approved" if result.approved else "rejected",
+            index=last.index,
+            code_output=result.output,
+            review_output=last.review_output,
+            approved=result.approved,
+            code_result=last.code_result,
+            review_result=last.review_result,
+        )
+        yield ReviewLoopEvent(
+            type="done",
+            index=last.index,
+            code_output=result.output,
+            review_output=last.review_output,
+            approved=result.approved,
+            code_result=last.code_result,
+            review_result=last.review_result,
+            result=result,
+        )
+
 
 __all__ = [
     "AsyncReviewLoop",
+    "ReviewLoopEvent",
+    "ReviewLoopEventType",
     "ReviewLoopIteration",
     "ReviewLoopResult",
 ]

--- a/prompture/infra/coding_agent_events.py
+++ b/prompture/infra/coding_agent_events.py
@@ -251,10 +251,10 @@ _QUESTION_PHRASE_RE = re.compile(
 
 _CHOICE_LINE_RE = re.compile(
     r"^\s*(?:"
-    r"(?P<num>\d+)[.\):]\s+|"     # 1. foo  1) foo  1: foo
-    r"[-*•]\s+|"                  # - foo   * foo   • foo
-    r"\([a-zA-Z]\)\s+|"           # (a) foo
-    r"[a-zA-Z][.\)]\s+"           # a) foo  a. foo
+    r"(?P<num>\d+)[.\):]\s+|"  # 1. foo  1) foo  1: foo
+    r"[-*•]\s+|"  # - foo   * foo   • foo
+    r"\([a-zA-Z]\)\s+|"  # (a) foo
+    r"[a-zA-Z][.\)]\s+"  # a) foo  a. foo
     r")(?P<body>.+\S)\s*$"
 )
 

--- a/prompture/infra/coding_agents.py
+++ b/prompture/infra/coding_agents.py
@@ -55,6 +55,7 @@ def _record_into_session(
     }
     session.record(response_info)
 
+
 CodingAgentId = str
 ApprovalMode = Literal["default", "auto", "yolo"]
 OutputFormat = Literal["text", "json"]

--- a/tests/test_assistant.py
+++ b/tests/test_assistant.py
@@ -157,6 +157,57 @@ def test_from_registry_unknown_raises():
 
 
 # ---------------------------------------------------------------------------
+# build_async_agent
+# ---------------------------------------------------------------------------
+
+
+def test_build_async_agent_returns_async_agent(persona):
+    from prompture import AsyncAgent
+
+    a = Assistant(
+        name="dev",
+        persona=persona,
+        model="openai/gpt-4o",
+        output_key="page_output",
+    )
+    agent = a.build_async_agent(role="senior")
+    assert isinstance(agent, AsyncAgent)
+    assert agent.name == "dev"
+    assert agent.output_key == "page_output"
+
+
+def test_build_async_agent_returns_deep_when_planning_enabled(persona):
+    from prompture import AsyncDeepAgent
+
+    a = Assistant(
+        name="dev",
+        persona=persona,
+        model="openai/gpt-4o",
+        enable_planning=True,
+    )
+    agent = a.build_async_agent()
+    assert isinstance(agent, AsyncDeepAgent)
+
+
+def test_build_async_agent_rejects_coding_agent_backend(persona):
+    a = Assistant(name="cli", persona=persona, coding_agent="claude")
+    with pytest.raises(ValueError, match="only available for the LLM backend"):
+        a.build_async_agent()
+
+
+def test_build_async_agent_applies_skills_to_system_prompt(persona, skill):
+    a = Assistant(
+        name="dev",
+        persona=persona,
+        skills=[skill],
+        model="openai/gpt-4o",
+    )
+    agent = a.build_async_agent()
+    rendered = agent._system_prompt.render()
+    assert "Always use semantic tags" in rendered
+
+
+# ---------------------------------------------------------------------------
 # Coding-agent backend (mocked)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_assistant.py
+++ b/tests/test_assistant.py
@@ -192,6 +192,63 @@ def test_build_async_agent_rejects_coding_agent_backend(persona):
         a.build_async_agent()
 
 
+def test_agent_options_forward_to_async_agent_kwargs(persona):
+    """agent_options must spread into AsyncAgent.__init__ so callers can
+    set budget controls (max_cost, budget_policy, fallback_models, ...)
+    that the Assistant doesn't expose as first-class fields."""
+    from prompture import BudgetPolicy
+
+    a = Assistant(
+        name="dev",
+        persona=persona,
+        model="openai/gpt-4o",
+        agent_options={
+            "max_iterations": 5,
+            "max_cost": 0.50,
+            "budget_policy": BudgetPolicy.warn_and_continue,
+            "fallback_models": ["openai/gpt-4o-mini"],
+        },
+    )
+    with patch("prompture.agents.async_agent.AsyncAgent.__init__", return_value=None) as init:
+        a.build_async_agent()
+    assert init.called
+    kwargs = init.call_args.kwargs
+    assert kwargs["max_iterations"] == 5
+    assert kwargs["max_cost"] == 0.50
+    assert kwargs["budget_policy"] is BudgetPolicy.warn_and_continue
+    assert kwargs["fallback_models"] == ["openai/gpt-4o-mini"]
+
+
+def test_agent_options_ignored_when_planning_enabled(persona):
+    """enable_planning=True routes through AsyncDeepAgent, so agent_options
+    must NOT leak through — deep_agent_options is the right escape hatch."""
+    from prompture import AsyncDeepAgent
+
+    a = Assistant(
+        name="dev",
+        persona=persona,
+        model="openai/gpt-4o",
+        enable_planning=True,
+        agent_options={"max_iterations": 5},
+    )
+    with patch("prompture.agents.async_deep_agent.AsyncDeepAgent.__init__", return_value=None) as init:
+        agent = a.build_async_agent()
+    assert isinstance(agent, AsyncDeepAgent)
+    assert "max_iterations" not in init.call_args.kwargs
+
+
+def test_agent_options_empty_by_default(persona):
+    """Default Assistant carries an empty agent_options dict; nothing is
+    forwarded so callers who don't opt in see no behavior change."""
+    a = Assistant(name="dev", persona=persona, model="openai/gpt-4o")
+    assert a.agent_options == {}
+    with patch("prompture.agents.async_agent.AsyncAgent.__init__", return_value=None) as init:
+        a.build_async_agent()
+    kwargs = init.call_args.kwargs
+    for budget_kw in ("max_iterations", "max_cost", "budget_policy", "fallback_models"):
+        assert budget_kw not in kwargs, f"{budget_kw} should not appear without agent_options"
+
+
 def test_build_async_agent_applies_skills_to_system_prompt(persona, skill):
     a = Assistant(
         name="dev",

--- a/tests/test_assistant.py
+++ b/tests/test_assistant.py
@@ -180,6 +180,7 @@ def test_build_async_agent_returns_deep_when_planning_enabled(persona):
         persona=persona,
         model="openai/gpt-4o",
         enable_planning=True,
+        deep_agent_options={"enable_summarization": False},
     )
     agent = a.build_async_agent()
     assert isinstance(agent, AsyncDeepAgent)

--- a/tests/test_assistant.py
+++ b/tests/test_assistant.py
@@ -55,9 +55,7 @@ def test_requires_exactly_one_backend(persona):
         Assistant(name="bad", persona=persona)
 
     with pytest.raises(ValueError, match="exactly one"):
-        Assistant(
-            name="bad", persona=persona, model="openai/gpt-4o", coding_agent="claude"
-        )
+        Assistant(name="bad", persona=persona, model="openai/gpt-4o", coding_agent="claude")
 
 
 def test_planning_requires_llm_backend(persona):
@@ -103,9 +101,7 @@ def test_with_skills_appends(persona, skill):
 
 
 def test_composed_persona_includes_skill_instructions(persona, skill):
-    a = Assistant(
-        name="dev", persona=persona, skills=[skill], model="openai/gpt-4o"
-    )
+    a = Assistant(name="dev", persona=persona, skills=[skill], model="openai/gpt-4o")
     composed = a._composed_persona({})
     rendered = composed.render()
     assert "Always use semantic tags" in rendered
@@ -259,13 +255,16 @@ def test_coding_agent_auto_resolves_first_healthy(persona):
             "session_id": None,
         },
     )()
-    with patch(
-        "prompture.infra.discovery.get_available_coding_agents",
-        return_value=fake_specs,
-    ), patch(
-        "prompture.infra.coding_agents.arun_coding_agent",
-        new=AsyncMock(return_value=fake_result),
-    ) as runner:
+    with (
+        patch(
+            "prompture.infra.discovery.get_available_coding_agents",
+            return_value=fake_specs,
+        ),
+        patch(
+            "prompture.infra.coding_agents.arun_coding_agent",
+            new=AsyncMock(return_value=fake_result),
+        ) as runner,
+    ):
         asyncio.run(a.arun("hi"))
     assert runner.call_args.args[0] == "claude"
 

--- a/tests/test_code_extraction.py
+++ b/tests/test_code_extraction.py
@@ -21,11 +21,7 @@ def test_fenced_blocks_basic():
 
 
 def test_fenced_blocks_multiple_languages():
-    text = (
-        "```html\n<p>x</p>\n```\n"
-        "```css\np { color: red; }\n```\n"
-        "```js\nconsole.log(1);\n```"
-    )
+    text = "```html\n<p>x</p>\n```\n```css\np { color: red; }\n```\n```js\nconsole.log(1);\n```"
     blocks = extract_fenced_blocks(text)
     assert [b.language for b in blocks] == ["html", "css", "js"]
 
@@ -122,11 +118,6 @@ def test_html_document_skips_empty_script_tags():
 
 
 def test_html_document_multiple_styles_collected():
-    text = (
-        "<!DOCTYPE html><html>"
-        "<style>a { color: red; }</style>"
-        "<style>b { color: blue; }</style>"
-        "</html>"
-    )
+    text = "<!DOCTYPE html><html><style>a { color: red; }</style><style>b { color: blue; }</style></html>"
     result = extract_html_document(text)
     assert result.styles == ("a { color: red; }", "b { color: blue; }")

--- a/tests/test_coding_agent_events.py
+++ b/tests/test_coding_agent_events.py
@@ -18,9 +18,7 @@ def _lines(*objs: dict) -> list[str]:
 class TestClaudeStreamJSONParser:
     def test_emits_system_init_event(self):
         events = list(
-            parse_claude_stream_json_lines(
-                _lines({"type": "system", "subtype": "init", "session_id": "abc"})
-            )
+            parse_claude_stream_json_lines(_lines({"type": "system", "subtype": "init", "session_id": "abc"}))
         )
         assert len(events) == 1
         assert events[0].type == "system"
@@ -208,19 +206,11 @@ class TestClaudeStreamJSONParser:
                     },
                     {
                         "type": "assistant",
-                        "message": {
-                            "content": [
-                                {"type": "tool_use", "name": "Read", "input": {"path": "a.py"}}
-                            ]
-                        },
+                        "message": {"content": [{"type": "tool_use", "name": "Read", "input": {"path": "a.py"}}]},
                     },
                     {
                         "type": "user",
-                        "message": {
-                            "content": [
-                                {"type": "tool_result", "tool_use_id": "1", "content": "print('hi')"}
-                            ]
-                        },
+                        "message": {"content": [{"type": "tool_result", "tool_use_id": "1", "content": "print('hi')"}]},
                     },
                     {
                         "type": "result",
@@ -251,22 +241,16 @@ class TestCodexJSONParser:
         assert [e.type for e in events] == ["system"]
 
     def test_agent_message_emits_message_event(self):
-        events = list(
-            parse_codex_json_lines(_lines({"msg": {"type": "agent_message", "message": "hello"}}))
-        )
+        events = list(parse_codex_json_lines(_lines({"msg": {"type": "agent_message", "message": "hello"}})))
         assert events == [CodingAgentEvent(type="message", text="hello", raw=events[0].raw)]
 
     def test_agent_message_delta_emits_partial_message(self):
-        events = list(
-            parse_codex_json_lines(_lines({"msg": {"type": "agent_message_delta", "delta": "Hel"}}))
-        )
+        events = list(parse_codex_json_lines(_lines({"msg": {"type": "agent_message_delta", "delta": "Hel"}})))
         assert [e.type for e in events] == ["message"]
         assert events[0].text == "Hel"
 
     def test_empty_delta_is_skipped(self):
-        events = list(
-            parse_codex_json_lines(_lines({"msg": {"type": "agent_message_delta", "delta": ""}}))
-        )
+        events = list(parse_codex_json_lines(_lines({"msg": {"type": "agent_message_delta", "delta": ""}})))
         assert events == []
 
     def test_exec_command_begin_is_tool_call(self):
@@ -318,9 +302,7 @@ class TestCodexJSONParser:
         assert events[0].output_tokens == 200
 
     def test_explicit_error_event(self):
-        events = list(
-            parse_codex_json_lines(_lines({"msg": {"type": "error", "message": "rate limit"}}))
-        )
+        events = list(parse_codex_json_lines(_lines({"msg": {"type": "error", "message": "rate limit"}})))
         assert events[0].type == "error"
         assert events[0].error == "rate limit"
 
@@ -350,12 +332,7 @@ class TestQuestionDetection:
     def test_numbered_choices_extracted(self):
         from prompture.infra.coding_agent_events import detect_question
 
-        text = (
-            "Which approach do you want?\n"
-            "1. Refactor the whole module\n"
-            "2. Add a thin wrapper\n"
-            "3. Leave it as-is"
-        )
+        text = "Which approach do you want?\n1. Refactor the whole module\n2. Add a thin wrapper\n3. Leave it as-is"
         is_q, choices = detect_question(text)
         assert is_q is True
         assert choices == (
@@ -423,11 +400,7 @@ class TestQuestionDetection:
                     {
                         "msg": {
                             "type": "agent_message",
-                            "message": (
-                                "Do you want me to:\n"
-                                "1. Update the schema\n"
-                                "2. Skip the migration"
-                            ),
+                            "message": ("Do you want me to:\n1. Update the schema\n2. Skip the migration"),
                         }
                     }
                 )
@@ -457,9 +430,7 @@ class TestQuestionDetection:
 class TestSessionIdExtraction:
     def test_claude_system_event_extracts_session_id(self):
         events = list(
-            parse_claude_stream_json_lines(
-                _lines({"type": "system", "subtype": "init", "session_id": "abc-123"})
-            )
+            parse_claude_stream_json_lines(_lines({"type": "system", "subtype": "init", "session_id": "abc-123"}))
         )
         assert events[0].session_id == "abc-123"
 
@@ -474,16 +445,10 @@ class TestSessionIdExtraction:
 
     def test_codex_task_started_extracts_session_id_from_msg(self):
         events = list(
-            parse_codex_json_lines(
-                _lines({"msg": {"type": "task_started", "model": "gpt-5", "session_id": "codex-1"}})
-            )
+            parse_codex_json_lines(_lines({"msg": {"type": "task_started", "model": "gpt-5", "session_id": "codex-1"}}))
         )
         assert events[0].session_id == "codex-1"
 
     def test_codex_session_configured_extracts_envelope_session_id(self):
-        events = list(
-            parse_codex_json_lines(
-                _lines({"session_id": "codex-2", "msg": {"type": "session_configured"}})
-            )
-        )
+        events = list(parse_codex_json_lines(_lines({"session_id": "codex-2", "msg": {"type": "session_configured"}})))
         assert events[0].session_id == "codex-2"

--- a/tests/test_coding_agents.py
+++ b/tests/test_coding_agents.py
@@ -829,9 +829,7 @@ class TestAskedQuestionProperty:
                     {
                         "type": "assistant",
                         "message": {
-                            "content": [
-                                {"type": "text", "text": "Which approach do you want?\n1. Foo\n2. Bar"}
-                            ]
+                            "content": [{"type": "text", "text": "Which approach do you want?\n1. Foo\n2. Bar"}]
                         },
                     }
                 ),

--- a/tests/test_pick_best_coding_agent.py
+++ b/tests/test_pick_best_coding_agent.py
@@ -96,9 +96,7 @@ def test_require_session_resume_filters_out_aider():
         "prompture.infra.discovery.get_available_coding_agents",
         return_value=[_info("aider"), _info("claude")],
     ):
-        chosen = pick_best_coding_agent(
-            require_session_resume=True, verify=False
-        )
+        chosen = pick_best_coding_agent(require_session_resume=True, verify=False)
     assert chosen is not None
     assert chosen.id == "claude"
 
@@ -108,9 +106,7 @@ def test_returns_none_when_no_requirements_satisfied():
         "prompture.infra.discovery.get_available_coding_agents",
         return_value=[_info("aider")],
     ):
-        chosen = pick_best_coding_agent(
-            require_session_resume=True, verify=False
-        )
+        chosen = pick_best_coding_agent(require_session_resume=True, verify=False)
     assert chosen is None
 
 
@@ -128,8 +124,6 @@ def test_require_structured_output_filters_aider():
         "prompture.infra.discovery.get_available_coding_agents",
         return_value=[_info("aider"), _info("codex")],
     ):
-        chosen = pick_best_coding_agent(
-            require_structured_output=True, verify=False
-        )
+        chosen = pick_best_coding_agent(require_structured_output=True, verify=False)
     assert chosen is not None
     assert chosen.id == "codex"

--- a/tests/test_review_loop.py
+++ b/tests/test_review_loop.py
@@ -175,3 +175,93 @@ def test_default_approve_matches_word_approved_case_insensitive():
     loop = AsyncReviewLoop(coder=coder, reviewer=reviewer)
     result = asyncio.run(loop.arun("task"))
     assert result.approved is True
+
+
+# ---------------------------------------------------------------------------
+# astream (streaming events)
+# ---------------------------------------------------------------------------
+
+
+def _drain_stream(loop, prompt, **kwargs):
+    async def go():
+        return [event async for event in loop.astream(prompt, **kwargs)]
+
+    return asyncio.run(go())
+
+
+def test_astream_emits_lifecycle_for_single_iteration():
+    coder = _ScriptedAgent(["code-v1"])
+    reviewer = _ScriptedAgent(["nice. APPROVED."])
+    loop = AsyncReviewLoop(
+        coder=coder,
+        reviewer=reviewer,
+        approve_when=lambda r: "APPROVED" in r.output,
+    )
+    events = _drain_stream(loop, "task")
+    types = [e.type for e in events]
+    assert types == [
+        "iteration_started",
+        "coder_done",
+        "reviewer_done",
+        "approved",
+        "done",
+    ]
+    # iteration_started carries the prompt the coder will receive.
+    assert events[0].prompt == "task"
+    # coder_done carries code_output + the raw coder result.
+    assert events[1].code_output == "code-v1"
+    assert events[1].code_result.output == "code-v1"
+    # reviewer_done carries both outputs + approval flag.
+    assert events[2].review_output == "nice. APPROVED."
+    assert events[2].approved is True
+    # done carries the full ReviewLoopResult.
+    assert events[-1].result.approved is True
+    assert events[-1].result.iterations == 1
+
+
+def test_astream_emits_rejected_when_max_iters_exceeded():
+    coder = _ScriptedAgent(["v1", "v2"])
+    reviewer = _ScriptedAgent(["nope", "still nope"])
+    loop = AsyncReviewLoop(
+        coder=coder,
+        reviewer=reviewer,
+        max_iters=2,
+        approve_when=lambda r: False,
+    )
+    events = _drain_stream(loop, "task")
+    terminal_types = [e.type for e in events if e.type in ("approved", "rejected", "done")]
+    assert terminal_types == ["rejected", "done"]
+    assert events[-1].result.approved is False
+    assert events[-1].result.iterations == 2
+
+
+def test_astream_emits_two_iterations_then_approval():
+    coder = _ScriptedAgent(["v1", "v2"])
+    reviewer = _ScriptedAgent(["bad", "APPROVED"])
+    loop = AsyncReviewLoop(
+        coder=coder,
+        reviewer=reviewer,
+        approve_when=lambda r: "APPROVED" in r.output,
+    )
+    events = _drain_stream(loop, "task")
+    starts = [e for e in events if e.type == "iteration_started"]
+    assert [e.index for e in starts] == [0, 1]
+    # First iteration_started gets the original prompt; second gets the
+    # feedback-augmented prompt.
+    assert starts[0].prompt == "task"
+    assert "v1" in starts[1].prompt
+    assert "bad" in starts[1].prompt
+
+
+def test_arun_returns_same_result_as_streaming_done_event():
+    coder = _ScriptedAgent(["v1", "v2"])
+    reviewer = _ScriptedAgent(["bad", "APPROVED"])
+    loop = AsyncReviewLoop(
+        coder=coder,
+        reviewer=reviewer,
+        approve_when=lambda r: "APPROVED" in r.output,
+    )
+    via_arun = asyncio.run(loop.arun("task"))
+    assert via_arun.iterations == 2
+    assert via_arun.approved is True
+    assert via_arun.output == "v2"


### PR DESCRIPTION
The `Assistant` dataclass had grown into a friendly façade that quietly hid the agent it built — great until you wanted to plug it into a group, a budget, or a streaming UI and discovered the door only opened one way. This PR widens that door: Assistants now hand back the underlying `AsyncAgent`, accept `ToolRegistry` instances, forward budget controls, and `AsyncReviewLoop` gains an `astream()` that emits per-step events instead of making callers wait for the whole loop to finish.

### Highlights

- `Assistant.build_async_agent()` returns the underlying `AsyncAgent` (or `AsyncDeepAgent`) for direct orchestration — useful for agent groups, custom streaming layers, or anything that needs the raw agent
- `AsyncReviewLoop.astream()` yields live `ReviewLoopEvent`s — `iteration_started`, `coder_done`, `reviewer_done`, terminal `approved`/`rejected`, and a final `done` carrying the full result
- `Assistant.tools` now accepts a `ToolRegistry` in addition to plain callables
- New `agent_options` and `deep_agent_options` escape hatches forward budget controls (`max_cost`, `budget_policy`, `fallback_models`, ...) and deep-agent toggles (`enable_vfs`, `enable_summarization`, ...) without bloating the Assistant signature
- New `output_key` field on `Assistant` is forwarded to `AsyncAgent`

<details>
<summary>Technical changes</summary>

- Add `Assistant.build_async_agent(**vars)` that returns `AsyncAgent` or `AsyncDeepAgent` depending on `enable_planning`; raises `ValueError` when called on a `coding_agent` backend since there is no in-process agent to expose
- Add `Assistant.output_key: str | None` and forward it to `AsyncAgent.__init__`
- Add `Assistant.agent_options: dict[str, Any]` (spread into `AsyncAgent.__init__`, ignored when `enable_planning=True`) and `Assistant.deep_agent_options: dict[str, Any]` (spread into `AsyncDeepAgent.__init__`) — keeps budget controls and deep-agent toggles out of the Assistant signature
- Relax `Assistant.tools` typing from `tuple[Callable, ...]` to `Any`; add `_tools_for_agent()` that returns `None` for empty, a `list` for callable iterables, and passes a `ToolRegistry` through verbatim
- Update `__post_init__` to only tuple-coerce `list`/`set` tools so a `ToolRegistry` survives unchanged; preserve skill-tuple normalisation
- Add `ReviewLoopEvent` (frozen dataclass) and `ReviewLoopEventType` literal covering `iteration_started`, `coder_done`, `reviewer_done`, `approved`, `rejected`, `done`; re-export both from `prompture.agents`
- Add `AsyncReviewLoop.astream(prompt, *, coder_kwargs, reviewer_kwargs)` async generator that emits the per-iteration lifecycle and a final `done` event carrying the `ReviewLoopResult`
- Refactor `AsyncReviewLoop.arun()` to consume `astream()` and return the final `done.result`, so both entry points share one execution path
- Forward `Assistant.agent_options` and `Assistant.deep_agent_options` via `**dict(...)` spreads at agent construction
- Delete the static `VERSION` file in favor of `setuptools_scm`-driven versioning (already the documented behavior)
- Tests: add `test_assistant.py` coverage for `build_async_agent` LLM/deep/coding-agent branches, `agent_options` forwarding into `AsyncAgent.__init__`, `agent_options` suppression when planning is on, default-empty behavior, and skills appearing in the rendered system prompt
- Tests: add `test_review_loop.py` coverage for the streaming lifecycle (single approval, max-iter rejection, multi-iteration with feedback-augmented prompt) and parity between `arun()` and the streaming `done` event
- Tests: disable `enable_summarization` in the deep-agent test to keep mocked runs deterministic
- Examples and tests: formatting cleanup — collapse multi-line strings/prints, simplify walrus parens, modernize `with patch(...)` parenthesised contexts
- Minor: trailing-newline fix in `infra/coding_agents.py` and inline-comment alignment in `infra/coding_agent_events.py`

</details>
