### PR TITLE
Add live agentic streaming, deep-research toolkit, swarm runtime, and RAG/eval upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,6 +225,8 @@ PLAN_INGESTION.md
 /feedback
 PLAN_CACHIBOT_ROOMS.md
 PROMPTURE_FEATURES.md
+prompt.md
+prompts/
 .claude/settings.local.json
 /.pr
 /docs-cacao

--- a/README.md
+++ b/README.md
@@ -1286,6 +1286,37 @@ if doc.found:
 
 Both helpers return plain dataclasses with no I/O of their own.  See `examples/assistant_example.py` for the assistant + review-loop + extractor flow end-to-end.
 
+### Prompt Caching (Claude)
+
+Anthropic prompt caching cuts input-token cost on cached prefixes to ~10% of
+the normal rate. Prompture turns it on by default for `ClaudeDriver` and
+`AsyncClaudeDriver` whenever the system prompt or tools bundle is large
+enough to benefit (≥4000 chars, roughly 1024 tokens — Anthropic's minimum
+cacheable block).
+
+```python
+from prompture import Conversation
+
+# Caching is automatic. The first call writes the cache (~1.25x cost on the
+# cached portion); subsequent calls within 5 minutes hit it (~0.1x cost).
+conv = Conversation(model_name="claude/claude-sonnet-4-6", system_prompt=LONG_SYSTEM_PROMPT)
+conv.ask("First question")   # cache_creation_input_tokens > 0
+conv.ask("Second question")  # cache_read_input_tokens > 0
+```
+
+To inspect cache activity, read `cached_prompt_tokens` and
+`cache_creation_tokens` from the response meta. To disable caching for a
+specific call pass `options={"cache_prompt": False}`.
+
+Tips:
+- Put stable content (persona, tools description, JSON schema) at the
+  **start** of the system prompt; put per-call variables (user query,
+  retrieved RAG context) in the message stream so they don't bust the cache.
+- Avoid `{{iteration}}` or other per-turn variables in Persona templates —
+  they rotate the cache key every turn.
+- Block size below ~1024 tokens is silently dropped by Anthropic; below
+  the threshold Prompture skips the `cache_control` marker to avoid noise.
+
 ### Cost Pre-flight
 
 Forecast the cost of a call **before** making it.  Accepts either text

--- a/README.md
+++ b/README.md
@@ -1669,6 +1669,13 @@ request body are forwarded to the driver as schemas; if the model
 returns `tool_calls`, they appear in the response shape so the
 client can execute locally.
 
+> **Single-worker constraint:** the server keeps conversations and
+> rate-limit buckets in **per-process memory**. Run with
+> `uvicorn --workers 1` (the default) — multi-worker deployments will
+> partition state across processes, so a `conversation_id` created on
+> one worker can return 404 on another. A shared-state backend (Redis
+> / Postgres) is on the roadmap.
+
 Selected flags:
 
 | Flag | Purpose |

--- a/README.md
+++ b/README.md
@@ -860,6 +860,21 @@ print(result["usage"])        # token counts and cost
 
 Prompture picks how to obtain structured JSON based on each model's capabilities. The cascade is `provider_native` (built-in JSON mode / schema enforcement) → `tool_call` (encode the schema as a function definition and read it back from the tool call) → `prompted_repair` (prompt for JSON, repair malformed output via AI cleanup). Pass `strategy="auto"` (default) to let Prompture select per model, or pin a specific strategy via the `StructuredOutputStrategy` enum or its string value. The strategy used is recorded in the response so you can see which path each call took.
 
+### Constrained Decoding (vLLM / LMStudio / OpenRouter)
+
+For any OpenAI-compatible driver — `OpenAICompatibleDriver`, `OpenRouterDriver`, `LMStudioDriver` (sync + async) — set `options={"guided_decoding": True}` to also ship vLLM-style `guided_json` fields alongside the standard `response_format`. That unlocks logit-level FSM-constrained sampling (100% schema validity at sample time) on backends that support it. Pin a specific backend with `"outlines"`, `"xgrammar"`, or `"lm-format-enforcer"`:
+
+```python
+result = extract_with_model(
+    Person,
+    "Maria is 32, a developer in NYC.",
+    model_name="openai_compatible/local-vllm",
+    options={"guided_decoding": "xgrammar"},   # fast lattice FSM
+)
+```
+
+Unknown servers ignore the extra fields, so it's safe to leave on. An `options={"extra_body": {...}}` escape hatch mirrors the OpenAI SDK so you can also pass `min_p`, `repetition_penalty`, OpenRouter provider preferences, etc. See `examples/constrained_decoding_example.py`.
+
 ### Multi-Model Fallback
 
 Try a list of models in priority order, with full per-attempt accounting — every model tried (success, failure, or skipped) is recorded with its cost, tokens, duration, capabilities, and strategy. The first success wins; if all fail, an optional `fallback` Pydantic instance is returned instead of raising.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ person = extract_with_model(Person, "Maria is 32, a developer in NYC.", model_na
 print(person.name)  # Maria
 ```
 
+> **First time?** Pick a provider and install its extra. The core package above
+> is just the orchestration layer — provider SDKs are opt-in.
+>
+> | Use `provider/...` | Install | Auth env var |
+> |---|---|---|
+> | `openai/gpt-4`, `openai/gpt-4o-mini`, … | `pip install "prompture[openai]"` | `OPENAI_API_KEY` |
+> | `claude/claude-sonnet-4-6`, … | `pip install "prompture[anthropic]"` | `CLAUDE_API_KEY` |
+> | `google/gemini-1.5-pro`, … | `pip install "prompture[google]"` | `GOOGLE_API_KEY` |
+> | `groq/llama-3.1-8b-instant`, … | `pip install "prompture[groq]"` | `GROQ_API_KEY` |
+> | `ollama/llama3.1:8b`, … (local) | no extra needed | — (set `OLLAMA_HOST` if non-default) |
+> | everything in one go | `pip install "prompture[all]"` | provider-specific |
+
 ## Key Features
 
 **Structured extraction**
@@ -964,8 +976,8 @@ from prompture import Conversation
 
 conv = Conversation(model_name="openai/gpt-4")
 conv.add_message("system", "You are a helpful assistant.")
-response = conv.send("What is the capital of France?")
-follow_up = conv.send("What about Germany?")  # retains context
+response = conv.ask("What is the capital of France?")
+follow_up = conv.ask("What about Germany?")  # retains context
 ```
 
 ### Tool Use

--- a/dev.ps1
+++ b/dev.ps1
@@ -47,6 +47,16 @@ function Invoke-AllChecks {
         Write-Host "fixed $fixed files" -ForegroundColor Yellow
     }
 
+    # --- bandit security scan (matches .github/workflows/security.yml) ---
+    Write-Host "  bandit          " -ForegroundColor Cyan -NoNewline
+    $banditOut = & bandit -q -r $pyPath -c "$Root\pyproject.toml" 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "ok" -ForegroundColor Green
+    } else {
+        Write-Host "fail" -ForegroundColor Red
+        $banditOut | Where-Object { $_ -match ">> Issue|Severity|Location" } | ForEach-Object { Write-Host "    $_" -ForegroundColor DarkGray }
+    }
+
     # --- mypy type check ---
     Write-Host "  mypy            " -ForegroundColor Cyan -NoNewline
     $out = & mypy $pyPath 2>&1

--- a/examples/agent_live_stream.py
+++ b/examples/agent_live_stream.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Live agent stream — interleaved tool calling with text deltas.
+
+This is the "Claude Code feel": the model narrates as it decides what to
+do, fires a tool, narrates again, fires another tool, and finally answers
+— all streamed live instead of buffered.
+
+Compare with ``agent_example.py`` Section 10 (``run_stream``): that one
+yields ``tool_call`` / ``tool_result`` events between rounds but the text
+of each turn arrives in one chunk *after* the tools execute. ``run_live``
+streams text deltas as the model produces them, including *before* and
+*between* tool calls within a single turn.
+
+Usage::
+
+    OPENAI_API_KEY=sk-... python examples/agent_live_stream.py
+    # or
+    CLAUDE_API_KEY=sk-ant-... python examples/agent_live_stream.py --model claude/claude-haiku-4-5-20251001
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any
+
+from prompture import Agent
+from prompture.agents.live_events import (
+    AssistantTurnStart,
+    MessageStop,
+    TextDelta,
+    ThinkingDelta,
+    ToolInputDelta,
+    ToolResult,
+    ToolUseStart,
+    ToolUseStop,
+    TurnComplete,
+)
+
+CITY_DATA: dict[str, dict[str, Any]] = {
+    "Paris": {"country": "France", "population": 2_161_000, "timezone": "CET"},
+    "Tokyo": {"country": "Japan", "population": 13_960_000, "timezone": "JST"},
+    "London": {"country": "United Kingdom", "population": 8_982_000, "timezone": "GMT"},
+    "São Paulo": {"country": "Brazil", "population": 12_396_000, "timezone": "BRT"},
+}
+
+
+def lookup_country(city: str) -> str:
+    """Return the country a city is in."""
+    info = CITY_DATA.get(city)
+    return info["country"] if info else f"Unknown city: {city}"
+
+
+def lookup_population(city: str) -> str:
+    """Return the population of a city."""
+    info = CITY_DATA.get(city)
+    return str(info["population"]) if info else f"Unknown city: {city}"
+
+
+def compare_populations(city_a: str, city_b: str) -> str:
+    """Return which city has the larger population."""
+    a, b = CITY_DATA.get(city_a), CITY_DATA.get(city_b)
+    if not a or not b:
+        return "Unknown city in comparison."
+    if a["population"] > b["population"]:
+        return f"{city_a} is larger ({a['population']:,} vs {b['population']:,})."
+    if a["population"] < b["population"]:
+        return f"{city_b} is larger ({b['population']:,} vs {a['population']:,})."
+    return f"{city_a} and {city_b} have equal populations."
+
+
+def render_event(event: Any) -> None:
+    """Pretty-print one LiveEvent so the stream is visible in a terminal."""
+    if isinstance(event, AssistantTurnStart):
+        print(f"\n--- turn {event.turn_index} ---")
+    elif isinstance(event, TextDelta):
+        print(event.text, end="", flush=True)
+    elif isinstance(event, ThinkingDelta):
+        print(f"\033[2m{event.text}\033[0m", end="", flush=True)
+    elif isinstance(event, ToolUseStart):
+        print(f"\n[> calling {event.name} ({event.id[:8]})]", flush=True)
+    elif isinstance(event, ToolInputDelta):
+        # Show input-JSON arriving piece by piece.
+        print(f"\033[2m{event.fragment}\033[0m", end="", flush=True)
+    elif isinstance(event, ToolUseStop):
+        print(f"\n[> {event.name} input ready: {event.input}]", flush=True)
+    elif isinstance(event, ToolResult):
+        out = event.output if len(event.output) < 200 else event.output[:200] + "…"
+        prefix = "!" if event.is_error else "<"
+        print(f"\n[{prefix} {event.name} -> {out}]", flush=True)
+    elif isinstance(event, MessageStop):
+        cost = event.usage.get("cost", 0.0)
+        tokens = event.usage.get("total_tokens", 0)
+        print(f"\n[turn done: {tokens} tokens, ${cost:.5f}, stop={event.stop_reason}]")
+    elif isinstance(event, TurnComplete):
+        cost = event.usage.get("cost", 0.0)
+        tokens = event.usage.get("total_tokens", 0)
+        print(f"\n[all done: {tokens} tokens, ${cost:.5f}]")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Live agent stream demo.")
+    parser.add_argument("--model", default="openai/gpt-4o-mini", help="provider/model string")
+    parser.add_argument(
+        "--prompt",
+        default=(
+            "Compare Tokyo and Paris. Tell me which is bigger and what country each is in. "
+            "Use your tools to verify the numbers."
+        ),
+    )
+    args = parser.parse_args()
+
+    agent = Agent(
+        args.model,
+        system_prompt=(
+            "You are a careful researcher. Use tools to verify facts before answering. "
+            "Narrate briefly what you are about to do before each tool call."
+        ),
+        tools=[lookup_country, lookup_population, compare_populations],
+    )
+
+    streamed = agent.run_live(args.prompt)
+    for event in streamed:
+        render_event(event)
+
+    final = streamed.result
+    if final is not None:
+        print(f"\n\nFinal answer:\n{final.output_text}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/agent_live_to_sse.py
+++ b/examples/agent_live_to_sse.py
@@ -18,6 +18,7 @@ FastAPI / Starlette / Flask / aiohttp handler.
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 import json
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -90,7 +91,7 @@ def event_to_sse(event: LiveEvent) -> str:
 
 
 class _Handler(BaseHTTPRequestHandler):
-    def do_GET(self) -> None:  # noqa: N802 — required by BaseHTTPRequestHandler
+    def do_GET(self) -> None:
         if self.path != "/chat":
             self.send_response(404)
             self.end_headers()
@@ -125,10 +126,8 @@ def main() -> int:
     print(f"SSE demo listening at http://{addr[0]}:{addr[1]}/chat")
     print("In another shell:  curl -N http://127.0.0.1:8765/chat")
     server = HTTPServer(addr, _Handler)
-    try:
+    with contextlib.suppress(KeyboardInterrupt):
         server.serve_forever()
-    except KeyboardInterrupt:
-        pass
     return 0
 
 

--- a/examples/agent_live_to_sse.py
+++ b/examples/agent_live_to_sse.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Forward a live agent stream to Server-Sent Events.
+
+Drop-in pattern for any web app: every LiveEvent is one ``data:`` frame.
+Frontend reads them with ``EventSource`` and renders text deltas + tool
+calls as they arrive. No buffering, no callbacks required.
+
+Run::
+
+    OPENAI_API_KEY=sk-... python examples/agent_live_to_sse.py
+    # then in another shell:
+    curl -N http://127.0.0.1:8765/chat
+
+This example uses ``http.server`` so it has zero web-framework deps. The
+event-shaping logic in :func:`event_to_sse` is what you'd lift into a
+FastAPI / Starlette / Flask / aiohttp handler.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+from prompture import Agent
+from prompture.agents.live_events import (
+    AssistantTurnStart,
+    LiveEvent,
+    MessageStop,
+    TextDelta,
+    ThinkingDelta,
+    ToolInputDelta,
+    ToolResult,
+    ToolUseStart,
+    ToolUseStop,
+    TurnComplete,
+)
+
+
+def get_weather(city: str) -> str:
+    """Return a fake weather report for *city*."""
+    fake = {"Paris": "18°C, cloudy", "Tokyo": "27°C, sunny", "London": "12°C, rainy"}
+    return fake.get(city, f"No data for {city}.")
+
+
+def event_to_sse(event: LiveEvent) -> str:
+    """Convert one ``LiveEvent`` into an SSE ``data:`` frame.
+
+    Each variant is serialised as a typed JSON object so the frontend can
+    ``switch (msg.type)`` cleanly. We do not include the raw dataclass
+    because some fields (like ``usage``) are nested dicts.
+    """
+    payload: dict[str, Any]
+    match event:
+        case AssistantTurnStart():
+            payload = {"type": "turn_start", "turn": event.turn_index}
+        case TextDelta():
+            payload = {"type": "text", "text": event.text}
+        case ThinkingDelta():
+            payload = {"type": "thinking", "text": event.text}
+        case ToolUseStart():
+            payload = {"type": "tool_start", "id": event.id, "name": event.name}
+        case ToolInputDelta():
+            payload = {"type": "tool_input_delta", "id": event.id, "fragment": event.fragment}
+        case ToolUseStop():
+            payload = {
+                "type": "tool_input_ready",
+                "id": event.id,
+                "name": event.name,
+                "input": event.input,
+            }
+        case ToolResult():
+            payload = {
+                "type": "tool_result",
+                "id": event.id,
+                "name": event.name,
+                "output": event.output,
+                "is_error": event.is_error,
+            }
+        case MessageStop():
+            payload = {"type": "turn_stop", "stop_reason": event.stop_reason, "usage": event.usage}
+        case TurnComplete():
+            payload = {"type": "done", "usage": event.usage}
+        case _:
+            payload = {"type": "unknown", "repr": repr(event)}
+            if dataclasses.is_dataclass(event):
+                payload["data"] = dataclasses.asdict(event)
+    return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802 — required by BaseHTTPRequestHandler
+        if self.path != "/chat":
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("X-Accel-Buffering", "no")
+        self.end_headers()
+
+        agent = Agent(
+            "openai/gpt-4o-mini",
+            system_prompt="Use the weather tool when asked about cities. Narrate what you're doing.",
+            tools=[get_weather],
+        )
+        streamed = agent.run_live("What's the weather in Paris and Tokyo? Compare them.")
+        for event in streamed:
+            try:
+                self.wfile.write(event_to_sse(event).encode("utf-8"))
+                self.wfile.flush()
+            except BrokenPipeError:
+                break
+
+    def log_message(self, *_a: Any, **_kw: Any) -> None:
+        # Silence default access log for cleaner demo output.
+        pass
+
+
+def main() -> int:
+    addr = ("127.0.0.1", 8765)
+    print(f"SSE demo listening at http://{addr[0]}:{addr[1]}/chat")
+    print("In another shell:  curl -N http://127.0.0.1:8765/chat")
+    server = HTTPServer(addr, _Handler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/batch_processing_example.py
+++ b/examples/batch_processing_example.py
@@ -5,7 +5,6 @@ This example shows how to use Prompture for processing multiple documents with r
 It demonstrates batch processing of contact information with validation and comprehensive error tracking.
 """
 
-from typing import Optional
 
 from pydantic import BaseModel
 
@@ -14,9 +13,9 @@ from prompture import extract_with_model, field_from_registry
 
 class ContactInfo(BaseModel):
     name: str = field_from_registry("name")
-    email: Optional[str] = field_from_registry("email")
-    phone: Optional[str] = field_from_registry("phone")
-    company: Optional[str] = field_from_registry("company")
+    email: str | None = field_from_registry("email")
+    phone: str | None = field_from_registry("phone")
+    company: str | None = field_from_registry("company")
 
 
 # Sample contact data

--- a/examples/constrained_decoding_example.py
+++ b/examples/constrained_decoding_example.py
@@ -1,0 +1,134 @@
+"""Constrained-decoding example for vLLM / LMStudio / OpenRouter.
+
+Demonstrates the Phase 8A-lite ``guided_decoding`` and ``extra_body``
+options. Any OpenAI-compatible driver — ``OpenAICompatibleDriver``,
+``OpenRouterDriver``, ``LMStudioDriver`` (sync + async) — accepts these
+options and ships them on the request:
+
+* ``options={"guided_decoding": True}`` adds vLLM's ``guided_json``
+  field at the top level. The server picks its own backend (Outlines
+  by default on vLLM 0.5+).
+* ``options={"guided_decoding": "outlines"}`` (or ``"xgrammar"`` /
+  ``"lm-format-enforcer"``) explicitly pins the backend.
+* ``options={"extra_body": {...}}`` mirrors the OpenAI SDK's
+  ``extra_body`` escape hatch — drop any vendor-specific fields here.
+
+Why this matters
+~~~~~~~~~~~~~~~~
+
+Modern vLLM honours ``response_format`` natively, so most users don't
+need ``guided_decoding`` at all. But:
+
+* Older vLLM versions (<0.5) only respect ``guided_json``.
+* Some models / servers handle FSM-level decoding only via the
+  ``guided_*`` family, not ``response_format``.
+* Some backends (xgrammar) are dramatically faster than the default
+  Outlines backend and can be selected explicitly.
+
+This example assembles a request payload via Prompture's stack
+without sending it anywhere — it prints the body that would hit the
+server, so you can see exactly what flows under the hood.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from pydantic import BaseModel
+
+from prompture.drivers._openai_compat import apply_structured_output
+
+
+class Address(BaseModel):
+    street: str
+    city: str
+    zip_code: str
+
+
+class Person(BaseModel):
+    name: str
+    age: int
+    address: Address
+
+
+def _print_body(label: str, body: dict[str, Any]) -> None:
+    print(f"  {label}:")
+    print(json.dumps(body, indent=2, default=str))
+    print()
+
+
+def main() -> None:
+    schema = Person.model_json_schema()
+
+    print("=" * 72)
+    print("EXAMPLE 1: response_format only (every OpenAI-compatible server)")
+    print("=" * 72)
+    body = {"model": "meta-llama/Llama-3.1-8B-Instruct", "messages": [{"role": "user", "content": "..."}]}
+    apply_structured_output(body, options={"json_mode": True, "json_schema": schema})
+    _print_body("payload", body)
+
+    print("=" * 72)
+    print("EXAMPLE 2: + guided_decoding=True (vLLM picks its own backend)")
+    print("=" * 72)
+    body = {"model": "meta-llama/Llama-3.1-8B-Instruct", "messages": [{"role": "user", "content": "..."}]}
+    apply_structured_output(
+        body,
+        options={"json_mode": True, "json_schema": schema, "guided_decoding": True},
+    )
+    _print_body("payload", body)
+
+    print("=" * 72)
+    print("EXAMPLE 3: pin to xgrammar (fast lattice FSM)")
+    print("=" * 72)
+    body = {"model": "meta-llama/Llama-3.1-8B-Instruct", "messages": [{"role": "user", "content": "..."}]}
+    apply_structured_output(
+        body,
+        options={"json_mode": True, "json_schema": schema, "guided_decoding": "xgrammar"},
+    )
+    _print_body("payload", body)
+
+    print("=" * 72)
+    print("EXAMPLE 4: extra_body escape hatch for vendor-specific fields")
+    print("=" * 72)
+    body = {"model": "meta-llama/Llama-3.1-8B-Instruct", "messages": [{"role": "user", "content": "..."}]}
+    apply_structured_output(
+        body,
+        options={
+            "json_mode": True,
+            "json_schema": schema,
+            "guided_decoding": "outlines",
+            # vLLM sampling-knob examples; OpenRouter provider-preference example.
+            "extra_body": {
+                "min_p": 0.05,
+                "repetition_penalty": 1.05,
+                "provider": {"order": ["Hyperbolic", "Together"]},
+            },
+        },
+    )
+    _print_body("payload", body)
+
+    print("=" * 72)
+    print("How to use in practice")
+    print("=" * 72)
+    print(
+        "  from prompture import extract_with_model\n"
+        "  from prompture.drivers.openai_compatible_driver import OpenAICompatibleDriver\n"
+        "\n"
+        '  driver = OpenAICompatibleDriver(endpoint="http://my-vllm:8000/v1", model="...")\n'
+        "\n"
+        "  result = extract_with_model(\n"
+        "      Person,\n"
+        '      "Alice Smith, 32, lives at 1 Main St, Springfield, IL 62701",\n'
+        '      model_name="openai_compatible/local-vllm",\n'
+        '      options={"guided_decoding": "outlines"},  # FSM-constrained sampling\n'
+        "  )\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/dataset_modernization_example.py
+++ b/examples/dataset_modernization_example.py
@@ -1,0 +1,333 @@
+"""Synthetic dataset modernisation example.
+
+Walks through every Phase 8C addition end-to-end against a tiny
+in-memory corpus:
+
+1. ``generate_qa_dataset`` with **personas** for stylistic diversity.
+2. ``QualityFilter`` to drop junk before dedup.
+3. ``DedupConfig(strategy="shingle")`` for paraphrase-aware dedup.
+4. ``EvolInstruct`` to evolve the surviving pairs along depth /
+   breadth / reasoning axes.
+5. ``SelfInstruct`` to expand a small seed set into a larger one.
+
+Falls back to a scripted LLM if Ollama isn't reachable so the demo
+runs in any environment. With Ollama available, the same flow scales
+to real corpora — swap the inline ``Document`` for a file path or
+glob.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from prompture.agents.persona import Persona
+from prompture.dataset import (
+    DedupConfig,
+    EvolInstruct,
+    QAPair,
+    QualityFilter,
+    SelfInstruct,
+    generate_qa_dataset,
+)
+from prompture.dataset.schemas import QAPairBatch
+from prompture.rag.documents import Document
+
+# =============================================================================
+# Sample corpus — two short docs so the demo runs quickly
+# =============================================================================
+
+CORPUS = [
+    Document(
+        content=(
+            "Mitochondria are membrane-bound organelles inside most "
+            "eukaryotic cells. They generate adenosine triphosphate (ATP) "
+            "via oxidative phosphorylation and have their own circular DNA "
+            "inherited maternally."
+        ),
+        metadata={"source": "biology-textbook-1"},
+    ),
+    Document(
+        content=(
+            "Photosynthesis converts light energy into chemical energy in "
+            "chloroplasts. The Calvin cycle fixes CO2 using NADPH and ATP "
+            "produced by the light-dependent reactions in the thylakoid "
+            "membrane."
+        ),
+        metadata={"source": "biology-textbook-2"},
+    ),
+]
+
+
+# =============================================================================
+# Scripted LLM fallback
+# =============================================================================
+
+
+class _ScriptedDataDriver:
+    """Returns plausible synthetic responses keyed by prompt content."""
+
+    model = "scripted/datagen"
+    model_name = "scripted/datagen"
+
+    _SCRIPT: dict[str, list[QAPair]] = {
+        # Mitochondria chunk responses (one for each persona)
+        "mitochondria-tutor": [
+            QAPair(
+                question="Where in the cell is ATP generated?",
+                answer="ATP is generated in the mitochondria via oxidative phosphorylation.",
+            ),
+            QAPair(
+                question="How is mitochondrial DNA inherited?",
+                answer="Mitochondrial DNA is inherited maternally as a circular genome.",
+            ),
+        ],
+        "mitochondria-quiz": [
+            QAPair(
+                question="What organelle hosts oxidative phosphorylation?",
+                answer="The mitochondrion hosts oxidative phosphorylation.",
+            ),
+            QAPair(
+                question="Is mitochondrial DNA circular or linear?",
+                answer="Mitochondrial DNA is circular.",
+            ),
+        ],
+        # Photosynthesis chunk responses
+        "photosynthesis-tutor": [
+            QAPair(
+                question="In which organelle does photosynthesis occur?",
+                answer="Photosynthesis occurs in chloroplasts.",
+            ),
+            QAPair(
+                question="What molecules drive the Calvin cycle?",
+                answer="NADPH and ATP from the light-dependent reactions drive the Calvin cycle.",
+            ),
+        ],
+        "photosynthesis-quiz": [
+            QAPair(
+                question="What does the Calvin cycle fix?",
+                answer="The Calvin cycle fixes CO2.",
+            ),
+            QAPair(
+                question="Where do the light-dependent reactions take place?",
+                answer="They take place in the thylakoid membrane.",
+            ),
+        ],
+        # Evol-Instruct evolutions
+        "evol-depth": [QAPair(
+            question="In a cell deprived of oxygen, what happens to ATP output?",
+            answer="Without oxygen, oxidative phosphorylation halts and ATP yield drops sharply.",
+        )],
+        "evol-breadth": [QAPair(
+            question="What other organelle has its own DNA besides mitochondria?",
+            answer="Chloroplasts also have their own circular DNA, inherited maternally in most plants.",
+        )],
+        "evol-reasoning": [QAPair(
+            question="Why does a marathon runner's muscle pH drop when ATP demand exceeds aerobic supply?",
+            answer="When demand outpaces oxidative phosphorylation, lactic-acid fermentation takes over to produce ATP, lowering pH.",
+        )],
+        # Self-Instruct expansion
+        "self-instruct-batch": [
+            QAPair(
+                question="What is the role of NADPH in photosynthesis?",
+                answer="NADPH provides the reducing power needed by the Calvin cycle to fix CO2.",
+            ),
+            QAPair(
+                question="What is a chloroplast?",
+                answer="A chloroplast is a double-membraned organelle in plant cells where photosynthesis takes place.",
+            ),
+            QAPair(
+                question="What pigment captures light in plants?",
+                answer="Chlorophyll captures light, primarily in the red and blue wavelengths.",
+            ),
+        ],
+    }
+
+    def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        return {"text": "", "meta": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "cost": 0.0}}
+
+    # When the example uses extract_with_model, prompture invokes our patched
+    # _fake_extract directly — we don't need a real generate path.
+
+
+def _pick_driver_or_mock() -> tuple[str, bool]:
+    """Return (model_string, using_real_llm)."""
+    try:
+        from prompture.drivers.ollama_driver import OllamaDriver
+
+        driver = OllamaDriver(
+            endpoint=os.getenv("OLLAMA_ENDPOINT", "http://localhost:11434/api/generate"),
+            model=os.getenv("OLLAMA_MODEL", "llama3.1:8b"),
+        )
+        driver.generate("ping", {"temperature": 0.0, "max_tokens": 4})
+        print(f"[LLM: ollama/{driver.model}]\n")
+        return f"ollama/{driver.model}", True
+    except Exception as e:
+        print(f"[LLM: scripted fallback — Ollama not reachable: {type(e).__name__}]\n")
+        return "scripted/datagen", False
+
+
+# When Ollama isn't around we monkey-patch ``extract_with_model`` to return
+# pre-baked pairs keyed by the persona / operator the prompt mentions.
+def _content_keyed_extract(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    text = args[1] if len(args) > 1 else kwargs.get("text", "")
+    text_lower = (text or "").lower()
+
+    # Determine which canned response to return based on prompt content.
+    key: str
+    if "tutor" in text_lower and "mitochond" in text_lower:
+        key = "mitochondria-tutor"
+    elif "quiz" in text_lower and "mitochond" in text_lower:
+        key = "mitochondria-quiz"
+    elif "tutor" in text_lower and "photosynth" in text_lower:
+        key = "photosynthesis-tutor"
+    elif "quiz" in text_lower and "photosynth" in text_lower:
+        key = "photosynthesis-quiz"
+    elif "more specific" in text_lower:
+        key = "evol-depth"
+    elif "broaden" in text_lower or "sibling" in text_lower:
+        key = "evol-breadth"
+    elif "multi-step" in text_lower or "reasoning" in text_lower:
+        key = "evol-reasoning"
+    elif "example pairs" in text_lower or "training data" in text_lower:
+        key = "self-instruct-batch"
+    elif "mitochond" in text_lower:
+        key = "mitochondria-tutor"
+    else:
+        key = "photosynthesis-tutor"
+
+    pairs = _ScriptedDataDriver._SCRIPT.get(key, [])
+    if "{" in str(kwargs.get("model_cls", "")) or "QAPairBatch" in str(args[0] if args else ""):
+        return {
+            "model": QAPairBatch(pairs=pairs),
+            "json_string": "",
+            "usage": {"prompt_tokens": 50, "completion_tokens": 30, "total_tokens": 80, "cost": 0.0},
+        }
+    # Single QAPair extraction (EvolInstruct)
+    return {
+        "model": pairs[0] if pairs else QAPair(question="?", answer="."),
+        "json_string": "",
+        "usage": {"prompt_tokens": 50, "completion_tokens": 30, "total_tokens": 80, "cost": 0.0},
+    }
+
+
+# =============================================================================
+# Examples
+# =============================================================================
+
+
+def example_personas_and_filters(model: str) -> list[QAPair]:
+    print("=" * 70)
+    print("STEP 1: generate_qa_dataset with personas + quality_filter + shingle dedup")
+    print("=" * 70)
+
+    tutor = Persona(
+        name="tutor",
+        system_prompt="You are a patient biology tutor. Ask clear, foundational questions and explain answers in plain English.",
+    )
+    quiz = Persona(
+        name="quiz",
+        system_prompt="You write multiple-choice-style quiz questions. Be terse, direct, factual.",
+    )
+
+    pairs, stats = generate_qa_dataset(
+        CORPUS,
+        model=model,
+        personas=[tutor, quiz],
+        quality_filter=QualityFilter(),
+        dedup=DedupConfig(strategy="shingle", threshold=0.7, shingle_size=4),
+        return_stats=True,
+    )
+
+    print(f"  raw pairs:        {stats['raw_count']}")
+    if "filter" in stats:
+        print(f"  filter dropped:   {stats['filter']['dropped']}")
+    if "dedup_removed" in stats:
+        print(f"  dedup removed:    {stats['dedup_removed']} ({stats['dedup_strategy']})")
+    print(f"  surviving pairs:  {len(pairs)}")
+    for i, p in enumerate(pairs[:5], 1):
+        print(f"    [{i}] Q: {p.question}")
+        print(f"        A: {p.answer}")
+    print()
+    return pairs
+
+
+def example_evol_instruct(model: str, base_pairs: list[QAPair]) -> list[QAPair]:
+    print("=" * 70)
+    print("STEP 2: EvolInstruct — depth / breadth / reasoning evolutions")
+    print("=" * 70)
+    if not base_pairs:
+        print("  (no input pairs — skipping)\n")
+        return []
+
+    evol = EvolInstruct(model=model, seed=42)
+    seeds = base_pairs[:1]  # one source pair keeps the demo short
+    result = evol.evolve_batch(seeds, operators=["depth", "breadth", "reasoning"], rounds=1)
+    print(f"  source pairs: {len(seeds)}")
+    print(f"  evolved:      {len(result.evolved)}")
+    print(f"  failures:     {result.failures}")
+    print(f"  LLM calls:    {result.meta.get('calls', 0)}")
+    for i, p in enumerate(result.evolved, 1):
+        print(f"    [{i}] Q: {p.question}")
+        print(f"        A: {p.answer}")
+    print()
+    return result.evolved
+
+
+def example_self_instruct(model: str, seeds: list[QAPair]) -> list[QAPair]:
+    print("=" * 70)
+    print("STEP 3: SelfInstruct — expand seeds into more in-style pairs")
+    print("=" * 70)
+    if not seeds:
+        print("  (no seeds — skipping)\n")
+        return []
+
+    si = SelfInstruct(
+        model=model,
+        topic="introductory cell biology study questions",
+        seed_random=random.Random(0),
+        seed_sample_size=3,
+    )
+    result = si.expand(
+        seeds=seeds[:3] if len(seeds) >= 3 else seeds,
+        target_count=5,
+        batch_size=3,
+        max_rounds=3,
+    )
+    print(f"  seeds:            {len(seeds[:3] if len(seeds) >= 3 else seeds)}")
+    print(f"  generated:        {len(result.pairs)}")
+    print(f"  rounds completed: {result.rounds_completed}")
+    print(f"  LLM calls:        {result.meta.get('calls', 0)}")
+    for i, p in enumerate(result.pairs, 1):
+        print(f"    [{i}] Q: {p.question}")
+        print(f"        A: {p.answer}")
+    print()
+    return result.pairs
+
+
+def main() -> None:
+    model, real = _pick_driver_or_mock()
+    if real:
+        all_base = example_personas_and_filters(model)
+        evolved = example_evol_instruct(model, all_base)
+        _ = example_self_instruct(model, all_base + evolved)
+    else:
+        from unittest.mock import patch
+
+        with (
+            patch("prompture.dataset.synth.extract_with_model", _content_keyed_extract),
+            patch("prompture.dataset.evol.extract_with_model", _content_keyed_extract),
+            patch("prompture.dataset.seed.extract_with_model", _content_keyed_extract),
+        ):
+            all_base = example_personas_and_filters(model)
+            evolved = example_evol_instruct(model, all_base)
+            _ = example_self_instruct(model, all_base + evolved)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/deep_research_example.py
+++ b/examples/deep_research_example.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Deep-research example — wiring citations + session memory + checkpoints + KG.
+
+A small Perplexity-style flow:
+
+1. Pretend a retriever found three sources about a topic.
+2. Build a citation-instructed prompt with CitationTracker.
+3. Ask the LLM (one call) for a cited answer.
+4. Parse the citations back into typed records.
+5. Stash a user preference in SessionMemory so the next session is
+   primed.
+6. Save a Checkpoint so the run survives a process restart.
+7. Add the cited entities to a KnowledgeGraph.
+
+Usage:
+    python examples/deep_research_example.py
+
+Requires:
+    - A valid API key for the configured MODEL (defaults to
+      openai/gpt-4o-mini).  Swap to an Ollama / local model to run free.
+"""
+
+from __future__ import annotations
+
+from prompture import (
+    Checkpoint,
+    CheckpointManager,
+    CitationTracker,
+    Conversation,
+    InMemoryCheckpointStore,
+    InMemorySessionStore,
+    KnowledgeGraph,
+    SessionMemory,
+    Source,
+)
+
+MODEL = "openai/gpt-4o-mini"
+USER_ID = "alice"
+SESSION_ID = "trip-research-2026-05"
+RUN_ID = "paris-deep-dive"
+
+
+# ── Step 1: pretend the retriever found these (in a real flow this is RAG) ──
+
+sources = [
+    Source(
+        id="1",
+        title="Wikipedia: Paris",
+        text=(
+            "Paris is the capital and most populous city of France, "
+            "with a population of 2,102,650 within its administrative limits."
+        ),
+    ),
+    Source(
+        id="2",
+        title="Visit Paris — Eiffel Tower",
+        text=(
+            "The Eiffel Tower was completed in 1889 for the World's Fair and "
+            "stands 330 metres tall on the Champ de Mars."
+        ),
+    ),
+    Source(
+        id="3",
+        title="Louvre Museum facts",
+        text=(
+            "The Louvre is the world's most-visited art museum. It was "
+            "originally a fortress built by King Philip II in the late 12th century."
+        ),
+    ),
+]
+
+
+# ── Step 2: build the citation-instructed prompt ────────────────────────────
+
+tracker = CitationTracker(sources=sources, question="What should I see on a 2-day Paris trip?")
+prompt = tracker.build_prompt()
+
+print("=" * 60)
+print("Step 1: Sending citation-instructed prompt to LLM")
+print("=" * 60)
+print(prompt[:400] + "…\n")
+
+
+# ── Step 3: ask the LLM once ────────────────────────────────────────────────
+
+conv = Conversation(model_name=MODEL)
+response = conv.ask(prompt)
+
+
+# ── Step 4: parse the citations ─────────────────────────────────────────────
+
+answer = tracker.parse_response(response, usage=conv.usage)
+
+print("=" * 60)
+print("Step 2: Parsed cited answer")
+print("=" * 60)
+print(f"Grounded: {answer.is_grounded} | Coverage: {answer.coverage:.0%}")
+print(f"Cited sources: {sorted(answer.cited_source_ids)}")
+print(f"\n{answer.clean_answer}\n")
+for c in answer.citations:
+    print(f"  • {c.text!r:60s} → {c.source_ids}")
+
+
+# ── Step 5: remember a user preference for next session ────────────────────
+
+memory = SessionMemory(
+    user_id=USER_ID,
+    session_id=SESSION_ID,
+    store=InMemorySessionStore(),
+)
+memory.remember("Prefers museum-heavy itineraries over nightlife.", kind="preference", importance=0.8)
+memory.remember(f"Currently researching: {tracker._question}", session_scoped=True)
+
+print("=" * 60)
+print("Step 3: Session memory")
+print("=" * 60)
+print(memory.render_for_prompt("paris"))
+
+
+# ── Step 6: checkpoint so we can resume ────────────────────────────────────
+
+store = InMemoryCheckpointStore()
+mgr = CheckpointManager(store, run_id=RUN_ID, agent_name="research-agent")
+mgr.save_conversation(
+    conv,
+    iteration=1,
+    prompt=tracker._question or "",
+    metadata={
+        "cited_sources": sorted(answer.cited_source_ids),
+        "coverage": answer.coverage,
+    },
+)
+mgr.mark("completed")
+
+print("=" * 60)
+print("Step 4: Checkpoint saved")
+print("=" * 60)
+cp: Checkpoint | None = mgr.load()
+assert cp is not None
+print(f"run_id        : {cp.run_id}")
+print(f"status        : {cp.status}")
+print(f"iteration     : {cp.iteration}")
+print(f"messages saved: {len(cp.messages)}")
+print(f"coverage meta : {cp.metadata.get('coverage')}")
+
+
+# ── Step 7: drop the cited entities into a knowledge graph ─────────────────
+
+kg = KnowledgeGraph()
+kg.upsert_entity("Paris", type="location")
+kg.upsert_entity("Eiffel Tower", type="landmark")
+kg.upsert_entity("Louvre", type="museum", aliases=("Louvre Museum",))
+
+kg.add_relation("Eiffel Tower", "located_in", "Paris")
+kg.add_relation("Louvre", "located_in", "Paris")
+
+# Mark which entities came up in cited claims.
+for cit in answer.citations:
+    for ent_name in ("Paris", "Eiffel Tower", "Louvre"):
+        if ent_name.lower() in cit.text.lower():
+            kg.mention(ent_name, ent_name, source=f"source:{cit.first_source()}")
+
+print()
+print("=" * 60)
+print("Step 5: Knowledge graph")
+print("=" * 60)
+paris = kg.resolve("Paris")
+assert paris is not None
+print(f"Neighbors of {paris.name}:")
+for rel in kg.neighbors(paris, direction="in"):
+    other = kg.get(rel.subject_id)
+    other_name = other.name if other is not None else rel.subject_id
+    print(f"  ← {other_name} {rel.predicate} → {paris.name}")
+
+for ent_name in ("Paris", "Eiffel Tower", "Louvre"):
+    mentions = kg.mentions(ent_name)
+    print(f"{ent_name:14s}: {len(mentions)} mention(s)")

--- a/examples/ecommerce_product_example.py
+++ b/examples/ecommerce_product_example.py
@@ -5,7 +5,6 @@ This example shows how to use Prompture for extracting product information from 
 It demonstrates extraction of product features, pricing, brand information, and categorization.
 """
 
-from typing import Optional
 
 from pydantic import BaseModel
 
@@ -70,11 +69,11 @@ register_field(
 
 class Product(BaseModel):
     name: str = field_from_registry("name")
-    brand: Optional[str] = field_from_registry("brand")
-    price: Optional[float] = field_from_registry("price")
-    description: Optional[str] = field_from_registry("description")
-    features: Optional[list[str]] = field_from_registry("product_features")
-    category: Optional[str] = field_from_registry("category")
+    brand: str | None = field_from_registry("brand")
+    price: float | None = field_from_registry("price")
+    description: str | None = field_from_registry("description")
+    features: list[str] | None = field_from_registry("product_features")
+    category: str | None = field_from_registry("category")
 
 
 # Sample product description

--- a/examples/eval_example.py
+++ b/examples/eval_example.py
@@ -1,0 +1,240 @@
+"""LLM-as-judge evaluation examples.
+
+Runs all four evaluators in :mod:`prompture.eval`:
+
+1. :class:`LLMJudge` — rubric scoring on a 1..5 scale
+2. :class:`PairwiseJudge` — A/B preference with position-bias correction
+3. :class:`SelfConsistencyEvaluator` — N-sample majority vote
+4. :class:`FaithfulnessEvaluator` — claim-by-claim RAG grounding
+
+By default the example uses Ollama (so it runs without any cloud API
+key). Set ``OLLAMA_MODEL`` to control which model evaluates. When
+Ollama isn't reachable the example falls back to a scripted driver
+that simulates plausible judge responses — the demo still shows the
+API end-to-end.
+
+Run it
+~~~~~~
+
+::
+
+    ollama pull llama3.1:8b
+    OLLAMA_MODEL=llama3.1:8b python examples/eval_example.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from prompture.eval import (
+    FaithfulnessEvaluator,
+    LLMJudge,
+    PairwiseJudge,
+    SelfConsistencyEvaluator,
+)
+
+# =============================================================================
+# Driver selection
+# =============================================================================
+
+
+class _ScriptedJudgeDriver:
+    """Fallback driver that returns plausible judge responses keyed by content.
+
+    The match logic is intentionally crude — the goal is to make the
+    example illustrative without an LLM, not to be a real eval.
+    """
+
+    model = "scripted/judge"
+    model_name = "scripted/judge"
+
+    def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        text = self._respond(prompt)
+        return {
+            "text": text,
+            "meta": {"prompt_tokens": 50, "completion_tokens": 20, "total_tokens": 70, "cost": 0.0},
+        }
+
+    @staticmethod
+    def _respond(prompt: str) -> str:
+        p = prompt.lower()
+
+        # FaithfulnessEvaluator decomposition step ----------------------
+        if "atomic claims" in p:
+            if "eiffel" in p:
+                return '["Paris is the capital of France.", "The Eiffel Tower is in Paris."]'
+            if "wright" in p:
+                return (
+                    '["The Wright brothers built the first powered airplane.", '
+                    '"They worked as bicycle mechanics in Dayton, Ohio.", '
+                    '"Their first flight was in 1903."]'
+                )
+            return '["claim 1", "claim 2"]'
+
+        # FaithfulnessEvaluator verification step -----------------------
+        if "supported   (the evidence" in p or "contradicted   (the evidence" in p:
+            # crude content match against evidence section
+            if "eiffel" in p:
+                return "SUPPORTED"
+            if "wright" in p:
+                # Mix verdicts so the example shows partial grounding.
+                if "1903" in p[: p.find("claim:")]:
+                    return "SUPPORTED"
+                if "bicycle" in p:
+                    return "SUPPORTED"
+                return "SILENT"
+            return "SUPPORTED"
+
+        # PairwiseJudge -------------------------------------------------
+        if "pick exactly one" in p and "response a:" in p and "response b:" in p:
+            # Crude: prefer the longer response.
+            a_start = p.find("response a:")
+            b_start = p.find("response b:")
+            tail_start = p.find("pick exactly one")
+            a_text = p[a_start:b_start]
+            b_text = p[b_start:tail_start]
+            choice = "A" if len(a_text) > len(b_text) else "B"
+            return f"CHOICE: {choice}\nREASON: Picked the more detailed answer."
+
+        # LLMJudge ------------------------------------------------------
+        if "impartial evaluator" in p:
+            # Always a 4 with a positive reasoning, per_criterion mixed.
+            return json.dumps(
+                {
+                    "score": 4,
+                    "per_criterion": {"factuality": 5, "clarity": 4, "brevity": 3},
+                    "reasoning": "Mostly factual and clear; slightly verbose.",
+                }
+            )
+
+        # SelfConsistencyEvaluator (raw QA prompt) ----------------------
+        if "17 * 23" in p or "17*23" in p:
+            return "391"
+
+        return "Acknowledged."
+
+
+def _pick_driver():
+    """Return Ollama if reachable, otherwise the scripted fallback."""
+    try:
+        from prompture.drivers.ollama_driver import OllamaDriver
+
+        driver = OllamaDriver(
+            endpoint=os.getenv("OLLAMA_ENDPOINT", "http://localhost:11434/api/generate"),
+            model=os.getenv("OLLAMA_MODEL", "llama3.1:8b"),
+        )
+        # Reachability probe.
+        driver.generate("ping", {"temperature": 0.0, "max_tokens": 4})
+        print(f"[LLM: ollama/{driver.model}]\n")
+        return driver
+    except Exception as e:
+        print(f"[LLM: scripted fallback — Ollama not reachable: {type(e).__name__}]\n")
+        return _ScriptedJudgeDriver()
+
+
+# =============================================================================
+# Examples
+# =============================================================================
+
+
+def example_llm_judge(driver) -> None:
+    print("=" * 70)
+    print("EXAMPLE 1: LLMJudge — rubric scoring")
+    print("=" * 70)
+    judge = LLMJudge(
+        driver=driver,
+        criteria=[
+            "factuality: claims must match the reference",
+            "clarity: clean prose, no jargon",
+            "brevity: short and to the point",
+        ],
+        scale=5,
+        pass_threshold=4,
+    )
+    result = judge.evaluate(
+        input_text="What is the capital of France?",
+        output="Paris is the capital of France. It is also France's largest city.",
+        reference="Paris",
+    )
+    print(f"  score:        {result.score}/5")
+    print(f"  passed (>=4): {result.passed}")
+    print(f"  per criterion: {result.per_criterion}")
+    print(f"  reasoning:    {result.reasoning}")
+    print()
+
+
+def example_pairwise(driver) -> None:
+    print("=" * 70)
+    print("EXAMPLE 2: PairwiseJudge — A/B with position-bias correction")
+    print("=" * 70)
+    judge = PairwiseJudge(driver=driver)
+    result = judge.compare(
+        input_text="Summarise quantum entanglement in one sentence.",
+        output_a="Two particles share a state.",
+        output_b=(
+            "Quantum entanglement is a physical phenomenon in which two or more particles "
+            "share a quantum state, so measuring one instantly determines properties of the "
+            "other regardless of distance."
+        ),
+    )
+    print(f"  winner:     {result.winner}")
+    print(f"  confidence: {result.confidence:.0%}")
+    print(f"  votes:      {result.votes}")
+    print()
+
+
+def example_self_consistency(driver) -> None:
+    print("=" * 70)
+    print("EXAMPLE 3: SelfConsistencyEvaluator — sample N, vote")
+    print("=" * 70)
+    evaluator = SelfConsistencyEvaluator(driver=driver, n_samples=5)
+    result = evaluator.evaluate("What is 17 * 23? Answer with just the number.")
+    print(f"  consensus:  {result.consensus}")
+    print(f"  agreement:  {result.agreement:.0%}")
+    print(f"  counts:     {result.counts}")
+    print()
+
+
+def example_faithfulness(driver) -> None:
+    print("=" * 70)
+    print("EXAMPLE 4: FaithfulnessEvaluator — claim-by-claim RAG grounding")
+    print("=" * 70)
+    evaluator = FaithfulnessEvaluator(driver=driver)
+    result = evaluator.evaluate(
+        answer=(
+            "The Wright brothers built the first powered airplane. They worked as "
+            "bicycle mechanics in Dayton, Ohio. Their first flight was in 1903."
+        ),
+        evidence=[
+            "Orville and Wilbur Wright, owners of a bicycle shop in Dayton, Ohio, "
+            "designed and flew the first heavier-than-air powered aircraft in 1903.",
+            "Their initial flight at Kitty Hawk lasted 12 seconds.",
+        ],
+    )
+    print(f"  score:        {result.score:.0%}")
+    print(f"  supported:    {len(result.supported)}")
+    print(f"  unsupported:  {len(result.unsupported)}")
+    print(f"  contradicted: {len(result.contradicted)}")
+    if result.unsupported:
+        print("  unsupported claims:")
+        for c in result.unsupported:
+            print(f"    - {c}")
+    print()
+
+
+def main() -> None:
+    driver = _pick_driver()
+    example_llm_judge(driver)
+    example_pairwise(driver)
+    example_self_consistency(driver)
+    example_faithfulness(driver)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/few_shot_extraction_example.py
+++ b/examples/few_shot_extraction_example.py
@@ -1,0 +1,214 @@
+"""Few-Shot Extraction Example
+
+Demonstrates :class:`prompture.extraction.few_shot.FewShotExampleStore`
+plumbed into :func:`prompture.extract_with_model` via the new
+``examples_store`` parameter.
+
+The example builds a small bank of curated ``(input, expected_output)``
+pairs that encode subtle extraction conventions the model would
+otherwise have to guess at — date formats, US state abbreviations,
+phone normalisation. We then run extraction with and without the
+example bank against a contrived test set and tally how many records
+the model gets right under each setting.
+
+Run it
+~~~~~~
+
+Set ``OLLAMA_ENDPOINT`` (default ``http://localhost:11434``) and pull a
+small instruction-tuned model::
+
+    ollama pull llama3.1:8b
+    OLLAMA_MODEL=llama3.1:8b python examples/few_shot_extraction_example.py
+
+For OpenAI/Claude instead, set the corresponding env var and edit
+``MODEL`` below. The example skips gracefully when no LLM is reachable.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Add parent directory to path for local development
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from pydantic import BaseModel, Field
+
+from prompture import extract_with_model
+from prompture.exceptions import ConfigurationError
+from prompture.extraction.few_shot import FewShotExampleStore
+
+# =============================================================================
+# Schema — narrow enough that the conventions in our examples actually matter
+# =============================================================================
+
+
+class ContactRecord(BaseModel):
+    """Address-book row with strict normalisation rules."""
+
+    full_name: str = Field(..., description="Full legal name in 'First Last' order")
+    state: str = Field(..., description="US state as 2-letter uppercase abbreviation")
+    phone_e164: str = Field(..., description="Phone number in E.164 format with + and country code")
+    join_date: str = Field(..., description="Date the contact joined, as YYYY-MM-DD")
+
+
+# =============================================================================
+# Few-shot bank — encodes the conventions a free-style LLM tends to violate
+# =============================================================================
+
+CURATED_EXAMPLES: list[tuple[str, dict[str, str]]] = [
+    (
+        "Robert Schwartz, lives in Texas, phone (512) 555-0177, joined March 4th 2021.",
+        {
+            "full_name": "Robert Schwartz",
+            "state": "TX",
+            "phone_e164": "+15125550177",
+            "join_date": "2021-03-04",
+        },
+    ),
+    (
+        "Aisha Khan from California, number 415.555.0123, started Jan 9, 2020.",
+        {
+            "full_name": "Aisha Khan",
+            "state": "CA",
+            "phone_e164": "+14155550123",
+            "join_date": "2020-01-09",
+        },
+    ),
+    (
+        "Yuki Tanaka — New York — cell 1-212-555-0144 — onboarded 12/15/2022.",
+        {
+            "full_name": "Yuki Tanaka",
+            "state": "NY",
+            "phone_e164": "+12125550144",
+            "join_date": "2022-12-15",
+        },
+    ),
+    (
+        "Diego Hernández (Florida) at +1 305 555 0190; came aboard 7-22-2019.",
+        {
+            "full_name": "Diego Hernández",
+            "state": "FL",
+            "phone_e164": "+13055550190",
+            "join_date": "2019-07-22",
+        },
+    ),
+]
+
+# Test set — same format / convention diversity, different people.
+TEST_CASES: list[tuple[str, dict[str, str]]] = [
+    (
+        "Maria Lopez out of Illinois, phone (773) 555-0111, joined April 5 2023.",
+        {
+            "full_name": "Maria Lopez",
+            "state": "IL",
+            "phone_e164": "+17735550111",
+            "join_date": "2023-04-05",
+        },
+    ),
+    (
+        "Liam O'Brien from Massachusetts, 617-555-0166, started 02/14/2020.",
+        {
+            "full_name": "Liam O'Brien",
+            "state": "MA",
+            "phone_e164": "+16175550166",
+            "join_date": "2020-02-14",
+        },
+    ),
+    (
+        "Priya Patel — Washington — 1.206.555.0188 — onboarded November 3rd 2021.",
+        {
+            "full_name": "Priya Patel",
+            "state": "WA",
+            "phone_e164": "+12065550188",
+            "join_date": "2021-11-03",
+        },
+    ),
+]
+
+
+# =============================================================================
+# Model — Ollama by default; can be swapped via env
+# =============================================================================
+
+MODEL = os.getenv("PROMPTURE_FEWSHOT_MODEL", "ollama/" + os.getenv("OLLAMA_MODEL", "llama3.1:8b"))
+
+
+def _try_extract(text: str, examples_store: FewShotExampleStore | None) -> ContactRecord | None:
+    try:
+        kwargs: dict = {"model_name": MODEL}
+        if examples_store is not None:
+            kwargs["examples_store"] = examples_store
+        result = extract_with_model(ContactRecord, text, **kwargs)
+        return result["model"]
+    except (ConfigurationError, ConnectionError) as e:
+        print(f"    [extraction failed: {type(e).__name__}: {str(e)[:120]}]")
+        return None
+    except Exception as e:
+        print(f"    [extraction failed: {type(e).__name__}: {str(e)[:120]}]")
+        return None
+
+
+def _score(pred: ContactRecord | None, gold: dict[str, str]) -> int:
+    if pred is None:
+        return 0
+    return sum(1 for k, v in gold.items() if getattr(pred, k, None) == v)
+
+
+def main() -> None:
+    print("=" * 70)
+    print(f"Few-Shot extraction comparison — model = {MODEL}")
+    print("=" * 70)
+
+    store = FewShotExampleStore()
+    store.add_many(CURATED_EXAMPLES)
+    print(f"Loaded {len(store)} curated examples into the few-shot store.\n")
+
+    field_count = len(TEST_CASES[0][1])
+    total = field_count * len(TEST_CASES)
+
+    without_correct = 0
+    with_correct = 0
+
+    for i, (text, gold) in enumerate(TEST_CASES, 1):
+        print(f"[case {i}] {text}")
+        print(f"  expected: {json.dumps(gold)}")
+
+        print("  -> without few-shot:")
+        pred_no = _try_extract(text, examples_store=None)
+        s_no = _score(pred_no, gold)
+        without_correct += s_no
+        if pred_no is not None:
+            print(f"    got: {pred_no.model_dump_json()}")
+            print(f"    fields correct: {s_no}/{field_count}")
+
+        print("  -> with few-shot:")
+        pred_fs = _try_extract(text, examples_store=store)
+        s_fs = _score(pred_fs, gold)
+        with_correct += s_fs
+        if pred_fs is not None:
+            print(f"    got: {pred_fs.model_dump_json()}")
+            print(f"    fields correct: {s_fs}/{field_count}")
+        print()
+
+    print("=" * 70)
+    print("Summary")
+    print("=" * 70)
+    print(f"  without few-shot: {without_correct}/{total} fields correct "
+          f"({without_correct / total:.0%})")
+    print(f"  with few-shot:    {with_correct}/{total} fields correct "
+          f"({with_correct / total:.0%})")
+    if with_correct > without_correct:
+        delta = with_correct - without_correct
+        print(f"  -> +{delta} fields correct from few-shot examples "
+              f"({delta / total:.0%} absolute improvement).")
+    elif with_correct == without_correct:
+        print("  -> no measurable improvement on this test set (model may already be solid).")
+    else:
+        print("  -> few-shot regressed accuracy - examples may be confusing this model.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/financial_document_example.py
+++ b/examples/financial_document_example.py
@@ -5,7 +5,6 @@ This example shows how to use Prompture for processing financial statements and 
 It demonstrates extraction of financial metrics such as revenue, profit margins, and fiscal data.
 """
 
-from typing import Optional
 
 from pydantic import BaseModel
 
@@ -59,10 +58,10 @@ register_field(
 
 class FinancialSummary(BaseModel):
     company: str = field_from_registry("company")
-    revenue: Optional[float] = field_from_registry("revenue")
-    profit_margin: Optional[float] = field_from_registry("profit_margin")
-    fiscal_year: Optional[int] = field_from_registry("year")
-    currency: Optional[str] = field_from_registry("currency")
+    revenue: float | None = field_from_registry("revenue")
+    profit_margin: float | None = field_from_registry("profit_margin")
+    fiscal_year: int | None = field_from_registry("year")
+    currency: str | None = field_from_registry("currency")
 
 
 # Sample financial report

--- a/examples/medical_record_example.py
+++ b/examples/medical_record_example.py
@@ -6,7 +6,6 @@ It demonstrates registration of medical-specific fields and structured extractio
 including conditions, medications, and allergies.
 """
 
-from typing import Optional
 
 from pydantic import BaseModel
 
@@ -61,10 +60,10 @@ register_field(
 class PatientRecord(BaseModel):
     name: str = field_from_registry("name")
     age: int = field_from_registry("age")
-    date_of_birth: Optional[str] = field_from_registry("date_of_birth")
-    medical_conditions: Optional[list[str]] = field_from_registry("medical_conditions")
-    medications: Optional[list[str]] = field_from_registry("medications")
-    allergies: Optional[list[str]] = field_from_registry("allergies")
+    date_of_birth: str | None = field_from_registry("date_of_birth")
+    medical_conditions: list[str] | None = field_from_registry("medical_conditions")
+    medications: list[str] | None = field_from_registry("medications")
+    allergies: list[str] | None = field_from_registry("allergies")
 
 
 # Sample medical record

--- a/examples/pydantic_model_example.py
+++ b/examples/pydantic_model_example.py
@@ -15,7 +15,6 @@ guide the LLM's extraction process.
 """
 
 from datetime import datetime
-from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -29,7 +28,7 @@ class Person(BaseModel):
     birth_date: datetime = Field(..., description="The person's date of birth in ISO format (YYYY-MM-DD).")
     profession: str = Field(..., description="Their main job or role.")
     is_employed: bool = Field(..., description="Whether the person is currently employed. True or False.")
-    salary: Optional[float] = Field(None, description="Annual salary in USD, if available. Numbers only e.g. 75000.50")
+    salary: float | None = Field(None, description="Annual salary in USD, if available. Numbers only e.g. 75000.50")
 
 
 # Define a Person model with default values to demonstrate default handling
@@ -40,7 +39,7 @@ class PersonWithDefaults(BaseModel):
     is_employed: bool = Field(
         False, description="Whether the person is currently employed. Default to False if unclear."
     )
-    salary: Optional[float] = Field(None, description="Annual salary in USD, if available. Numbers only e.g. 75000.50")
+    salary: float | None = Field(None, description="Annual salary in USD, if available. Numbers only e.g. 75000.50")
 
 
 # Example text to extract information from

--- a/examples/rag_advanced_retrievers_example.py
+++ b/examples/rag_advanced_retrievers_example.py
@@ -74,7 +74,7 @@ class _CharNGramVectorStore(VectorStore):
 
     def delete(self, ids: list[str]) -> None:
         kept_docs, kept_ids = [], []
-        for doc, did in zip(self._docs, self._ids):
+        for doc, did in zip(self._docs, self._ids, strict=False):
             if did not in ids:
                 kept_docs.append(doc)
                 kept_ids.append(did)
@@ -91,7 +91,7 @@ class _CharNGramVectorStore(VectorStore):
         if not q:
             return []
         scored: list[tuple[float, Document, str]] = []
-        for doc, did in zip(self._docs, self._ids):
+        for doc, did in zip(self._docs, self._ids, strict=False):
             d = self._trigrams(doc.content)
             inter = len(q & d)
             union = len(q | d)

--- a/examples/rag_advanced_retrievers_example.py
+++ b/examples/rag_advanced_retrievers_example.py
@@ -1,0 +1,281 @@
+"""RAG Advanced Retrievers Example
+
+Demonstrates the three query-side retriever wrappers introduced in Phase 3:
+
+* :class:`HyDERetriever` — LLM drafts a hypothetical answer; the base
+  retriever embeds + retrieves on that.
+* :class:`MultiQueryRetriever` — LLM generates N reformulations; results
+  from each are fused via Reciprocal Rank Fusion.
+* :class:`StepBackRetriever` — LLM produces a broader / more abstract
+  query; original and broader rankings are fused.
+
+The wrappers compose naturally — each one decorates any base retriever
+(including another wrapper) — so you can stack ``HyDE(MultiQuery(...))``
+or any other combination.
+
+Run it
+~~~~~~
+
+Set ``OLLAMA_ENDPOINT`` (default ``http://localhost:11434``) and pull a
+small instruction-tuned model like ``llama3.1:8b``. The example uses a
+tiny in-memory char-trigram store so no embedding model is required.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+# Add parent directory to path for local development
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from prompture.rag.documents import Document
+from prompture.rag.retrievers import (
+    HyDERetriever,
+    MultiQueryRetriever,
+    StepBackRetriever,
+    VectorStoreRetriever,
+)
+from prompture.rag.vectorstores.base import VectorSearchResult, VectorStore
+
+# =============================================================================
+# Minimal in-memory vector store (char-trigram Jaccard — no embeddings)
+# =============================================================================
+
+
+class _CharNGramVectorStore(VectorStore):
+    """Same toy store used in ``rag_with_rerank_example.py``."""
+
+    def __init__(self) -> None:
+        self._docs: list[Document] = []
+        self._ids: list[str] = []
+
+    @staticmethod
+    def _trigrams(text: str) -> set[str]:
+        s = f"  {text.lower()}  "
+        return {s[i : i + 3] for i in range(len(s) - 2)}
+
+    def add_documents(self, documents: list[Document], ids: list[str] | None = None) -> list[str]:
+        new_ids = list(ids) if ids is not None else [str(uuid.uuid4()) for _ in documents]
+        self._docs.extend(documents)
+        self._ids.extend(new_ids)
+        return new_ids
+
+    def add_vectors(
+        self,
+        vectors: list[list[float]],
+        documents: list[Document],
+        ids: list[str] | None = None,
+    ) -> list[str]:
+        return self.add_documents(documents, ids=ids)
+
+    def delete(self, ids: list[str]) -> None:
+        kept_docs, kept_ids = [], []
+        for doc, did in zip(self._docs, self._ids):
+            if did not in ids:
+                kept_docs.append(doc)
+                kept_ids.append(did)
+        self._docs, self._ids = kept_docs, kept_ids
+
+    def similarity_search(
+        self,
+        query: str,
+        k: int = 4,
+        filter: dict | None = None,
+        **kwargs: Any,
+    ) -> list[VectorSearchResult]:
+        q = self._trigrams(query)
+        if not q:
+            return []
+        scored: list[tuple[float, Document, str]] = []
+        for doc, did in zip(self._docs, self._ids):
+            d = self._trigrams(doc.content)
+            inter = len(q & d)
+            union = len(q | d)
+            score = inter / union if union else 0.0
+            scored.append((score, doc, did))
+        scored.sort(key=lambda t: t[0], reverse=True)
+        # Stamp id into metadata so the fusion helper can dedupe across variants.
+        out: list[VectorSearchResult] = []
+        for s, doc, did in scored[:k]:
+            doc_with_id = Document(content=doc.content, metadata={**doc.metadata, "id": did})
+            out.append(VectorSearchResult(document=doc_with_id, score=s))
+        return out
+
+    def similarity_search_by_vector(
+        self, vector: list[float], k: int = 4, **kwargs: Any
+    ) -> list[VectorSearchResult]:
+        raise NotImplementedError("char-trigram store has no embeddings")
+
+
+def _build_sample_store() -> _CharNGramVectorStore:
+    store = _CharNGramVectorStore()
+    store.add_documents(
+        [
+            Document(content="Paris is the capital of France and home to the Eiffel Tower."),
+            Document(content="Berlin is the capital of Germany; population around 3.6M."),
+            Document(content="The Louvre Museum sits along the Seine in central Paris."),
+            Document(content="France uses the euro and operates on Central European Time."),
+            Document(content="Rome is the capital of Italy and was the heart of the Roman Empire."),
+            Document(content="Madrid is Spain's capital and its largest city."),
+            Document(content="The European Union has 27 member states using a common market."),
+            Document(content="Lyon, Marseille, and Toulouse are major French cities (not the capital)."),
+        ]
+    )
+    return store
+
+
+# =============================================================================
+# LLM choice — tries Ollama if available, otherwise uses a scripted stub
+# =============================================================================
+
+
+class _ScriptedLLM:
+    """Fallback for when Ollama isn't reachable. Keeps the demo runnable."""
+
+    _SCRIPT = {
+        "HyDE": (
+            "Paris is the capital city of France. It is located on the river Seine "
+            "and is the country's largest city, with iconic landmarks including the "
+            "Eiffel Tower and the Louvre."
+        ),
+        "MultiQuery": (
+            "Which city serves as France's capital?\n"
+            "What is the name of the capital of France?\n"
+            "What city is the seat of the French government?"
+        ),
+        "StepBack": "What are the major capital cities of European countries?",
+    }
+
+    def __init__(self, kind: str) -> None:
+        self.kind = kind
+
+    def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "text": self._SCRIPT[self.kind],
+            "meta": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "cost": 0.0},
+        }
+
+
+def _ollama_or_scripted(kind: str):
+    """Return an Ollama driver if reachable, else a scripted fallback."""
+    try:
+        from prompture.drivers.ollama_driver import OllamaDriver
+
+        driver = OllamaDriver(
+            endpoint=os.getenv("OLLAMA_ENDPOINT", "http://localhost:11434/api/generate"),
+            model=os.getenv("OLLAMA_MODEL", "llama3.1:8b"),
+        )
+        # Probe with a tiny call to confirm reachability.
+        driver.generate("ping", {"temperature": 0.0, "max_tokens": 4})
+        print(f"  [LLM: ollama/{driver.model}]")
+        return driver
+    except Exception as e:
+        print(f"  [LLM: scripted fallback — Ollama not reachable: {type(e).__name__}]")
+        return _ScriptedLLM(kind)
+
+
+# =============================================================================
+# Pretty-print helpers
+# =============================================================================
+
+
+def _print_results(results: list[VectorSearchResult], label: str) -> None:
+    print(f"  {label}:")
+    if not results:
+        print("    (no results)")
+        return
+    for i, r in enumerate(results, 1):
+        snippet = r.document.content[:90].replace("\n", " ")
+        print(f"    [{i}] {snippet}")
+
+
+# =============================================================================
+# Examples
+# =============================================================================
+
+
+QUERY = "Where is the Eiffel Tower?"
+
+
+def example_baseline() -> None:
+    print("=" * 70)
+    print("EXAMPLE 0: Baseline (similarity retriever, no wrapping)")
+    print("=" * 70)
+    store = _build_sample_store()
+    base = VectorStoreRetriever(store, k=4)
+    _print_results(base.retrieve(QUERY, k=4), "baseline")
+    print()
+
+
+def example_hyde() -> None:
+    print("=" * 70)
+    print(f"EXAMPLE 1: HyDE — LLM drafts a hypothetical answer for {QUERY!r}")
+    print("=" * 70)
+    store = _build_sample_store()
+    base = VectorStoreRetriever(store, k=4)
+    llm = _ollama_or_scripted("HyDE")
+
+    ret = HyDERetriever(base=base, llm=llm)
+    _print_results(ret.retrieve(QUERY, k=4), "after HyDE")
+    print()
+
+
+def example_multi_query() -> None:
+    print("=" * 70)
+    print("EXAMPLE 2: MultiQuery — 3 LLM-generated reformulations, RRF-fused")
+    print("=" * 70)
+    store = _build_sample_store()
+    base = VectorStoreRetriever(store, k=4)
+    llm = _ollama_or_scripted("MultiQuery")
+
+    ret = MultiQueryRetriever(base=base, llm=llm, n_queries=3, fetch_k=6)
+    _print_results(ret.retrieve(QUERY, k=4), "after MultiQuery")
+    print()
+
+
+def example_step_back() -> None:
+    print("=" * 70)
+    print("EXAMPLE 3: StepBack — LLM produces a broader query, RRF-fused")
+    print("=" * 70)
+    store = _build_sample_store()
+    base = VectorStoreRetriever(store, k=4)
+    llm = _ollama_or_scripted("StepBack")
+
+    ret = StepBackRetriever(base=base, llm=llm, fetch_k=6)
+    _print_results(ret.retrieve(QUERY, k=4), "after StepBack")
+    print()
+
+
+def example_stacked() -> None:
+    """Wrappers compose — wrap a wrapper to combine techniques."""
+    print("=" * 70)
+    print("EXAMPLE 4: Stacked — HyDE(MultiQuery(base))")
+    print("=" * 70)
+    store = _build_sample_store()
+    base = VectorStoreRetriever(store, k=4)
+    llm = _ollama_or_scripted("MultiQuery")
+
+    # MultiQuery runs first (its base IS the similarity retriever); HyDE
+    # then wraps the whole thing so the *outer* call swaps the user query
+    # for a hypothetical answer before fan-out.
+    inner = MultiQueryRetriever(base=base, llm=llm, n_queries=2, fetch_k=4)
+    outer = HyDERetriever(base=inner, llm=_ollama_or_scripted("HyDE"))
+
+    _print_results(outer.retrieve(QUERY, k=4), "after HyDE(MultiQuery(...))")
+    print()
+
+
+def main() -> None:
+    example_baseline()
+    example_hyde()
+    example_multi_query()
+    example_step_back()
+    example_stacked()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rag_with_rerank_example.py
+++ b/examples/rag_with_rerank_example.py
@@ -68,7 +68,7 @@ class _CharNGramVectorStore(VectorStore):
     def delete(self, ids: list[str]) -> None:
         kept_docs = []
         kept_ids = []
-        for doc, did in zip(self._docs, self._ids):
+        for doc, did in zip(self._docs, self._ids, strict=False):
             if did not in ids:
                 kept_docs.append(doc)
                 kept_ids.append(did)

--- a/examples/rag_with_rerank_example.py
+++ b/examples/rag_with_rerank_example.py
@@ -1,0 +1,259 @@
+"""RAG with Reranker Example
+
+Demonstrates the ``reranker`` parameter on :class:`RAGPipeline` /
+:class:`AsyncRAGPipeline`. Pass a ``"provider/model"`` string and Prompture
+resolves it to the right rerank driver via
+:func:`prompture.drivers.rerank_registry.get_rerank_driver_for_model`.
+
+The reranker runs **after** the base retriever returns top-K candidates and
+re-orders them by relevance to the query. This typically adds 5–15 nDCG
+points over dense-only retrieval.
+
+Supported reranker providers (set the appropriate API key):
+
+* ``cohere/rerank-v3.5``   — ``COHERE_API_KEY``
+* ``voyage/rerank-2.5``    — ``VOYAGE_API_KEY``
+* ``jina/jina-reranker-v2-base-multilingual`` — ``JINA_API_KEY``
+* ``mxbai/mxbai-rerank-large-v1`` — ``MIXEDBREAD_API_KEY``
+
+This example uses a tiny in-memory vector store so it runs without any
+external infrastructure. Only the reranker call hits a real API (and the
+example skips that section if the corresponding key isn't set).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+# Add parent directory to path for local development
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from prompture.rag import RAGPipeline
+from prompture.rag.documents import Document
+from prompture.rag.retrievers import VectorStoreRetriever
+from prompture.rag.vectorstores.base import VectorSearchResult, VectorStore
+
+# =============================================================================
+# Minimal in-memory vector store — keeps the example self-contained
+# =============================================================================
+
+
+class _CharNGramVectorStore(VectorStore):
+    """Trivial in-memory store that scores docs by char-trigram Jaccard overlap.
+
+    Real applications use a proper embedding model + Chroma/FAISS/etc., but
+    this stand-in lets the example run with zero external dependencies and
+    keeps the focus on the reranker integration.
+    """
+
+    def __init__(self) -> None:
+        self._docs: list[Document] = []
+        self._ids: list[str] = []
+
+    @staticmethod
+    def _trigrams(text: str) -> set[str]:
+        s = f"  {text.lower()}  "
+        return {s[i : i + 3] for i in range(len(s) - 2)}
+
+    def add_documents(self, documents: list[Document], ids: list[str] | None = None) -> list[str]:
+        new_ids = list(ids) if ids is not None else [str(uuid.uuid4()) for _ in documents]
+        self._docs.extend(documents)
+        self._ids.extend(new_ids)
+        return new_ids
+
+    def delete(self, ids: list[str]) -> None:
+        kept_docs = []
+        kept_ids = []
+        for doc, did in zip(self._docs, self._ids):
+            if did not in ids:
+                kept_docs.append(doc)
+                kept_ids.append(did)
+        self._docs, self._ids = kept_docs, kept_ids
+
+    def similarity_search(
+        self,
+        query: str,
+        k: int = 4,
+        filter: dict | None = None,
+        **kwargs: Any,
+    ) -> list[VectorSearchResult]:
+        q = self._trigrams(query)
+        if not q:
+            return []
+        scored: list[tuple[float, Document]] = []
+        for doc in self._docs:
+            d = self._trigrams(doc.content)
+            inter = len(q & d)
+            union = len(q | d)
+            score = inter / union if union else 0.0
+            scored.append((score, doc))
+        scored.sort(key=lambda t: t[0], reverse=True)
+        results = [VectorSearchResult(document=doc, score=s) for s, doc in scored[: k]]
+        return results
+
+    # Base class requires these abstracts; trivial passthroughs.
+    def add_vectors(
+        self,
+        vectors: list[list[float]],
+        documents: list[Document],
+        ids: list[str] | None = None,
+    ) -> list[str]:
+        # No embeddings here; just delegate to add_documents (vectors ignored).
+        return self.add_documents(documents, ids=ids)
+
+    def similarity_search_by_vector(self, vector: list[float], k: int = 4, **kwargs: Any) -> list[VectorSearchResult]:
+        raise NotImplementedError("char-trigram store has no embeddings")
+
+
+def _build_sample_store() -> _CharNGramVectorStore:
+    """Seed the store with a handful of facts where reranker order matters."""
+    store = _CharNGramVectorStore()
+    store.add_documents(
+        [
+            Document(content="Paris is the capital of France and home to the Eiffel Tower."),
+            Document(content="Berlin is the capital of Germany; its population is around 3.6 million."),
+            Document(content="The French Republic uses the euro and operates on Central European Time."),
+            Document(content="Rome is the capital of Italy and was once the center of the Roman Empire."),
+            Document(content="Madrid is Spain's capital and largest city."),
+            Document(content="Lyon, Marseille, and Toulouse are major French cities (not the capital)."),
+        ]
+    )
+    return store
+
+
+# =============================================================================
+# A fake LLM driver so the generation step doesn't need any API key
+# =============================================================================
+
+
+class _EchoLLM:
+    """Minimal LLM stub: just echoes the question back with the retrieved context."""
+
+    model = "fake/echo"
+    model_name = "fake/echo"
+
+    def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "text": f"(echo-llm) {prompt[:200]}{'...' if len(prompt) > 200 else ''}",
+            "meta": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "cost": 0.0},
+        }
+
+
+# =============================================================================
+# Examples
+# =============================================================================
+
+
+def example_without_reranker() -> None:
+    """Baseline: dense retrieval only, no reranker."""
+    print("=" * 70)
+    print("EXAMPLE 1: Baseline (no reranker)")
+    print("=" * 70)
+
+    store = _build_sample_store()
+    retriever = VectorStoreRetriever(store, k=4)
+    pipeline = RAGPipeline(retriever=retriever, llm=_EchoLLM())
+
+    answer = pipeline.query("What is the capital of France?", k=4)
+    print("Top retrieval results in original order:")
+    for i, r in enumerate(answer.retrieval_results, 1):
+        print(f"  [{i}] score={r.score:.3f}  {r.document.content}")
+    print()
+
+
+def example_with_reranker_string() -> None:
+    """Pass a 'provider/model' string and Prompture instantiates the driver."""
+    print("=" * 70)
+    print("EXAMPLE 2: With Cohere reranker (string form)")
+    print("=" * 70)
+
+    if not os.getenv("COHERE_API_KEY"):
+        print("Skipped: set COHERE_API_KEY to run this example.")
+        print("Once set, this example would call:")
+        print('    RAGPipeline(retriever=..., llm=..., reranker="cohere/rerank-v3.5")')
+        print()
+        return
+
+    store = _build_sample_store()
+    retriever = VectorStoreRetriever(store, k=6)
+
+    # NEW IN PHASE 2: pass a string, RAGPipeline resolves it for you.
+    pipeline = RAGPipeline(
+        retriever=retriever,
+        llm=_EchoLLM(),
+        reranker="cohere/rerank-v3.5",
+        top_n_after_rerank=3,
+    )
+
+    answer = pipeline.query("What is the capital of France?", k=6)
+    print("After reranker, kept top-3:")
+    for i, r in enumerate(answer.retrieval_results, 1):
+        print(f"  [{i}] {r.document.content}")
+    print()
+
+
+def example_with_pre_instantiated_driver() -> None:
+    """For when you need custom rerank-driver construction."""
+    print("=" * 70)
+    print("EXAMPLE 3: With a pre-instantiated rerank driver")
+    print("=" * 70)
+
+    if not os.getenv("COHERE_API_KEY"):
+        print("Skipped: set COHERE_API_KEY to run this example.")
+        print()
+        return
+
+    from prompture.drivers.rerank_registry import get_rerank_driver_for_model
+
+    # Hand-construct (e.g. if you need a custom API key, base_url, etc.)
+    reranker = get_rerank_driver_for_model("cohere/rerank-v3.5")
+
+    store = _build_sample_store()
+    retriever = VectorStoreRetriever(store, k=6)
+    pipeline = RAGPipeline(
+        retriever=retriever,
+        llm=_EchoLLM(),
+        reranker=reranker,
+        top_n_after_rerank=3,
+    )
+
+    answer = pipeline.query("Which European capital uses the euro?", k=6)
+    print("Reranked results:")
+    for i, r in enumerate(answer.retrieval_results, 1):
+        print(f"  [{i}] {r.document.content}")
+    print()
+
+
+def example_error_for_bad_string() -> None:
+    """Show what happens with a malformed reranker string."""
+    print("=" * 70)
+    print("EXAMPLE 4: Error path — malformed reranker string")
+    print("=" * 70)
+
+    store = _build_sample_store()
+    retriever = VectorStoreRetriever(store, k=4)
+
+    try:
+        RAGPipeline(
+            retriever=retriever,
+            llm=_EchoLLM(),
+            reranker="cohere",  # missing /model — invalid
+        )
+    except ValueError as e:
+        print(f"Got expected ValueError: {e}")
+    print()
+
+
+def main() -> None:
+    example_without_reranker()
+    example_with_reranker_string()
+    example_with_pre_instantiated_driver()
+    example_error_for_bad_string()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/resume_cv_example.py
+++ b/examples/resume_cv_example.py
@@ -1,4 +1,3 @@
-from typing import Optional
 
 from pydantic import BaseModel
 
@@ -29,11 +28,11 @@ register_field(
 
 class Resume(BaseModel):
     name: str = field_from_registry("name")
-    email: Optional[str] = field_from_registry("email")
-    phone: Optional[str] = field_from_registry("phone")
-    skills: Optional[list[str]] = field_from_registry("skills")
-    education: Optional[list[dict]] = field_from_registry("education_level")
-    work_experience: Optional[list[dict]] = field_from_registry("work_experience")
+    email: str | None = field_from_registry("email")
+    phone: str | None = field_from_registry("phone")
+    skills: list[str] | None = field_from_registry("skills")
+    education: list[dict] | None = field_from_registry("education_level")
+    work_experience: list[dict] | None = field_from_registry("work_experience")
 
 
 # Sample resume text

--- a/examples/social_media_example.py
+++ b/examples/social_media_example.py
@@ -5,7 +5,6 @@ This example shows how to use Prompture for extracting insights from social medi
 It demonstrates sentiment analysis, hashtag extraction, user mentions, and topic identification.
 """
 
-from typing import Optional
 
 from pydantic import BaseModel
 
@@ -71,9 +70,9 @@ register_field(
 class SocialPost(BaseModel):
     content: str = field_from_registry("content")
     sentiment: str = field_from_registry("sentiment")
-    hashtags: Optional[list[str]] = field_from_registry("hashtags")
-    mentions: Optional[list[str]] = field_from_registry("mentions")
-    topic: Optional[str] = field_from_registry("topic")
+    hashtags: list[str] | None = field_from_registry("hashtags")
+    mentions: list[str] | None = field_from_registry("mentions")
+    topic: str | None = field_from_registry("topic")
 
 
 # Sample social media post

--- a/examples/stepwise_vs_manual_comparison.py
+++ b/examples/stepwise_vs_manual_comparison.py
@@ -14,7 +14,6 @@ Both methods extract the same Person data and the comparison shows:
 
 from datetime import date
 from decimal import Decimal
-from typing import Optional
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -27,14 +26,14 @@ class Person(BaseModel):
 
     name: str = Field(..., description="Full name of the person")
     age: int = Field(..., ge=0, le=150, description="Age in years")
-    birth_date: Optional[date] = Field(None, description="Date of birth in YYYY-MM-DD format")
+    birth_date: date | None = Field(None, description="Date of birth in YYYY-MM-DD format")
     profession: str = Field(..., description="Current job or profession")
     is_employed: bool = Field(..., description="Whether the person is currently employed")
-    salary: Optional[Decimal] = Field(None, ge=0, description="Annual salary in USD")
-    email: Optional[str] = Field(None, description="Email address")
-    phone: Optional[str] = Field(None, description="Phone number")
-    city: Optional[str] = Field(None, description="City of residence")
-    years_experience: Optional[int] = Field(None, ge=0, description="Years of work experience")
+    salary: Decimal | None = Field(None, ge=0, description="Annual salary in USD")
+    email: str | None = Field(None, description="Email address")
+    phone: str | None = Field(None, description="Phone number")
+    city: str | None = Field(None, description="City of residence")
+    years_experience: int | None = Field(None, ge=0, description="Years of work experience")
 
     @field_validator("birth_date", mode="before")
     @classmethod
@@ -328,7 +327,7 @@ def print_comparison_table(results):
     print("COMPARISON SUMMARY")
     print("=" * 140)
 
-    models_tested = list(set(r["model_name"] for r in results))
+    models_tested = list({r["model_name"] for r in results})
     successful_results = [r for r in results if r["success"]]
 
     print("\nOverall Results:")

--- a/examples/streaming_extraction_example.py
+++ b/examples/streaming_extraction_example.py
@@ -1,0 +1,195 @@
+"""Streaming Extraction Example
+
+Demonstrates :func:`prompture.extraction.streaming.stream_extract` and
+:meth:`prompture.Conversation.ask_stream_model`: each yields a
+progressively-filled Pydantic model as the LLM streams its JSON
+response, so a UI can render fields the moment they arrive instead of
+blocking on the full payload.
+
+The example uses Ollama by default. Set ``OLLAMA_MODEL`` to a
+streaming-capable instruction model (default ``llama3.1:8b``). When
+the live LLM is unreachable, a scripted-driver fallback simulates the
+stream so the example still demonstrates the API.
+
+Run it
+~~~~~~
+
+::
+
+    ollama pull llama3.1:8b
+    OLLAMA_MODEL=llama3.1:8b python examples/streaming_extraction_example.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from pydantic import BaseModel, Field
+
+from prompture import Conversation
+from prompture.extraction.streaming import stream_extract
+
+# =============================================================================
+# Schema
+# =============================================================================
+
+
+class JobApplicant(BaseModel):
+    """A small applicant record with enough fields to make streaming visible."""
+
+    full_name: str = Field(..., description="Full legal name in 'First Last' order")
+    current_role: str = Field(..., description="Current job title")
+    years_experience: int = Field(..., description="Years of relevant work experience")
+    skills: list[str] = Field(default_factory=list, description="Notable technical skills")
+    location_city: str | None = Field(None, description="City the applicant is based in")
+
+
+SAMPLE_TEXT = (
+    "Alex Chen has been working in software for 9 years. Currently a senior "
+    "platform engineer at Stripe based in San Francisco. Strengths: Python, "
+    "Rust, distributed systems, observability, and Kubernetes."
+)
+
+
+# =============================================================================
+# Scripted-driver fallback (when Ollama isn't reachable)
+# =============================================================================
+
+
+class _ScriptedStreamingDriver:
+    """Simulates an LLM streaming a JSON object character-by-character.
+
+    Emits realistic-shaped chunks (not just one big string) so the
+    example shows progressive partial parsing in action even without
+    a real LLM.
+    """
+
+    supports_json_schema = True
+    model = "scripted/demo"
+    model_name = "scripted/demo"
+
+    _FULL_JSON = (
+        '{\n  "full_name": "Alex Chen",\n  "current_role": "Senior Platform Engineer",\n'
+        '  "years_experience": 9,\n  "skills": ["Python", "Rust", "Distributed Systems",'
+        ' "Observability", "Kubernetes"],\n  "location_city": "San Francisco"\n}'
+    )
+
+    def generate_messages_stream(
+        self, messages: list[dict[str, Any]], options: dict[str, Any]
+    ) -> Iterator[dict[str, Any]]:
+        # Stream in roughly 6-char chunks with a tiny sleep so the visual is realistic.
+        for i in range(0, len(self._FULL_JSON), 6):
+            piece = self._FULL_JSON[i : i + 6]
+            time.sleep(0.04)
+            yield {"type": "delta", "text": piece}
+        yield {"type": "done", "text": self._FULL_JSON}
+
+
+def _pick_driver():
+    """Return a real Ollama driver when reachable, otherwise the scripted fallback."""
+    try:
+        from prompture.drivers.ollama_driver import OllamaDriver
+
+        driver = OllamaDriver(
+            endpoint=os.getenv("OLLAMA_ENDPOINT", "http://localhost:11434/api/generate"),
+            model=os.getenv("OLLAMA_MODEL", "llama3.1:8b"),
+        )
+        # Quick reachability probe.
+        driver.generate("ping", {"temperature": 0.0, "max_tokens": 4})
+        print(f"[LLM: ollama/{driver.model}]\n")
+        return driver
+    except Exception as e:
+        print(f"[LLM: scripted fallback — Ollama not reachable: {type(e).__name__}]\n")
+        return _ScriptedStreamingDriver()
+
+
+# =============================================================================
+# Pretty-print a partial model live (one line, updates in place)
+# =============================================================================
+
+
+def _render_snapshot(model: BaseModel, prev_text: str = "") -> str:
+    """Print a partial-model snapshot, returning the text we rendered."""
+    fields_set = {}
+    for name in type(model).model_fields:
+        try:
+            val = getattr(model, name)
+        except AttributeError:
+            continue
+        # model_construct leaves missing fields unset rather than None.
+        if val is None and name in model.model_fields_set:
+            fields_set[name] = None
+        elif val is not None:
+            fields_set[name] = val
+    text = ", ".join(f"{k}={v!r}" for k, v in fields_set.items())
+    if text != prev_text:
+        print(f"    snapshot: {text}")
+    return text
+
+
+# =============================================================================
+# Examples
+# =============================================================================
+
+
+def example_stream_extract_function() -> None:
+    print("=" * 70)
+    print("EXAMPLE 1: stream_extract() — direct, driver-level API")
+    print("=" * 70)
+
+    driver = _pick_driver()
+    prompt = (
+        "Extract the applicant fields from the text below as JSON matching "
+        "the documented schema.\n\nTEXT:\n" + SAMPLE_TEXT
+    )
+
+    prev = ""
+    final: JobApplicant | None = None
+    for partial in stream_extract(driver, prompt, JobApplicant, options={"json_mode": True}):
+        prev = _render_snapshot(partial, prev)
+        final = partial
+
+    print()
+    if final is not None:
+        print(f"  FINAL: {final.model_dump_json(indent=2)}")
+    print()
+
+
+def example_conversation_ask_stream_model() -> None:
+    print("=" * 70)
+    print("EXAMPLE 2: Conversation.ask_stream_model() — higher-level wrapper")
+    print("=" * 70)
+
+    driver = _pick_driver()
+    conv = Conversation(driver=driver, system_prompt="You are a careful résumé parser.")
+
+    prev = ""
+    final: JobApplicant | None = None
+    for partial in conv.ask_stream_model(
+        "Extract the applicant record from this résumé snippet:\n" + SAMPLE_TEXT,
+        JobApplicant,
+    ):
+        prev = _render_snapshot(partial, prev)
+        final = partial
+
+    print()
+    if final is not None:
+        print(f"  FINAL: {final.model_dump_json(indent=2)}")
+    print()
+    print(f"  Conversation history size: {len(conv._messages)} messages")
+
+
+def main() -> None:
+    example_stream_extract_function()
+    example_conversation_ask_stream_model()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/swarm_example.py
+++ b/examples/swarm_example.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Swarm runtime example — populating a shared environment with reacting agents.
+
+Demonstrates:
+1. Building a population of Persona-driven Agents
+2. Wrapping them as SwarmAgents with custom roles and observation policies
+3. Seeding the environment with a news event
+4. Running a multi-tick swarm with the default broadcast scheduler
+5. Switching to RoundRobinScheduler and SampleScheduler
+6. Reading the per-agent timeline, event log, and memory
+7. Stopping early via stop_when
+
+Usage:
+    python examples/swarm_example.py
+
+Requires:
+    - A valid API key for the LLM provider used (OpenAI here).
+    - Or set MODEL to an Ollama / local model to run free.
+"""
+
+from __future__ import annotations
+
+from prompture import Agent, Persona
+from prompture.swarm import (
+    Environment,
+    InMemoryStore,
+    RoundRobinScheduler,
+    SampleScheduler,
+    Swarm,
+    SwarmAgent,
+    SwarmCallbacks,
+)
+
+MODEL = "openai/gpt-4o-mini"
+
+
+# ── Section 1: Build the population ──────────────────────────────────────
+
+journalist = Agent(
+    MODEL,
+    system_prompt=Persona(
+        name="journalist",
+        system_prompt=(
+            "You are a city-desk reporter. Answer in one short factual sentence "
+            "describing the angle you would investigate next."
+        ),
+    ),
+)
+
+contrarian = Agent(
+    MODEL,
+    system_prompt=Persona(
+        name="contrarian",
+        system_prompt=(
+            "You are a contrarian commentator. Answer in one short sentence "
+            "challenging the most recent claim."
+        ),
+    ),
+)
+
+resident = Agent(
+    MODEL,
+    system_prompt=Persona(
+        name="resident",
+        system_prompt=(
+            "You are a long-time city resident. Answer in one short sentence "
+            "expressing how the news affects your daily life."
+        ),
+    ),
+)
+
+memory = InMemoryStore()
+env = Environment()
+
+agents = [
+    SwarmAgent(journalist, name="journalist", role="city reporter"),
+    SwarmAgent(contrarian, name="contrarian", role="loud sceptic"),
+    SwarmAgent(resident, name="resident", role="long-time resident"),
+]
+
+
+# ── Section 2: Default swarm — every agent every tick ────────────────────
+
+print("=" * 60)
+print("Section 1: AllScheduler — every agent every tick")
+print("=" * 60)
+
+swarm = Swarm(
+    agents=agents,
+    env=env,
+    memory=memory,
+    max_ticks=3,
+    callbacks=SwarmCallbacks(
+        on_tick_start=lambda t, names: print(f"  → tick {t}: {names}"),
+    ),
+)
+result = swarm.run(seed="The city council just passed a 12% transit tax.")
+
+print(f"\nticks_run = {result.ticks_run}")
+print(f"events    = {len(result.events)}")
+print(f"cost      = ${result.aggregate_usage['total_cost']:.4f}")
+print()
+print("Timeline:")
+for step in result.timeline:
+    snippet = (step.output or "").replace("\n", " ")[:80]
+    print(f"  [t{step.tick}] {step.agent_id:<11} → {snippet}")
+
+
+# ── Section 3: RoundRobin — one agent per tick ───────────────────────────
+
+print()
+print("=" * 60)
+print("Section 2: RoundRobinScheduler — one voice at a time")
+print("=" * 60)
+
+rr_swarm = Swarm(
+    agents=agents,
+    env=Environment(),
+    memory=InMemoryStore(),
+    scheduler=RoundRobinScheduler(),
+    max_ticks=4,
+)
+rr_swarm.environment.seed("Storm warning: heavy rain expected tomorrow.")
+rr_result = rr_swarm.run()
+for step in rr_result.timeline:
+    print(f"  [t{step.tick}] {step.agent_id}")
+
+
+# ── Section 4: Sampling — gossip-style stochastic activation ─────────────
+
+print()
+print("=" * 60)
+print("Section 3: SampleScheduler — random k per tick")
+print("=" * 60)
+
+import random
+
+sample_swarm = Swarm(
+    agents=agents,
+    env=Environment(),
+    scheduler=SampleScheduler(k=2, rng=random.Random(7)),
+    max_ticks=3,
+)
+sample_swarm.environment.seed("Tech startup announces hiring spree.")
+sample_result = sample_swarm.run()
+for step in sample_result.timeline:
+    snippet = (step.output or "").replace("\n", " ")[:80]
+    print(f"  [t{step.tick}] {step.agent_id:<11} → {snippet}")
+
+
+# ── Section 5: stop_when — end the run on a custom condition ─────────────
+
+print()
+print("=" * 60)
+print("Section 4: stop_when — bail when consensus emerges")
+print("=" * 60)
+
+
+def consensus_reached(env, tick) -> bool:
+    """Stop once the contrarian has echoed a key term twice."""
+    contrarian_says = [
+        e.content.lower()
+        for e in env.events
+        if e.agent_id == "contrarian"
+    ]
+    return sum("agree" in c for c in contrarian_says) >= 2
+
+
+early_swarm = Swarm(
+    agents=agents,
+    env=Environment(),
+    max_ticks=10,
+    stop_when=consensus_reached,
+)
+early_swarm.environment.seed("Mayor proposes a city-wide bike network.")
+early_result = early_swarm.run()
+print(f"stopped_reason: {early_result.stopped_reason}")
+print(f"ticks_run     : {early_result.ticks_run}")

--- a/examples/text_analysis_example.py
+++ b/examples/text_analysis_example.py
@@ -6,7 +6,6 @@ sentiment using enum fields. It shows how enum fields restrict LLM output to spe
 predefined values (positive, negative, neutral) for sentiment analysis.
 """
 
-from typing import Optional
 
 from pydantic import BaseModel
 
@@ -16,7 +15,7 @@ from prompture import extract_with_model, field_from_registry, get_field_definit
 # Define the Pydantic model for text analysis using the sentiment enum field
 class TextAnalysis(BaseModel):
     sentiment: str = field_from_registry("sentiment")
-    topic: Optional[str] = field_from_registry("topic")
+    topic: str | None = field_from_registry("topic")
 
 
 # Sample texts to analyze

--- a/examples/text_analysis_example_v2.py
+++ b/examples/text_analysis_example_v2.py
@@ -6,7 +6,6 @@ and topic categories using enum fields. Enum fields ensure that LLM outputs
 stay within predefined valid options, improving reliability and consistency.
 """
 
-from typing import Optional
 
 from pydantic import BaseModel
 
@@ -16,7 +15,7 @@ from prompture import extract_with_model, field_from_registry, get_field_definit
 # Define the Pydantic model for text classification using enum fields
 class TextClassification(BaseModel):
     tone: str = field_from_registry("tone")  # e.g. ["formal", "informal", "optimistic", "pessimistic"]
-    topic: Optional[str] = field_from_registry("topic")  # General subject/topic of the text
+    topic: str | None = field_from_registry("topic")  # General subject/topic of the text
 
 
 # Example texts to classify

--- a/examples/token_comparison_utility.py
+++ b/examples/token_comparison_utility.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 # Add project root to path
 EXAMPLES_DIR = Path(__file__).resolve().parent
@@ -35,7 +35,7 @@ def estimate_token_count(text: str, chars_per_token: int = 4) -> int:
 
 
 def compare_formats(
-    data: Union[list[dict[str, Any]], dict[str, Any]], data_key: str | None = None, chars_per_token: int = 4
+    data: list[dict[str, Any]] | dict[str, Any], data_key: str | None = None, chars_per_token: int = 4
 ) -> dict[str, Any]:
     """Compare JSON vs TOON format for token efficiency.
 

--- a/prompture/__init__.py
+++ b/prompture/__init__.py
@@ -9,6 +9,7 @@ try:
 except ImportError:  # tukuy not installed
     TukuyLLMBackend = None  # type: ignore[assignment,misc]
     create_tukuy_backend = None  # type: ignore[assignment]
+from . import eval as eval
 from . import plugins, rag
 from .cli import *
 from .dataset import (
@@ -22,6 +23,17 @@ from .dataset import (
     to_sharegpt,
 )
 from .drivers import *
+from .eval import (
+    EvalError,
+    FaithfulnessEvaluator,
+    FaithfulnessResult,
+    JudgeResult,
+    LLMJudge,
+    PairwiseJudge,
+    PairwiseResult,
+    SelfConsistencyEvaluator,
+    SelfConsistencyResult,
+)
 from .exceptions import (
     BudgetExceededError,
     ConfigurationError,

--- a/prompture/__init__.py
+++ b/prompture/__init__.py
@@ -69,6 +69,45 @@ from .security import (
     is_prompt_injection,
     redact_pii,
 )
+from .checkpoints import (
+    Checkpoint,
+    CheckpointManager,
+    CheckpointStore,
+    FileCheckpointStore,
+    InMemoryCheckpointStore,
+    RunStatus,
+    SQLiteCheckpointStore,
+    restore_conversation,
+    snapshot_conversation,
+)
+from .citations import (
+    CITATION_INSTRUCTION,
+    Citation,
+    CitationTracker,
+    CitedAnswer,
+    Source,
+    extract_citations,
+)
+from .kg import (
+    Entity,
+    EntityStore,
+    InMemoryEntityStore,
+    KnowledgeGraph,
+    Mention,
+    Relation,
+    SQLiteEntityStore,
+    extract_entities,
+    extract_relations,
+)
+from .session_memory import (
+    InMemorySessionStore,
+    MemoryFact,
+    MemoryKind,
+    SessionMemory,
+    SessionMemoryStore,
+    SQLiteSessionStore,
+    Summarizer,
+)
 from .swarm import (
     AllScheduler,
     CallableScheduler,

--- a/prompture/__init__.py
+++ b/prompture/__init__.py
@@ -50,25 +50,6 @@ from .integrations import *
 from .media import *
 from .persistence import *
 from .pipeline import *
-from .swarm import (
-    AllScheduler,
-    CallableScheduler,
-    Environment,
-    Event,
-    EventKind,
-    InMemoryStore,
-    Memory,
-    MemoryStore,
-    PriorityScheduler,
-    RoundRobinScheduler,
-    SampleScheduler,
-    Scheduler,
-    Swarm,
-    SwarmAgent,
-    SwarmCallbacks,
-    SwarmResult,
-    SwarmStep,
-)
 from .refusal import (
     RefusalCategory,
     RefusalDetector,
@@ -87,6 +68,25 @@ from .security import (
     RedactionResult,
     is_prompt_injection,
     redact_pii,
+)
+from .swarm import (
+    AllScheduler,
+    CallableScheduler,
+    Environment,
+    Event,
+    EventKind,
+    InMemoryStore,
+    Memory,
+    MemoryStore,
+    PriorityScheduler,
+    RoundRobinScheduler,
+    SampleScheduler,
+    Scheduler,
+    Swarm,
+    SwarmAgent,
+    SwarmCallbacks,
+    SwarmResult,
+    SwarmStep,
 )
 from .tools import (
     PythonSandboxTool,

--- a/prompture/__init__.py
+++ b/prompture/__init__.py
@@ -11,6 +11,25 @@ except ImportError:  # tukuy not installed
     create_tukuy_backend = None  # type: ignore[assignment]
 from . import eval as eval
 from . import plugins, rag
+from .checkpoints import (
+    Checkpoint,
+    CheckpointManager,
+    CheckpointStore,
+    FileCheckpointStore,
+    InMemoryCheckpointStore,
+    RunStatus,
+    SQLiteCheckpointStore,
+    restore_conversation,
+    snapshot_conversation,
+)
+from .citations import (
+    CITATION_INSTRUCTION,
+    Citation,
+    CitationTracker,
+    CitedAnswer,
+    Source,
+    extract_citations,
+)
 from .cli import *
 from .dataset import (
     ChatTurn,
@@ -47,6 +66,17 @@ from .groups import *
 from .infra import *
 from .ingestion import *
 from .integrations import *
+from .kg import (
+    Entity,
+    EntityStore,
+    InMemoryEntityStore,
+    KnowledgeGraph,
+    Mention,
+    Relation,
+    SQLiteEntityStore,
+    extract_entities,
+    extract_relations,
+)
 from .media import *
 from .persistence import *
 from .pipeline import *
@@ -68,36 +98,6 @@ from .security import (
     RedactionResult,
     is_prompt_injection,
     redact_pii,
-)
-from .checkpoints import (
-    Checkpoint,
-    CheckpointManager,
-    CheckpointStore,
-    FileCheckpointStore,
-    InMemoryCheckpointStore,
-    RunStatus,
-    SQLiteCheckpointStore,
-    restore_conversation,
-    snapshot_conversation,
-)
-from .citations import (
-    CITATION_INSTRUCTION,
-    Citation,
-    CitationTracker,
-    CitedAnswer,
-    Source,
-    extract_citations,
-)
-from .kg import (
-    Entity,
-    EntityStore,
-    InMemoryEntityStore,
-    KnowledgeGraph,
-    Mention,
-    Relation,
-    SQLiteEntityStore,
-    extract_entities,
-    extract_relations,
 )
 from .session_memory import (
     InMemorySessionStore,

--- a/prompture/__init__.py
+++ b/prompture/__init__.py
@@ -50,6 +50,25 @@ from .integrations import *
 from .media import *
 from .persistence import *
 from .pipeline import *
+from .swarm import (
+    AllScheduler,
+    CallableScheduler,
+    Environment,
+    Event,
+    EventKind,
+    InMemoryStore,
+    Memory,
+    MemoryStore,
+    PriorityScheduler,
+    RoundRobinScheduler,
+    SampleScheduler,
+    Scheduler,
+    Swarm,
+    SwarmAgent,
+    SwarmCallbacks,
+    SwarmResult,
+    SwarmStep,
+)
 from .refusal import (
     RefusalCategory,
     RefusalDetector,

--- a/prompture/_internal/__init__.py
+++ b/prompture/_internal/__init__.py
@@ -1,0 +1,5 @@
+"""Private internal helpers — NOT part of the public API.
+
+Anything in :mod:`prompture._internal` may change without a deprecation
+window. Do not import from here in downstream code.
+"""

--- a/prompture/_internal/json_encoder.py
+++ b/prompture/_internal/json_encoder.py
@@ -1,0 +1,118 @@
+"""Shared JSON encoder for Prompture.
+
+Replaces the ``json.dumps(..., default=str)`` pattern that was duplicated
+across ~15 call sites. The previous pattern coerced *everything* unknown
+to a string, including silently stringifying objects that should have
+serialized into structured forms (Pydantic models, sets, bytes…). This
+encoder handles the common Python types Prompture actually emits.
+
+Usage::
+
+    from prompture._internal.json_encoder import dumps, PromptureJSONEncoder
+
+    text = dumps(payload)                      # one-shot
+    text = json.dumps(payload, cls=PromptureJSONEncoder)  # in existing call
+
+Types handled (in order of precedence):
+
+* ``datetime`` / ``date`` / ``time``  → ISO 8601 string
+* ``timedelta``                       → total seconds (float)
+* ``Decimal``                         → str (preserves precision)
+* ``UUID``                            → str
+* ``Enum``                            → ``.value``
+* ``pathlib.PurePath``                → ``str(path)``
+* ``pydantic.BaseModel``              → ``model.model_dump(mode="json")``
+* ``set`` / ``frozenset``             → sorted list (deterministic output)
+* ``bytes`` / ``bytearray``           → ``ascii`` if printable, else ``base64``
+* anything with ``__dict__``          → its ``__dict__``
+* fallback                            → ``str(obj)`` (matches old behaviour)
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
+from enum import Enum
+from pathlib import PurePath
+from typing import Any
+from uuid import UUID
+
+
+def _encode_bytes(raw: bytes | bytearray) -> str:
+    """Round-trip bytes as ASCII when printable, otherwise base64."""
+    blob = bytes(raw)
+    try:
+        decoded = blob.decode("ascii")
+    except UnicodeDecodeError:
+        return base64.b64encode(blob).decode("ascii")
+    if decoded.isprintable():
+        return decoded
+    return base64.b64encode(blob).decode("ascii")
+
+
+class PromptureJSONEncoder(json.JSONEncoder):
+    """JSON encoder that knows how to serialise Prompture's common types.
+
+    Falls back to ``str(obj)`` for anything unrecognised so this is a
+    drop-in replacement for ``json.dumps(..., default=str)``.
+    """
+
+    def default(self, o: Any) -> Any:
+        # datetime/date/time first because datetime is a subclass of date
+        if isinstance(o, datetime):
+            return o.isoformat()
+        if isinstance(o, date):
+            return o.isoformat()
+        if isinstance(o, time):
+            return o.isoformat()
+        if isinstance(o, timedelta):
+            return o.total_seconds()
+        if isinstance(o, Decimal):
+            return str(o)
+        if isinstance(o, UUID):
+            return str(o)
+        if isinstance(o, Enum):
+            return o.value
+        if isinstance(o, PurePath):
+            return str(o)
+        if isinstance(o, (set, frozenset)):
+            try:
+                return sorted(o)
+            except TypeError:
+                # Items not comparable (e.g. raw Enum members). Fall back to a
+                # str()-keyed sort so output stays deterministic — important for
+                # cache-key stability.
+                return sorted(o, key=str)
+        if isinstance(o, (bytes, bytearray)):
+            return _encode_bytes(o)
+
+        # Pydantic BaseModel — imported lazily to avoid hard dep at import time.
+        try:
+            from pydantic import BaseModel
+        except ImportError:
+            BaseModel = None  # type: ignore[assignment]
+        if BaseModel is not None and isinstance(o, BaseModel):
+            return o.model_dump(mode="json")
+
+        if hasattr(o, "__dict__"):
+            return o.__dict__
+
+        # Final fallback: stringify. Matches the legacy ``default=str`` behaviour
+        # so this encoder cannot regress callers that depended on it.
+        return str(o)
+
+
+def dumps(obj: Any, **kwargs: Any) -> str:
+    """``json.dumps`` shortcut using :class:`PromptureJSONEncoder`.
+
+    Any keyword args are forwarded to :func:`json.dumps`. Setting ``cls``
+    explicitly will override the default encoder.
+    """
+    kwargs.setdefault("cls", PromptureJSONEncoder)
+    kwargs.setdefault("ensure_ascii", False)
+    return json.dumps(obj, **kwargs)
+
+
+__all__ = ["PromptureJSONEncoder", "dumps"]

--- a/prompture/agents/__init__.py
+++ b/prompture/agents/__init__.py
@@ -22,7 +22,7 @@ from .assistant import (
     register_assistant,
     unregister_assistant,
 )
-from .async_agent import AsyncAgent, AsyncAgentIterator, AsyncStreamedAgentResult
+from .async_agent import AsyncAgent, AsyncAgentIterator, AsyncLiveAgentResult, AsyncStreamedAgentResult
 from .async_conversation import AsyncConversation
 from .async_deep_agent import AsyncDeepAgent, create_async_deep_agent
 from .conversation import Conversation
@@ -107,6 +107,7 @@ __all__ = [
     "AsyncAgentIterator",
     "AsyncConversation",
     "AsyncDeepAgent",
+    "AsyncLiveAgentResult",
     "AsyncReviewLoop",
     "AsyncStreamedAgentResult",
     "Conversation",

--- a/prompture/agents/__init__.py
+++ b/prompture/agents/__init__.py
@@ -1,6 +1,18 @@
 """Agents, conversations, personas, skills, and tool schemas."""
 
-from .agent import Agent, AgentIterator, StreamedAgentResult
+from .agent import Agent, AgentIterator, LiveAgentResult, StreamedAgentResult
+from .live_events import (
+    AssistantTurnStart,
+    LiveEvent,
+    MessageStop,
+    TextDelta,
+    ThinkingDelta,
+    ToolInputDelta,
+    ToolResult,
+    ToolUseStart,
+    ToolUseStop,
+    TurnComplete,
+)
 from .assistant import (
     Assistant,
     AssistantResult,
@@ -90,6 +102,7 @@ __all__ = [
     "ApprovalRequired",
     "Assistant",
     "AssistantResult",
+    "AssistantTurnStart",
     "AsyncAgent",
     "AsyncAgentIterator",
     "AsyncConversation",
@@ -101,6 +114,9 @@ __all__ = [
     "DeepAgentResult",
     "DeepAgentState",
     "GuardrailError",
+    "LiveAgentResult",
+    "LiveEvent",
+    "MessageStop",
     "ModelRetry",
     "Persona",
     "ReviewLoopEvent",
@@ -115,6 +131,13 @@ __all__ = [
     "StreamEvent",
     "StreamEventType",
     "StreamedAgentResult",
+    "TextDelta",
+    "ThinkingDelta",
+    "ToolInputDelta",
+    "ToolResult",
+    "ToolUseStart",
+    "ToolUseStop",
+    "TurnComplete",
     "SubAgentCallRecord",
     "SubAgentSpec",
     "SummaryEvent",

--- a/prompture/agents/__init__.py
+++ b/prompture/agents/__init__.py
@@ -1,18 +1,6 @@
 """Agents, conversations, personas, skills, and tool schemas."""
 
 from .agent import Agent, AgentIterator, LiveAgentResult, StreamedAgentResult
-from .live_events import (
-    AssistantTurnStart,
-    LiveEvent,
-    MessageStop,
-    TextDelta,
-    ThinkingDelta,
-    ToolInputDelta,
-    ToolResult,
-    ToolUseStart,
-    ToolUseStop,
-    TurnComplete,
-)
 from .assistant import (
     Assistant,
     AssistantResult,
@@ -34,6 +22,18 @@ from .deep_state import (
     SubAgentSpec,
     SummaryEvent,
     Todo,
+)
+from .live_events import (
+    AssistantTurnStart,
+    LiveEvent,
+    MessageStop,
+    TextDelta,
+    ThinkingDelta,
+    ToolInputDelta,
+    ToolResult,
+    ToolUseStart,
+    ToolUseStop,
+    TurnComplete,
 )
 from .persona import (
     PERSONAS,
@@ -132,19 +132,19 @@ __all__ = [
     "StreamEvent",
     "StreamEventType",
     "StreamedAgentResult",
+    "SubAgentCallRecord",
+    "SubAgentSpec",
+    "SummaryEvent",
     "TextDelta",
     "ThinkingDelta",
+    "Todo",
+    "ToolDefinition",
     "ToolInputDelta",
+    "ToolRegistry",
     "ToolResult",
     "ToolUseStart",
     "ToolUseStop",
     "TurnComplete",
-    "SubAgentCallRecord",
-    "SubAgentSpec",
-    "SummaryEvent",
-    "Todo",
-    "ToolDefinition",
-    "ToolRegistry",
     "clear_assistant_registry",
     "clear_persona_registry",
     "clear_skill_registry",

--- a/prompture/agents/agent.py
+++ b/prompture/agents/agent.py
@@ -651,12 +651,31 @@ class Agent(Generic[DepsType]):
     # ------------------------------------------------------------------
 
     def _resolve_system_prompt(self, ctx: RunContext[Any] | None = None) -> str | None:
-        """Build the system prompt, appending output schema if needed."""
+        """Build the system prompt, appending output schema if needed.
+
+        Assembly order (stable across iterations to maximise prompt-cache hits
+        on Anthropic / OpenAI auto-caching providers):
+
+        1. **persona / system_prompt content** — first, so it forms the cache
+           prefix. The Persona ``render(model=..., iteration=...)`` call only
+           substitutes placeholders the template actually references; a persona
+           template that includes ``{{iteration}}`` will rotate the cache key
+           every turn, defeating caching. Avoid per-turn variables in personas
+           if you want cache reuse.
+        2. **JSON output schema instruction** — second. Stable across calls
+           because ``self._output_type`` is fixed at Agent construction.
+
+        Variable per-call content (user query, retrieved RAG context, etc.)
+        belongs in the message stream, not the system prompt.
+        """
         parts: list[str] = []
 
         if self._system_prompt is not None:
             if isinstance(self._system_prompt, Persona):
-                # Render Persona with RunContext variables if available
+                # Render Persona with RunContext variables if available.
+                # NOTE: ``iteration`` makes the system prompt change every turn
+                # if the persona template references it — that's intentional
+                # for advanced cases but it breaks prompt caching. See docstring.
                 render_kwargs: dict[str, Any] = {}
                 if ctx is not None:
                     render_kwargs["model"] = ctx.model

--- a/prompture/agents/agent.py
+++ b/prompture/agents/agent.py
@@ -1258,7 +1258,6 @@ class Agent(Generic[DepsType]):
             self._lifecycle = AgentState.errored
             raise
 
-
     # ------------------------------------------------------------------
     # run_live() — interleaved tool calling with streaming text deltas
     # ------------------------------------------------------------------
@@ -1350,9 +1349,7 @@ class Agent(Generic[DepsType]):
             )
 
             if self._output_type is not None:
-                output, output_text = self._parse_output(
-                    conv, response_text, steps, all_tool_calls, 0.0, session
-                )
+                output, output_text = self._parse_output(conv, response_text, steps, all_tool_calls, 0.0, session)
             else:
                 output = response_text
                 output_text = response_text

--- a/prompture/agents/agent.py
+++ b/prompture/agents/agent.py
@@ -1259,6 +1259,135 @@ class Agent(Generic[DepsType]):
             raise
 
 
+    # ------------------------------------------------------------------
+    # run_live() — interleaved tool calling with streaming text deltas
+    # ------------------------------------------------------------------
+
+    def run_live(self, prompt: str, *, deps: Any = None) -> LiveAgentResult:
+        """Execute the agent loop yielding interleaved
+        :class:`~prompture.agents.live_events.LiveEvent` objects.
+
+        Unlike :meth:`run_stream`, ``run_live`` forwards the driver's
+        native streaming event sequence (Anthropic SSE / OpenAI deltas)
+        so the caller sees text and reasoning deltas *between* tool calls
+        within a single LLM turn — the "Claude Code feel".
+
+        Drivers without ``supports_streaming_tool_use`` fall back to the
+        base-class synthetic event sequence (one bundle per turn).
+
+        Returns a :class:`LiveAgentResult` iterable. After iteration
+        completes, :attr:`LiveAgentResult.result` holds the final
+        :class:`AgentResult`.
+        """
+        gen = self._execute_live(prompt, deps)
+        return LiveAgentResult(gen)
+
+    def _execute_live(self, prompt: str, deps: Any) -> Generator[Any, None, AgentResult]:
+        """Generator that drives ask_live and yields :class:`LiveEvent`."""
+        from ..infra.tracker import get_tracker
+        from .live_events import TextDelta, ThinkingDelta
+
+        current_depth = _agent_depth.get()
+        if current_depth >= self._max_depth:
+            raise RecursionError(f"Agent recursion depth exceeded: {current_depth} >= {self._max_depth}")
+        token = _agent_depth.set(current_depth + 1)
+        self._lifecycle = AgentState.running
+        self._stop_requested = False
+        steps: list[AgentStep] = []
+
+        try:
+            session = UsageSession()
+            driver_callbacks = DriverCallbacks(
+                on_response=session.record,
+                on_error=session.record_error,
+            )
+            ctx = self._build_run_context(prompt, deps, session, [], 0)
+            effective_prompt = self._run_input_guardrails(ctx, prompt)
+            resolved_system_prompt = self._resolve_system_prompt(ctx)
+            wrapped_tools = self._wrap_tools_with_context(ctx, session)
+
+            conv = self._build_conversation(
+                system_prompt=resolved_system_prompt,
+                tools=wrapped_tools if wrapped_tools else None,
+                driver_callbacks=driver_callbacks,
+            )
+
+            if self._agent_callbacks.on_iteration:
+                self._agent_callbacks.on_iteration(0)
+
+            tracker = get_tracker()
+            agent_name = self.name or self.__class__.__name__
+
+            response_text_parts: list[str] = []
+            thinking_parts: list[str] = []
+
+            with tracker.agent(agent_name):
+                security_token = None
+                if self._security_context is not None:
+                    from tukuy.safety import set_security_context
+
+                    security_token = set_security_context(self._security_context)
+                try:
+                    for event in conv.ask_live(effective_prompt):
+                        if isinstance(event, TextDelta):
+                            response_text_parts.append(event.text)
+                        elif isinstance(event, ThinkingDelta):
+                            thinking_parts.append(event.text)
+                        yield event
+                finally:
+                    if security_token is not None:
+                        from tukuy.safety import reset_security_context
+
+                        reset_security_context(security_token)
+
+            response_text = "".join(response_text_parts)
+            all_tool_calls: list[dict[str, Any]] = []
+            self._extract_steps(
+                conv.messages,
+                steps,
+                all_tool_calls,
+                getattr(conv, "_full_tool_results", None),
+            )
+
+            if self._output_type is not None:
+                output, output_text = self._parse_output(
+                    conv, response_text, steps, all_tool_calls, 0.0, session
+                )
+            else:
+                output = response_text
+                output_text = response_text
+
+            result = AgentResult(
+                output=output,
+                output_text=output_text,
+                messages=conv.messages,
+                usage=conv.usage,
+                steps=steps,
+                all_tool_calls=all_tool_calls,
+                state=AgentState.idle,
+                run_usage=session.summary(),
+            )
+
+            if self._output_guardrails:
+                result = self._run_output_guardrails(ctx, result, conv, session, steps, all_tool_calls)
+
+            if self._agent_callbacks.on_step:
+                for step in steps:
+                    self._agent_callbacks.on_step(step)
+            if self._agent_callbacks.on_output:
+                self._agent_callbacks.on_output(result)
+            if self._agent_callbacks.on_message:
+                self._agent_callbacks.on_message(result.output_text)
+
+            self._lifecycle = AgentState.idle
+            return result
+        except Exception:
+            self._lifecycle = AgentState.errored
+            raise
+        finally:
+            _agent_depth.reset(token)
+
+
 # ------------------------------------------------------------------
 # AgentIterator
 # ------------------------------------------------------------------
@@ -1311,6 +1440,39 @@ class StreamedAgentResult:
         return self
 
     def __next__(self) -> StreamEvent:
+        try:
+            return next(self._gen)
+        except StopIteration as e:
+            self._result = e.value
+            raise
+
+    @property
+    def result(self) -> AgentResult | None:
+        """The final :class:`AgentResult`, available after iteration completes."""
+        return self._result
+
+
+# ------------------------------------------------------------------
+# LiveAgentResult
+# ------------------------------------------------------------------
+
+
+class LiveAgentResult:
+    """Wraps the :meth:`Agent.run_live` generator, capturing the final result.
+
+    Yields :class:`~prompture.agents.live_events.LiveEvent` objects during
+    iteration.  After iteration completes, :attr:`result` holds the final
+    :class:`AgentResult`.
+    """
+
+    def __init__(self, gen: Generator[Any, None, AgentResult]) -> None:
+        self._gen = gen
+        self._result: AgentResult | None = None
+
+    def __iter__(self) -> LiveAgentResult:
+        return self
+
+    def __next__(self) -> Any:
         try:
             return next(self._gen)
         except StopIteration as e:

--- a/prompture/agents/async_agent.py
+++ b/prompture/agents/async_agent.py
@@ -1103,7 +1103,7 @@ class AsyncAgent(Generic[DepsType]):
         deps: Any,
         *,
         images: list[Any] | None = None,
-    ) -> AsyncGenerator[AgentStep, None]:
+    ) -> AsyncGenerator[AgentStep]:
         """Async generator that executes the agent loop and yields each step."""
         self._lifecycle = AgentState.running
         self._stop_requested = False
@@ -1130,7 +1130,7 @@ class AsyncAgent(Generic[DepsType]):
         deps: Any,
         *,
         images: list[Any] | None = None,
-    ) -> AsyncGenerator[StreamEvent, None]:
+    ) -> AsyncGenerator[StreamEvent]:
         """Async generator that executes the agent loop and yields stream events.
 
         Raises:
@@ -1253,7 +1253,7 @@ class AsyncAgentIterator:
     After async iteration completes, :attr:`result` holds the :class:`AgentResult`.
     """
 
-    def __init__(self, gen: AsyncGenerator[AgentStep, None]) -> None:
+    def __init__(self, gen: AsyncGenerator[AgentStep]) -> None:
         self._gen = gen
         self._result: AgentResult | None = None
         self._agent: AsyncAgent[Any] | None = None
@@ -1290,7 +1290,7 @@ class AsyncStreamedAgentResult:
     :attr:`result` holds the :class:`AgentResult`.
     """
 
-    def __init__(self, gen: AsyncGenerator[StreamEvent, None]) -> None:
+    def __init__(self, gen: AsyncGenerator[StreamEvent]) -> None:
         self._gen = gen
         self._result: AgentResult | None = None
 

--- a/prompture/agents/async_agent.py
+++ b/prompture/agents/async_agent.py
@@ -1332,9 +1332,7 @@ class AsyncAgent(Generic[DepsType]):
             self._extract_steps(conv.messages, steps, all_tool_calls, full_results)
 
             if self._output_type is not None:
-                output, output_text = await self._parse_output(
-                    conv, response_text, steps, all_tool_calls, 0.0, session
-                )
+                output, output_text = await self._parse_output(conv, response_text, steps, all_tool_calls, 0.0, session)
             else:
                 output = response_text
                 output_text = response_text

--- a/prompture/agents/async_agent.py
+++ b/prompture/agents/async_agent.py
@@ -1241,6 +1241,134 @@ class AsyncAgent(Generic[DepsType]):
         finally:
             _agent_depth.reset(token)
 
+    # ------------------------------------------------------------------
+    # run_live() — interleaved tool calling with streaming text deltas
+    # ------------------------------------------------------------------
+
+    def run_live(
+        self,
+        prompt: str,
+        *,
+        deps: Any = None,
+        images: list[Any] | None = None,
+    ) -> AsyncLiveAgentResult:
+        """Execute the async agent loop yielding interleaved
+        :class:`~prompture.agents.live_events.LiveEvent` objects.
+
+        Async sibling of :meth:`Agent.run_live`. Returns an
+        :class:`AsyncLiveAgentResult` you ``async for`` over; after the
+        stream completes, ``.result`` holds the final
+        :class:`AgentResult`.
+        """
+        gen = self._execute_live(prompt, deps, images=images)
+        return AsyncLiveAgentResult(gen, agent=self)
+
+    async def _execute_live(
+        self,
+        prompt: str,
+        deps: Any,
+        *,
+        images: list[Any] | None = None,
+    ) -> AsyncGenerator[Any]:
+        """Async generator that drives ask_live and yields :class:`LiveEvent`."""
+        from ..infra.tracker import get_tracker
+        from .live_events import TextDelta, ThinkingDelta
+
+        current_depth = _agent_depth.get()
+        if current_depth >= self._max_depth:
+            raise RecursionError(f"Agent recursion depth exceeded: {current_depth} >= {self._max_depth}")
+        token = _agent_depth.set(current_depth + 1)
+        self._lifecycle = AgentState.running
+        self._stop_requested = False
+        steps: list[AgentStep] = []
+
+        try:
+            session = UsageSession()
+            driver_callbacks = DriverCallbacks(
+                on_response=session.record,
+                on_error=session.record_error,
+            )
+            ctx = self._build_run_context(prompt, deps, session, [], 0)
+            effective_prompt = self._run_input_guardrails(ctx, prompt)
+            resolved_system_prompt = self._resolve_system_prompt(ctx)
+            wrapped_tools = self._wrap_tools_with_context(ctx, session)
+
+            conv = self._build_conversation(
+                system_prompt=resolved_system_prompt,
+                tools=wrapped_tools if wrapped_tools else None,
+                driver_callbacks=driver_callbacks,
+            )
+
+            if self._agent_callbacks.on_iteration:
+                await self._invoke_callback(self._agent_callbacks.on_iteration, 0)
+
+            tracker = get_tracker()
+            agent_name = self.name or self.__class__.__name__
+
+            response_text_parts: list[str] = []
+
+            with tracker.agent(agent_name):
+                security_token = None
+                if self._security_context is not None:
+                    from tukuy.safety import set_security_context
+
+                    security_token = set_security_context(self._security_context)
+                try:
+                    async for event in conv.ask_live(effective_prompt, images=images):
+                        if isinstance(event, TextDelta):
+                            response_text_parts.append(event.text)
+                        elif isinstance(event, ThinkingDelta):
+                            pass
+                        yield event
+                finally:
+                    if security_token is not None:
+                        from tukuy.safety import reset_security_context
+
+                        reset_security_context(security_token)
+
+            response_text = "".join(response_text_parts)
+            all_tool_calls: list[dict[str, Any]] = []
+            full_results = getattr(conv, "_full_tool_results", None)
+            self._extract_steps(conv.messages, steps, all_tool_calls, full_results)
+
+            if self._output_type is not None:
+                output, output_text = await self._parse_output(
+                    conv, response_text, steps, all_tool_calls, 0.0, session
+                )
+            else:
+                output = response_text
+                output_text = response_text
+
+            result = AgentResult(
+                output=output,
+                output_text=output_text,
+                messages=conv.messages,
+                usage=conv.usage,
+                steps=steps,
+                all_tool_calls=all_tool_calls,
+                state=AgentState.idle,
+                run_usage=session.summary(),
+            )
+
+            if self._output_guardrails:
+                result = await self._run_output_guardrails(ctx, result, conv, session, steps, all_tool_calls)
+
+            if self._agent_callbacks.on_step:
+                for step in steps:
+                    await self._invoke_callback(self._agent_callbacks.on_step, step)
+            if self._agent_callbacks.on_output:
+                await self._invoke_callback(self._agent_callbacks.on_output, result)
+            if self._agent_callbacks.on_message:
+                await self._invoke_callback(self._agent_callbacks.on_message, result.output_text)
+
+            self._lifecycle = AgentState.idle
+            self._last_live_result = result
+        except Exception:
+            self._lifecycle = AgentState.errored
+            raise
+        finally:
+            _agent_depth.reset(token)
+
 
 # ------------------------------------------------------------------
 # AsyncAgentIterator
@@ -1305,6 +1433,46 @@ class AsyncStreamedAgentResult:
                 self._result = event.data
             return event
         except StopAsyncIteration:
+            raise
+
+    @property
+    def result(self) -> AgentResult | None:
+        """The final :class:`AgentResult`, available after iteration completes."""
+        return self._result
+
+
+# ------------------------------------------------------------------
+# AsyncLiveAgentResult
+# ------------------------------------------------------------------
+
+
+class AsyncLiveAgentResult:
+    """Wraps the :meth:`AsyncAgent.run_live` async generator.
+
+    Yields :class:`~prompture.agents.live_events.LiveEvent` objects.
+    After async iteration completes, :attr:`result` holds the final
+    :class:`AgentResult`.
+
+    Async generators cannot return values via :class:`StopAsyncIteration`
+    the way sync generators do, so the wrapper keeps a reference to the
+    originating agent and reads ``_last_live_result`` from it when the
+    stream terminates.
+    """
+
+    def __init__(self, gen: AsyncGenerator[Any], *, agent: AsyncAgent[Any] | None = None) -> None:
+        self._gen = gen
+        self._agent = agent
+        self._result: AgentResult | None = None
+
+    def __aiter__(self) -> AsyncLiveAgentResult:
+        return self
+
+    async def __anext__(self) -> Any:
+        try:
+            return await self._gen.__anext__()
+        except StopAsyncIteration:
+            if self._agent is not None:
+                self._result = getattr(self._agent, "_last_live_result", None)
             raise
 
     @property

--- a/prompture/agents/async_conversation.py
+++ b/prompture/agents/async_conversation.py
@@ -322,13 +322,24 @@ class AsyncConversation:
         return cls.from_export(data, callbacks=callbacks, tools=tools)
 
     def _maybe_auto_save(self) -> None:
-        """Auto-save after each turn if configured."""
+        """Auto-save after each turn if configured.
+
+        Errors are logged at WARNING level (not silently swallowed) so that
+        disk-full, permission, or serialization failures are visible to the
+        operator. We still don't re-raise — auto-save is best-effort and
+        should never break the conversation loop.
+        """
         if self._auto_save is None:
             return
         try:
             self.save(self._auto_save)
         except Exception:
-            logger.debug("Auto-save failed for conversation %s", self._conversation_id, exc_info=True)
+            logger.warning(
+                "Auto-save failed for conversation %s (path=%s)",
+                self._conversation_id,
+                self._auto_save,
+                exc_info=True,
+            )
 
     # ------------------------------------------------------------------
     # Budget enforcement

--- a/prompture/agents/async_conversation.py
+++ b/prompture/agents/async_conversation.py
@@ -697,10 +697,7 @@ class AsyncConversation:
         """
         from .live_events import (
             AssistantTurnStart,
-            MessageStop,
             TextDelta,
-            ThinkingDelta,
-            ToolInputDelta,
             ToolResult,
             ToolUseStart,
             ToolUseStop,
@@ -806,9 +803,7 @@ class AsyncConversation:
                     is_error = False
                 except Exception as exc:
                     result_str = (
-                        f"Error ({type(exc).__name__}): {exc}"
-                        if str(exc)
-                        else f"Error: {type(exc).__name__}: {exc!r}"
+                        f"Error ({type(exc).__name__}): {exc}" if str(exc) else f"Error: {type(exc).__name__}: {exc!r}"
                     )
                     is_error = True
                 finally:

--- a/prompture/agents/async_conversation.py
+++ b/prompture/agents/async_conversation.py
@@ -6,11 +6,11 @@ import json
 import logging
 import time
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import date, datetime, timezone
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Callable, Literal, Union, cast
+from typing import Any, Literal, cast
 
 from pydantic import BaseModel
 
@@ -1142,7 +1142,7 @@ class AsyncConversation:
         fields: list[str] | None,
         field_definitions: dict[str, Any] | None,
         json_mode: Literal["auto", "on", "off"],
-    ) -> dict[str, Union[str, dict[str, Any]]]:
+    ) -> dict[str, str | dict[str, Any]]:
         """Stepwise extraction using async conversation context between fields."""
         if field_definitions is None:
             field_definitions = get_registry_snapshot()

--- a/prompture/agents/async_conversation.py
+++ b/prompture/agents/async_conversation.py
@@ -681,6 +681,153 @@ class AsyncConversation:
 
         raise RuntimeError(f"Tool execution loop exceeded {self._max_tool_rounds} rounds")
 
+    async def ask_live(
+        self,
+        content: str,
+        options: dict[str, Any] | None = None,
+        images: list[ImageInput] | None = None,
+    ) -> AsyncIterator[Any]:
+        """Async sibling of :meth:`Conversation.ask_live`.
+
+        Runs an agentic tool loop yielding :class:`LiveEvent` as work
+        happens — text/thinking deltas, tool_use start/input/stop,
+        tool_result, turn_complete — driven by the driver's native
+        streaming events for providers that support it (Claude, OpenAI,
+        Groq, etc.) and the synthetic fallback otherwise.
+        """
+        from .live_events import (
+            AssistantTurnStart,
+            MessageStop,
+            TextDelta,
+            ThinkingDelta,
+            ToolInputDelta,
+            ToolResult,
+            ToolUseStart,
+            ToolUseStop,
+            TurnComplete,
+        )
+
+        self._last_reasoning = None
+
+        if not self._tools:
+            async for chunk in self.ask_stream(content, options, images=images):
+                yield TextDelta(text=chunk)
+            yield TurnComplete(usage=dict(self._usage))
+            return
+
+        use_native = getattr(self._driver, "supports_tool_use", False)
+        if self._simulated_tools is True or (self._simulated_tools == "auto" and not use_native):
+            async for ev in self._ask_with_simulated_tool_events(content, options, images=images):
+                ev_type = ev.get("type")
+                if ev_type == "text_delta":
+                    yield TextDelta(text=ev.get("text", ""))
+                elif ev_type == "tool_call":
+                    yield ToolUseStart(id=ev.get("id", ""), name=ev.get("name", ""))
+                    yield ToolUseStop(
+                        id=ev.get("id", ""),
+                        name=ev.get("name", ""),
+                        input=ev.get("arguments", {}) or {},
+                    )
+                elif ev_type == "tool_result":
+                    yield ToolResult(
+                        id=ev.get("id", ""),
+                        name=ev.get("name", ""),
+                        output=ev.get("result", ""),
+                    )
+            yield TurnComplete(usage=dict(self._usage))
+            return
+
+        merged = {**self._options, **(options or {})}
+        tool_defs = self._tools.to_openai_format()
+
+        user_content = self._build_content_with_images(content, images)
+        self._messages.append({"role": "user", "content": user_content})
+        msgs = self._build_messages_raw()
+
+        for round_idx in range(self._max_tool_rounds):
+            self._check_budget()
+            if await self._run_before_turn():
+                msgs = self._build_messages_raw()
+
+            yield AssistantTurnStart(turn_index=round_idx)
+
+            assistant_text_parts: list[str] = []
+            assistant_thinking_parts: list[str] = []
+            tool_calls_in_turn: list[dict[str, Any]] = []
+            pending_tools: list[tuple[str, str, dict[str, Any]]] = []
+            turn_usage: dict[str, Any] = {}
+
+            stream = self._driver.generate_messages_with_tools_stream(msgs, tool_defs, merged)
+            async for event in stream:
+                yield event
+                et = getattr(event, "event_type", None)
+                if et == "text_delta":
+                    assistant_text_parts.append(event.text)
+                elif et == "thinking_delta":
+                    assistant_thinking_parts.append(event.text)
+                elif et == "tool_use_stop":
+                    pending_tools.append((event.id, event.name, event.input))
+                    tool_calls_in_turn.append(
+                        {
+                            "id": event.id,
+                            "type": "function",
+                            "function": {"name": event.name, "arguments": json.dumps(event.input)},
+                        }
+                    )
+                elif et == "message_stop":
+                    turn_usage = dict(event.usage or {})
+
+            full_text = "".join(assistant_text_parts)
+            full_thinking = "".join(assistant_thinking_parts) or None
+
+            assistant_msg: dict[str, Any] = {"role": "assistant", "content": full_text}
+            if tool_calls_in_turn:
+                assistant_msg["tool_calls"] = tool_calls_in_turn
+            if full_thinking is not None:
+                assistant_msg["reasoning_content"] = full_thinking
+                self._last_reasoning = full_thinking
+
+            self._messages.append(assistant_msg)
+            msgs.append(assistant_msg)
+            if turn_usage:
+                self._accumulate_usage(turn_usage)
+
+            if not pending_tools:
+                yield TurnComplete(usage=dict(self._usage))
+                return
+
+            for tool_id, tool_name, tool_input in pending_tools:
+                from ..extraction.tukuy_bridge import current_tool_call_id
+
+                _tok = current_tool_call_id.set(tool_id)
+                try:
+                    result = await self._tools.aexecute(tool_name, tool_input)
+                    result_str = json.dumps(result) if not isinstance(result, str) else result
+                    is_error = False
+                except Exception as exc:
+                    result_str = (
+                        f"Error ({type(exc).__name__}): {exc}"
+                        if str(exc)
+                        else f"Error: {type(exc).__name__}: {exc!r}"
+                    )
+                    is_error = True
+                finally:
+                    current_tool_call_id.reset(_tok)
+
+                self._full_tool_results[tool_id] = result_str
+                yield ToolResult(id=tool_id, name=tool_name, output=result_str, is_error=is_error)
+
+                truncated = self._truncate_tool_result(result_str)
+                tool_result_msg: dict[str, Any] = {
+                    "role": "tool",
+                    "tool_call_id": tool_id,
+                    "content": truncated,
+                }
+                self._messages.append(tool_result_msg)
+                msgs.append(tool_result_msg)
+
+        raise RuntimeError(f"ask_live exceeded {self._max_tool_rounds} rounds")
+
     async def _ask_with_simulated_tool_events(
         self,
         content: str,

--- a/prompture/agents/conversation.py
+++ b/prompture/agents/conversation.py
@@ -724,10 +724,7 @@ class Conversation:
         """
         from .live_events import (
             AssistantTurnStart,
-            MessageStop,
             TextDelta,
-            ThinkingDelta,
-            ToolInputDelta,
             ToolResult,
             ToolUseStart,
             ToolUseStop,
@@ -832,9 +829,7 @@ class Conversation:
                     is_error = False
                 except Exception as exc:
                     result_str = (
-                        f"Error ({type(exc).__name__}): {exc}"
-                        if str(exc)
-                        else f"Error: {type(exc).__name__}: {exc!r}"
+                        f"Error ({type(exc).__name__}): {exc}" if str(exc) else f"Error: {type(exc).__name__}: {exc!r}"
                     )
                     is_error = True
 

--- a/prompture/agents/conversation.py
+++ b/prompture/agents/conversation.py
@@ -695,6 +695,167 @@ class Conversation:
 
         raise RuntimeError(f"Tool execution loop exceeded {self._max_tool_rounds} rounds")
 
+    def ask_live(
+        self,
+        content: str,
+        options: dict[str, Any] | None = None,
+        images: list[ImageInput] | None = None,
+    ) -> Iterator[Any]:
+        """Run an agentic tool loop, yielding :class:`LiveEvent` as work happens.
+
+        Unlike :meth:`ask_with_tool_events`, which buffers each LLM turn and
+        emits ``tool_call`` / ``tool_result`` between rounds, ``ask_live``
+        forwards the driver's interleaved stream — so callers see text
+        deltas before, between, and after tool calls within a single turn.
+        This produces the "Claude Code feel" where the model narrates as it
+        decides what to do next.
+
+        Drivers that don't natively stream tool use (``supports_streaming_tool_use
+        == False``) fall back to the buffered method via the base-class
+        synthetic event sequence. The shape is still uniform.
+
+        Yields:
+            :class:`~prompture.agents.live_events.LiveEvent` instances:
+            ``AssistantTurnStart``, ``TextDelta``, ``ThinkingDelta``,
+            ``ToolUseStart``, ``ToolInputDelta``, ``ToolUseStop``,
+            ``ToolResult`` (after this layer executes the tool),
+            ``MessageStop`` (end of each LLM turn),
+            ``TurnComplete`` (no more tool calls pending — loop ends).
+        """
+        from .live_events import (
+            AssistantTurnStart,
+            MessageStop,
+            TextDelta,
+            ThinkingDelta,
+            ToolInputDelta,
+            ToolResult,
+            ToolUseStart,
+            ToolUseStop,
+            TurnComplete,
+        )
+
+        self._last_reasoning = None
+
+        if not self._tools:
+            for chunk in self.ask_stream(content, options, images=images):
+                yield TextDelta(text=chunk)
+            yield TurnComplete(usage=dict(self._usage))
+            return
+
+        use_native = getattr(self._driver, "supports_tool_use", False)
+        if self._simulated_tools is True or (self._simulated_tools == "auto" and not use_native):
+            for ev in self._ask_with_simulated_tool_events(content, options, images=images):
+                ev_type = ev.get("type")
+                if ev_type == "text_delta":
+                    yield TextDelta(text=ev.get("text", ""))
+                elif ev_type == "tool_call":
+                    yield ToolUseStart(id=ev.get("id", ""), name=ev.get("name", ""))
+                    yield ToolUseStop(
+                        id=ev.get("id", ""),
+                        name=ev.get("name", ""),
+                        input=ev.get("arguments", {}) or {},
+                    )
+                elif ev_type == "tool_result":
+                    yield ToolResult(
+                        id=ev.get("id", ""),
+                        name=ev.get("name", ""),
+                        output=ev.get("result", ""),
+                    )
+            yield TurnComplete(usage=dict(self._usage))
+            return
+
+        merged = {**self._options, **(options or {})}
+        tool_defs = self._tools.to_openai_format()
+
+        user_content = self._build_content_with_images(content, images)
+        self._messages.append({"role": "user", "content": user_content})
+        msgs = self._build_messages_raw()
+
+        for round_idx in range(self._max_tool_rounds):
+            self._check_budget()
+            if self._run_before_turn():
+                msgs = self._build_messages_raw()
+
+            yield AssistantTurnStart(turn_index=round_idx)
+
+            assistant_text_parts: list[str] = []
+            assistant_thinking_parts: list[str] = []
+            tool_calls_in_turn: list[dict[str, Any]] = []
+            pending_tools: list[tuple[str, str, dict[str, Any]]] = []
+            turn_usage: dict[str, Any] = {}
+            stop_reason: str = "end_turn"
+
+            stream = self._driver.generate_messages_with_tools_stream(msgs, tool_defs, merged)
+            for event in stream:
+                yield event
+                et = getattr(event, "event_type", None)
+                if et == "text_delta":
+                    assistant_text_parts.append(event.text)
+                elif et == "thinking_delta":
+                    assistant_thinking_parts.append(event.text)
+                elif et == "tool_use_stop":
+                    pending_tools.append((event.id, event.name, event.input))
+                    tool_calls_in_turn.append(
+                        {
+                            "id": event.id,
+                            "type": "function",
+                            "function": {"name": event.name, "arguments": json.dumps(event.input)},
+                        }
+                    )
+                elif et == "message_stop":
+                    turn_usage = dict(event.usage or {})
+                    stop_reason = event.stop_reason
+
+            full_text = "".join(assistant_text_parts)
+            full_thinking = "".join(assistant_thinking_parts) or None
+
+            assistant_msg: dict[str, Any] = {"role": "assistant", "content": full_text}
+            if tool_calls_in_turn:
+                assistant_msg["tool_calls"] = tool_calls_in_turn
+            if full_thinking is not None:
+                assistant_msg["reasoning_content"] = full_thinking
+                self._last_reasoning = full_thinking
+
+            self._messages.append(assistant_msg)
+            msgs.append(assistant_msg)
+            if turn_usage:
+                self._accumulate_usage(turn_usage)
+
+            if not pending_tools:
+                yield TurnComplete(usage=dict(self._usage))
+                return
+
+            for tool_id, tool_name, tool_input in pending_tools:
+                try:
+                    result = self._tools.execute(tool_name, tool_input)
+                    result_str = json.dumps(result) if not isinstance(result, str) else result
+                    is_error = False
+                except Exception as exc:
+                    result_str = (
+                        f"Error ({type(exc).__name__}): {exc}"
+                        if str(exc)
+                        else f"Error: {type(exc).__name__}: {exc!r}"
+                    )
+                    is_error = True
+
+                self._full_tool_results[tool_id] = result_str
+                yield ToolResult(id=tool_id, name=tool_name, output=result_str, is_error=is_error)
+
+                truncated = self._truncate_tool_result(result_str)
+                tool_result_msg: dict[str, Any] = {
+                    "role": "tool",
+                    "tool_call_id": tool_id,
+                    "content": truncated,
+                }
+                self._messages.append(tool_result_msg)
+                msgs.append(tool_result_msg)
+
+            # Unused stop_reason kept for symmetry with claw-code's loop;
+            # the real signal is whether pending_tools was non-empty.
+            del stop_reason
+
+        raise RuntimeError(f"ask_live exceeded {self._max_tool_rounds} rounds")
+
     def _ask_with_simulated_tool_events(
         self,
         content: str,

--- a/prompture/agents/conversation.py
+++ b/prompture/agents/conversation.py
@@ -6,11 +6,11 @@ import json
 import logging
 import time
 import uuid
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from datetime import date, datetime, timezone
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Callable, Literal, Union, cast
+from typing import Any, Literal, cast
 
 from pydantic import BaseModel
 
@@ -1247,7 +1247,7 @@ class Conversation:
         fields: list[str] | None,
         field_definitions: dict[str, Any] | None,
         json_mode: Literal["auto", "on", "off"],
-    ) -> dict[str, Union[str, dict[str, Any]]]:
+    ) -> dict[str, str | dict[str, Any]]:
         """Stepwise extraction using conversation context between fields."""
         if field_definitions is None:
             field_definitions = get_registry_snapshot()

--- a/prompture/agents/conversation.py
+++ b/prompture/agents/conversation.py
@@ -924,6 +924,90 @@ class Conversation:
             if chunk["type"] == "delta":
                 yield chunk["text"]
 
+    def ask_stream_model(
+        self,
+        content: str,
+        model_cls: type[BaseModel],
+        options: dict[str, Any] | None = None,
+        *,
+        json_mode: Literal["auto", "on", "off"] = "auto",
+        emit_unchanged: bool = False,
+    ) -> Iterator[BaseModel]:
+        """Stream a JSON response and yield progressive :class:`pydantic.BaseModel` partials.
+
+        Wraps the underlying streaming driver with the partial-JSON
+        parser from :mod:`prompture.extraction.streaming`. Each yielded
+        instance is built via :meth:`BaseModel.model_construct` (no
+        validation) until the stream completes; when the full response
+        validates, the *final* yield is a fully-validated instance.
+
+        The schema instructions are appended to the prompt; only the
+        original ``content`` is stored in conversation history.
+
+        Args:
+            content: User message.
+            model_cls: Pydantic v2 model to construct partials of.
+            options: Driver options forwarded to ``generate_messages_stream``.
+            json_mode: ``"auto"`` (default) sets ``json_mode=True`` and
+                provides a ``json_schema`` to the driver when the driver
+                declares ``supports_json_schema``. ``"on"`` forces JSON
+                mode; ``"off"`` sends the prompt as-is (caller must
+                instruct the model to produce JSON).
+            emit_unchanged: Yield even when consecutive partials are
+                identical. Defaults to False — only changed snapshots
+                are yielded.
+
+        Yields:
+            ``model_cls`` instances. The last one is validated when the
+            stream produced a complete JSON object; intermediate ones
+            are non-validated partials with missing fields left unset.
+
+        Raises:
+            AttributeError: when the driver doesn't expose
+                ``generate_messages_stream``.
+        """
+        from ..extraction.streaming import stream_extract
+
+        schema = model_cls.model_json_schema()
+        schema_str = json.dumps(schema, indent=2)
+        schema_instruction = (
+            "You MUST respond with a single JSON object (no markdown, no extra text) "
+            "that validates against this JSON schema:\n"
+            f"{schema_str}\n\nUse double quotes for keys and strings. "
+            "If a value is unknown use null."
+        )
+        prompt = f"{content}\n\n{schema_instruction}"
+
+        merged_options: dict[str, Any] = {**self._options, **(options or {})}
+        if json_mode in ("auto", "on"):
+            merged_options.setdefault("json_mode", True)
+            if json_mode != "off" and getattr(self._driver, "supports_json_schema", False):
+                merged_options.setdefault("json_schema", schema)
+
+        last_partial: BaseModel | None = None
+        for partial in stream_extract(
+            self._driver,
+            prompt,
+            model_cls,
+            system_prompt=self._system_prompt,
+            options=merged_options,
+            emit_unchanged=emit_unchanged,
+        ):
+            last_partial = partial
+            yield partial
+
+        # Record only the original content (not the schema instructions) in
+        # history; the assistant turn records the JSON serialisation of the
+        # last partial so subsequent turns can reference it textually.
+        self._messages.append({"role": "user", "content": content})
+        if last_partial is not None:
+            try:
+                last_text = last_partial.model_dump_json()
+            except Exception:
+                last_text = ""
+            if last_text:
+                self._messages.append({"role": "assistant", "content": last_text})
+
     def ask_for_json(
         self,
         content: str,

--- a/prompture/agents/conversation.py
+++ b/prompture/agents/conversation.py
@@ -329,13 +329,24 @@ class Conversation:
         return cls.from_export(data, callbacks=callbacks, tools=tools)
 
     def _maybe_auto_save(self) -> None:
-        """Auto-save after each turn if configured.  Errors are silently logged."""
+        """Auto-save after each turn if configured.
+
+        Errors are logged at WARNING level (not silently swallowed) so that
+        disk-full, permission, or serialization failures are visible to the
+        operator. We still don't re-raise — auto-save is best-effort and
+        should never break the conversation loop.
+        """
         if self._auto_save is None:
             return
         try:
             self.save(self._auto_save)
         except Exception:
-            logger.debug("Auto-save failed for conversation %s", self._conversation_id, exc_info=True)
+            logger.warning(
+                "Auto-save failed for conversation %s (path=%s)",
+                self._conversation_id,
+                self._auto_save,
+                exc_info=True,
+            )
 
     # ------------------------------------------------------------------
     # Budget enforcement

--- a/prompture/agents/deep/summarizer.py
+++ b/prompture/agents/deep/summarizer.py
@@ -22,6 +22,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
+from ..._internal.json_encoder import PromptureJSONEncoder
 from ...drivers import get_driver_for_model
 from ...drivers.base import Driver
 from ..deep_prompts import SUMMARIZER_SYSTEM_PROMPT, SUMMARY_PRELUDE
@@ -48,7 +49,7 @@ def _stringify_message(msg: dict[str, Any]) -> str:
                     parts.append("[image]")
         content = "\n".join(parts)
     elif not isinstance(content, str):
-        content = json.dumps(content, default=str)
+        content = json.dumps(content, cls=PromptureJSONEncoder)
 
     tool_calls = msg.get("tool_calls")
     if tool_calls:

--- a/prompture/agents/deep_state.py
+++ b/prompture/agents/deep_state.py
@@ -10,7 +10,7 @@ middleware. :class:`DeepAgent` owns the state, exposes it on the result via
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Literal, Union
+from typing import Any, Literal
 
 from .persona import Persona
 from .tools_schema import ToolDefinition
@@ -90,7 +90,7 @@ class SubAgentSpec:
 
     name: str
     description: str
-    system_prompt: Union[str, Persona]
+    system_prompt: str | Persona
     model: str | None = None
     tools: list[ToolDefinition] | None = None
     inherit_tools: bool = True

--- a/prompture/agents/live_events.py
+++ b/prompture/agents/live_events.py
@@ -1,0 +1,155 @@
+"""Live event types for streaming agentic tool calling.
+
+These events flow from a driver's :meth:`generate_messages_with_tools_stream`
+up through :meth:`Conversation.ask_live` and out to the caller, giving the
+"Claude Code feel" where the model narrates between tool calls instead of
+buffering tools and text into a single turn.
+
+Event ordering for a single tool-using turn::
+
+    AssistantTurnStart
+      [TextDelta | ThinkingDelta]*         # narration before any tool
+      ToolUseStart(id, name)
+        ToolInputDelta(id, fragment)*       # input JSON streamed in chunks
+      ToolUseStop(id, input)                # final parsed input dict
+      [TextDelta | ThinkingDelta]*         # optional narration between tools
+      ... (more ToolUseStart / Stop pairs)
+    MessageStop(usage, stop_reason)
+    ToolResult(id, name, output, is_error)* # one per executed tool (yielded
+                                            # by Conversation, not driver)
+    # loop repeats with another AssistantTurnStart until the model stops
+    # asking for tools, then:
+    TurnComplete(usage)
+
+The ``ToolResult`` event is emitted by the **conversation layer** after it
+executes the tool — drivers never produce it. Everything else is produced
+by the driver.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Union
+
+
+@dataclass(frozen=True)
+class AssistantTurnStart:
+    """Marks the start of an assistant turn (one LLM call)."""
+
+    event_type: Literal["assistant_turn_start"] = field(default="assistant_turn_start", init=False)
+    turn_index: int = 0
+
+
+@dataclass(frozen=True)
+class TextDelta:
+    """A fragment of assistant text being generated."""
+
+    text: str
+    event_type: Literal["text_delta"] = field(default="text_delta", init=False)
+
+
+@dataclass(frozen=True)
+class ThinkingDelta:
+    """A fragment of assistant reasoning/thinking content."""
+
+    text: str
+    event_type: Literal["thinking_delta"] = field(default="thinking_delta", init=False)
+
+
+@dataclass(frozen=True)
+class ToolUseStart:
+    """The model has decided to call a tool. Input JSON streams next."""
+
+    id: str
+    name: str
+    event_type: Literal["tool_use_start"] = field(default="tool_use_start", init=False)
+
+
+@dataclass(frozen=True)
+class ToolInputDelta:
+    """A fragment of the tool's input JSON as it's generated."""
+
+    id: str
+    fragment: str
+    event_type: Literal["tool_input_delta"] = field(default="tool_input_delta", init=False)
+
+
+@dataclass(frozen=True)
+class ToolUseStop:
+    """The tool's input is complete. ``input`` is the parsed dict."""
+
+    id: str
+    name: str
+    input: dict[str, Any]
+    event_type: Literal["tool_use_stop"] = field(default="tool_use_stop", init=False)
+
+
+@dataclass(frozen=True)
+class ToolResult:
+    """The conversation layer executed the tool and got this output."""
+
+    id: str
+    name: str
+    output: str
+    is_error: bool = False
+    event_type: Literal["tool_result"] = field(default="tool_result", init=False)
+
+
+@dataclass(frozen=True)
+class MessageStop:
+    """End of one assistant turn. ``stop_reason`` matches provider semantics
+    (``end_turn``, ``tool_use``, ``max_tokens``, ``stop``, ``length`` …)."""
+
+    stop_reason: str
+    usage: dict[str, Any] = field(default_factory=dict)
+    event_type: Literal["message_stop"] = field(default="message_stop", init=False)
+
+
+@dataclass(frozen=True)
+class TurnComplete:
+    """End of the whole interaction — no more tool calls pending."""
+
+    usage: dict[str, Any] = field(default_factory=dict)
+    event_type: Literal["turn_complete"] = field(default="turn_complete", init=False)
+
+
+LiveEvent = Union[
+    AssistantTurnStart,
+    TextDelta,
+    ThinkingDelta,
+    ToolUseStart,
+    ToolInputDelta,
+    ToolUseStop,
+    ToolResult,
+    MessageStop,
+    TurnComplete,
+]
+"""Discriminated union of every event the live tool-calling stream emits.
+
+Use the ``event_type`` field for dispatch::
+
+    for ev in agent.run_live("..."):
+        match ev.event_type:
+            case "text_delta":
+                print(ev.text, end="", flush=True)
+            case "tool_use_start":
+                print(f"\\n[calling {ev.name}({ev.id})]")
+            case "tool_result":
+                print(f"[result: {ev.output[:80]}]")
+            case "turn_complete":
+                print(f"\\n[done, ${ev.usage.get('cost', 0):.4f}]")
+"""
+
+
+__all__ = [
+    "AssistantTurnStart",
+    "LiveEvent",
+    "MessageStop",
+    "TextDelta",
+    "ThinkingDelta",
+    "ToolInputDelta",
+    "ToolResult",
+    "ToolUseStart",
+    "ToolUseStop",
+    "TurnComplete",
+]

--- a/prompture/agents/tools_schema.py
+++ b/prompture/agents/tools_schema.py
@@ -24,8 +24,9 @@ from __future__ import annotations
 import inspect
 import json
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable, get_type_hints
+from typing import Any, get_type_hints
 
 logger = logging.getLogger("prompture.tools_schema")
 

--- a/prompture/agents/types.py
+++ b/prompture/agents/types.py
@@ -133,9 +133,9 @@ class AgentCallbacks:
     """
 
     on_step: Callable[[AgentStep], None] | Callable[[AgentStep], Awaitable[None]] | None = None
-    on_tool_start: (
-        Callable[[str, dict[str, Any]], None] | Callable[[str, dict[str, Any]], Awaitable[None]] | None
-    ) = None
+    on_tool_start: Callable[[str, dict[str, Any]], None] | Callable[[str, dict[str, Any]], Awaitable[None]] | None = (
+        None
+    )
     on_tool_end: Callable[[str, Any], None] | Callable[[str, Any], Awaitable[None]] | None = None
     on_iteration: Callable[[int], None] | Callable[[int], Awaitable[None]] | None = None
     on_output: Callable[[AgentResult], None] | Callable[[AgentResult], Awaitable[None]] | None = None

--- a/prompture/agents/types.py
+++ b/prompture/agents/types.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Generic, TypeVar, Union
 
+from .._internal.json_encoder import PromptureJSONEncoder
+
 DepsType = TypeVar("DepsType")
 
 
@@ -246,7 +248,7 @@ class AgentResult:
             with open("agent_history.json", "w") as f:
                 f.write(json_str)
         """
-        return json.dumps(self.to_dict(include_messages=include_messages), indent=2, default=str)
+        return json.dumps(self.to_dict(include_messages=include_messages), indent=2, cls=PromptureJSONEncoder)
 
 
 class StreamEventType(str, enum.Enum):

--- a/prompture/agents/types.py
+++ b/prompture/agents/types.py
@@ -10,7 +10,7 @@ import json
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Generic, TypeVar, Union
+from typing import Any, Generic, TypeVar
 
 from .._internal.json_encoder import PromptureJSONEncoder
 
@@ -132,18 +132,18 @@ class AgentCallbacks:
             without processing the full :class:`AgentResult`.
     """
 
-    on_step: Union[Callable[[AgentStep], None], Callable[[AgentStep], Awaitable[None]], None] = None
-    on_tool_start: Union[
-        Callable[[str, dict[str, Any]], None], Callable[[str, dict[str, Any]], Awaitable[None]], None
-    ] = None
-    on_tool_end: Union[Callable[[str, Any], None], Callable[[str, Any], Awaitable[None]], None] = None
-    on_iteration: Union[Callable[[int], None], Callable[[int], Awaitable[None]], None] = None
-    on_output: Union[Callable[[AgentResult], None], Callable[[AgentResult], Awaitable[None]], None] = None
-    on_thinking: Union[Callable[[str], None], Callable[[str], Awaitable[None]], None] = None
-    on_approval_needed: Union[
-        Callable[[str, str, dict[str, Any]], bool], Callable[[str, str, dict[str, Any]], Awaitable[bool]], None
-    ] = None
-    on_message: Union[Callable[[str], None], Callable[[str], Awaitable[None]], None] = None
+    on_step: Callable[[AgentStep], None] | Callable[[AgentStep], Awaitable[None]] | None = None
+    on_tool_start: (
+        Callable[[str, dict[str, Any]], None] | Callable[[str, dict[str, Any]], Awaitable[None]] | None
+    ) = None
+    on_tool_end: Callable[[str, Any], None] | Callable[[str, Any], Awaitable[None]] | None = None
+    on_iteration: Callable[[int], None] | Callable[[int], Awaitable[None]] | None = None
+    on_output: Callable[[AgentResult], None] | Callable[[AgentResult], Awaitable[None]] | None = None
+    on_thinking: Callable[[str], None] | Callable[[str], Awaitable[None]] | None = None
+    on_approval_needed: (
+        Callable[[str, str, dict[str, Any]], bool] | Callable[[str, str, dict[str, Any]], Awaitable[bool]] | None
+    ) = None
+    on_message: Callable[[str], None] | Callable[[str], Awaitable[None]] | None = None
 
 
 @dataclass

--- a/prompture/checkpoints/__init__.py
+++ b/prompture/checkpoints/__init__.py
@@ -1,0 +1,46 @@
+"""Resumable workflows for Prompture.
+
+Take a snapshot of an in-flight :class:`~prompture.agents.Conversation`
+or :class:`~prompture.agents.Agent` so it can resume after a process
+restart, crash, or human-in-the-loop pause.
+
+Three layers:
+
+- :class:`Checkpoint` — JSON-serialisable snapshot of a run.
+- :class:`CheckpointStore` — pluggable backend protocol.  Ships with
+  :class:`InMemoryCheckpointStore`, :class:`FileCheckpointStore`, and
+  :class:`SQLiteCheckpointStore`.
+- :class:`CheckpointManager` — high-level API tying a ``run_id`` to a
+  store, with ``save`` / ``load`` / ``resume`` helpers.
+
+Designed to be non-invasive: no modifications to :class:`Agent` or
+:class:`Conversation` are required.  Hook
+:meth:`CheckpointManager.save_conversation` into
+:attr:`Conversation.before_turn` or
+:attr:`AgentCallbacks.on_step` to persist progress automatically.
+"""
+
+from .core import (
+    CheckpointManager,
+    restore_conversation,
+    snapshot_conversation,
+)
+from .stores import (
+    CheckpointStore,
+    FileCheckpointStore,
+    InMemoryCheckpointStore,
+    SQLiteCheckpointStore,
+)
+from .types import Checkpoint, RunStatus
+
+__all__ = [
+    "Checkpoint",
+    "CheckpointManager",
+    "CheckpointStore",
+    "FileCheckpointStore",
+    "InMemoryCheckpointStore",
+    "RunStatus",
+    "SQLiteCheckpointStore",
+    "restore_conversation",
+    "snapshot_conversation",
+]

--- a/prompture/checkpoints/core.py
+++ b/prompture/checkpoints/core.py
@@ -57,9 +57,7 @@ def snapshot_conversation(
         partial_output: Any partial generation text worth persisting.
         metadata: Free-form payload merged into the snapshot.
     """
-    model = getattr(conv, "model_name", None) or getattr(
-        getattr(conv, "_driver", None), "model", None
-    )
+    model = getattr(conv, "model_name", None) or getattr(getattr(conv, "_driver", None), "model", None)
     system_prompt = getattr(conv, "system_prompt", None)
     return Checkpoint(
         run_id=run_id or uuid.uuid4().hex,
@@ -107,9 +105,7 @@ def restore_conversation(
 
     effective_model = model or checkpoint.model
     if driver is None and not effective_model:
-        raise ValueError(
-            "Cannot restore conversation: no model in checkpoint and no override provided"
-        )
+        raise ValueError("Cannot restore conversation: no model in checkpoint and no override provided")
 
     kwargs: dict[str, Any] = dict(conversation_kwargs)
     if "system_prompt" not in kwargs and checkpoint.system_prompt:

--- a/prompture/checkpoints/core.py
+++ b/prompture/checkpoints/core.py
@@ -1,0 +1,299 @@
+"""High-level checkpointing API.
+
+The intent is non-invasive: do not modify :class:`Agent` or
+:class:`Conversation`; instead provide free functions and a manager
+that callers compose with the existing hook points
+(:attr:`Conversation.before_turn`, :attr:`AgentCallbacks.on_step`,
+``run_id`` argument from the caller).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import copy
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from .stores import CheckpointStore, InMemoryCheckpointStore
+from .types import Checkpoint, RunStatus
+
+if TYPE_CHECKING:
+    from ..agents.agent import Agent
+    from ..agents.conversation import Conversation
+
+
+# ----------------------------------------------------------------------
+# Free functions — snapshot / restore
+# ----------------------------------------------------------------------
+
+
+def snapshot_conversation(
+    conv: Conversation,
+    *,
+    run_id: str | None = None,
+    iteration: int = 0,
+    prompt: str = "",
+    status: str = RunStatus.running.value,
+    agent_name: str | None = None,
+    partial_output: str = "",
+    metadata: dict[str, Any] | None = None,
+) -> Checkpoint:
+    """Capture a :class:`Conversation` as a :class:`Checkpoint`.
+
+    The system prompt, message history, and per-conversation usage
+    counters are recorded.  Free-form *metadata* is forwarded verbatim
+    so callers can stash extra state (todos, sub-agent specs,
+    in-flight tool results).
+
+    Args:
+        conv: The conversation to snapshot.
+        run_id: Override the run identifier.  Defaults to a fresh
+            UUID4 hex string.
+        iteration: Current iteration/turn index.
+        prompt: The user prompt that launched the run (or the most
+            recent prompt being processed).
+        status: Lifecycle state — see :class:`RunStatus`.
+        agent_name: Optional name of the owning agent.
+        partial_output: Any partial generation text worth persisting.
+        metadata: Free-form payload merged into the snapshot.
+    """
+    model = getattr(conv, "model_name", None) or getattr(
+        getattr(conv, "_driver", None), "model", None
+    )
+    system_prompt = getattr(conv, "system_prompt", None)
+    return Checkpoint(
+        run_id=run_id or uuid.uuid4().hex,
+        agent_name=agent_name,
+        model=model,
+        system_prompt=system_prompt,
+        messages=list(conv.messages),
+        usage=dict(getattr(conv, "usage", {}) or {}),
+        iteration=iteration,
+        status=status,
+        prompt=prompt,
+        partial_output=partial_output,
+        metadata=copy.deepcopy(metadata) if metadata else {},
+    )
+
+
+def restore_conversation(
+    checkpoint: Checkpoint,
+    *,
+    model: str | None = None,
+    driver: Any | None = None,
+    **conversation_kwargs: Any,
+) -> Conversation:
+    """Reconstruct a :class:`Conversation` from *checkpoint*.
+
+    The message history, system prompt, and previously-recorded usage
+    are restored so the next call to :meth:`Conversation.ask` continues
+    where the snapshot left off.
+
+    Args:
+        checkpoint: The snapshot to resume.
+        model: Override the model string.  Defaults to the value
+            recorded in the checkpoint.
+        driver: Pre-built driver to inject (preferred over *model*
+            when both are supplied).
+        **conversation_kwargs: Forwarded to
+            :class:`~prompture.agents.Conversation`.  Callers can
+            inject tools, callbacks, options, etc.
+
+    Raises:
+        ValueError: When neither *model*, *driver*, nor the
+            checkpoint's recorded model can supply a target.
+    """
+    from ..agents.conversation import Conversation
+
+    effective_model = model or checkpoint.model
+    if driver is None and not effective_model:
+        raise ValueError(
+            "Cannot restore conversation: no model in checkpoint and no override provided"
+        )
+
+    kwargs: dict[str, Any] = dict(conversation_kwargs)
+    if "system_prompt" not in kwargs and checkpoint.system_prompt:
+        kwargs["system_prompt"] = checkpoint.system_prompt
+    if driver is not None:
+        kwargs["driver"] = driver
+    else:
+        kwargs["model_name"] = effective_model
+
+    conv = Conversation(**kwargs)
+    # Restore message history.  ``messages`` is a read-only property,
+    # so write the backing list directly.
+    conv._messages = list(checkpoint.messages)
+    if checkpoint.usage:
+        # Best-effort restore — Conversation.usage may be read-only on
+        # some builds; silently skip when the attribute can't be updated.
+        with contextlib.suppress(Exception):
+            conv.usage.update(checkpoint.usage)
+    return conv
+
+
+# ----------------------------------------------------------------------
+# CheckpointManager
+# ----------------------------------------------------------------------
+
+
+class CheckpointManager:
+    """Lifecycle helper binding a ``run_id`` to a :class:`CheckpointStore`.
+
+    The manager owns a single run identifier and the most recent
+    snapshot for it.  Callers wire it into existing hook points:
+
+    - Pass :meth:`save_conversation` as a ``before_turn`` callback on
+      :class:`~prompture.agents.Conversation`.
+    - Call :meth:`save_agent` from
+      :attr:`AgentCallbacks.on_step` /
+      :attr:`AgentCallbacks.on_iteration`.
+    - On startup, call :meth:`load` to detect an interrupted run and
+      :meth:`resume_conversation` to keep going.
+
+    Args:
+        store: Backing :class:`CheckpointStore`.  Defaults to
+            :class:`InMemoryCheckpointStore`.
+        run_id: Stable run identifier.  Auto-generated when omitted.
+        agent_name: Optional default for snapshots produced by this
+            manager.
+
+    Example::
+
+        store = SQLiteCheckpointStore()
+        mgr = CheckpointManager(store, run_id="trip-research")
+        conv = Conversation(
+            model_name="openai/gpt-4o",
+            before_turn=lambda c, turn: mgr.save_conversation(c, iteration=turn),
+        )
+        conv.ask("Plan a 5-day Paris trip.")
+        # ... crash ...
+        cp = mgr.load()
+        resumed = mgr.resume_conversation()
+        resumed.ask("Continue from where we left off.")
+    """
+
+    def __init__(
+        self,
+        store: CheckpointStore | None = None,
+        *,
+        run_id: str | None = None,
+        agent_name: str | None = None,
+    ) -> None:
+        self._store: CheckpointStore = store if store is not None else InMemoryCheckpointStore()
+        self._run_id = run_id or uuid.uuid4().hex
+        self._agent_name = agent_name
+
+    # ------------------------------------------------------------------
+    # Accessors
+    # ------------------------------------------------------------------
+
+    @property
+    def run_id(self) -> str:
+        return self._run_id
+
+    @property
+    def store(self) -> CheckpointStore:
+        return self._store
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+
+    def save_conversation(
+        self,
+        conv: Conversation,
+        *,
+        iteration: int = 0,
+        prompt: str = "",
+        status: str = RunStatus.running.value,
+        partial_output: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> Checkpoint:
+        """Snapshot *conv* and persist under this manager's run id."""
+        cp = snapshot_conversation(
+            conv,
+            run_id=self._run_id,
+            iteration=iteration,
+            prompt=prompt,
+            status=status,
+            agent_name=self._agent_name,
+            partial_output=partial_output,
+            metadata=metadata,
+        )
+        self._store.save(cp)
+        return cp
+
+    def save_agent(
+        self,
+        agent: Agent,
+        *,
+        iteration: int = 0,
+        prompt: str = "",
+        status: str = RunStatus.running.value,
+        metadata: dict[str, Any] | None = None,
+    ) -> Checkpoint | None:
+        """Snapshot the persistent :class:`Conversation` an Agent holds.
+
+        Only works when the underlying agent has
+        ``persistent_conversation=True`` and has already executed at
+        least once.  Returns ``None`` if no conversation is available
+        yet.
+        """
+        conv = getattr(agent, "conversation", None) or getattr(agent, "_conversation", None)
+        if conv is None:
+            return None
+        return self.save_conversation(
+            conv,
+            iteration=iteration,
+            prompt=prompt,
+            status=status,
+            metadata=metadata,
+        )
+
+    def mark(self, status: str, *, metadata: dict[str, Any] | None = None) -> Checkpoint | None:
+        """Update the latest checkpoint's status (e.g. mark as completed).
+
+        Returns ``None`` when no checkpoint exists for this run.
+        """
+        cp = self._store.load(self._run_id)
+        if cp is None:
+            return None
+        cp.status = status
+        if metadata:
+            cp.metadata = {**cp.metadata, **metadata}
+        self._store.save(cp)
+        return cp
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    def load(self) -> Checkpoint | None:
+        """Return the latest checkpoint for this run id, or ``None``."""
+        return self._store.load(self._run_id)
+
+    def exists(self) -> bool:
+        """``True`` when a checkpoint exists for this run id."""
+        return self._store.load(self._run_id) is not None
+
+    def resume_conversation(
+        self,
+        *,
+        model: str | None = None,
+        driver: Any | None = None,
+        **conversation_kwargs: Any,
+    ) -> Conversation:
+        """Load the latest checkpoint and rebuild the conversation.
+
+        Raises :class:`LookupError` when no checkpoint exists.  All
+        keyword arguments are forwarded to
+        :func:`restore_conversation`.
+        """
+        cp = self.load()
+        if cp is None:
+            raise LookupError(f"No checkpoint found for run_id={self._run_id!r}")
+        return restore_conversation(cp, model=model, driver=driver, **conversation_kwargs)
+
+    def delete(self) -> bool:
+        """Drop this manager's checkpoint.  Returns whether it existed."""
+        return self._store.delete(self._run_id)

--- a/prompture/checkpoints/stores.py
+++ b/prompture/checkpoints/stores.py
@@ -1,0 +1,299 @@
+"""Storage backends for run checkpoints.
+
+Three implementations ship out of the box:
+
+- :class:`InMemoryCheckpointStore` — process-local, no dependencies.
+- :class:`FileCheckpointStore` — one JSON file per ``run_id`` in a
+  directory of your choosing.  Atomic writes via temp-file + rename.
+- :class:`SQLiteCheckpointStore` — single-file database, indexed by
+  ``run_id``, mirrors the persistence patterns used elsewhere in the
+  codebase.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from .types import Checkpoint
+
+_DEFAULT_DB_DIR = Path.home() / ".prompture" / "checkpoints"
+_DEFAULT_DB_PATH = _DEFAULT_DB_DIR / "checkpoints.db"
+
+
+@runtime_checkable
+class CheckpointStore(Protocol):
+    """Persistence contract for :class:`Checkpoint`.
+
+    Backends must be thread-safe — the same ``run_id`` may be saved
+    concurrently from multiple threads (an LLM call writing progress
+    while a UI thread reads it).
+    """
+
+    def save(self, checkpoint: Checkpoint) -> None:
+        """Upsert *checkpoint* by ``run_id``."""
+        ...
+
+    def load(self, run_id: str) -> Checkpoint | None:
+        """Return the latest :class:`Checkpoint` for *run_id*, or ``None``."""
+        ...
+
+    def list_runs(self, *, status: str | None = None) -> list[Checkpoint]:
+        """List the latest checkpoint for every known ``run_id``.
+
+        Filter by *status* when set.
+        """
+        ...
+
+    def delete(self, run_id: str) -> bool:
+        """Drop the checkpoint for *run_id*.  Returns whether one existed."""
+        ...
+
+
+# ----------------------------------------------------------------------
+# In-memory
+# ----------------------------------------------------------------------
+
+
+class InMemoryCheckpointStore:
+    """Thread-safe in-process :class:`CheckpointStore`."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._by_run: dict[str, Checkpoint] = {}
+
+    def save(self, checkpoint: Checkpoint) -> None:
+        with self._lock:
+            self._by_run[checkpoint.run_id] = checkpoint
+
+    def load(self, run_id: str) -> Checkpoint | None:
+        with self._lock:
+            return self._by_run.get(run_id)
+
+    def list_runs(self, *, status: str | None = None) -> list[Checkpoint]:
+        with self._lock:
+            records = list(self._by_run.values())
+        if status is not None:
+            records = [c for c in records if c.status == status]
+        records.sort(key=lambda c: c.ts, reverse=True)
+        return records
+
+    def delete(self, run_id: str) -> bool:
+        with self._lock:
+            return self._by_run.pop(run_id, None) is not None
+
+
+# ----------------------------------------------------------------------
+# File-based (JSON-per-run)
+# ----------------------------------------------------------------------
+
+
+class FileCheckpointStore:
+    """Persist checkpoints as JSON files in a directory.
+
+    File layout: ``<directory>/<run_id>.json``.  Writes are atomic via
+    ``tempfile + os.replace`` so a crash mid-write never leaves a
+    truncated file.
+
+    Args:
+        directory: Where to store JSON files.  Created if missing.
+
+    Example::
+
+        store = FileCheckpointStore("./.runs")
+        store.save(checkpoint)
+        cp = store.load("run-42")
+    """
+
+    def __init__(self, directory: str | Path) -> None:
+        self._dir = Path(directory)
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+
+    def _path_for(self, run_id: str) -> Path:
+        # Defensive: refuse path-traversal in run ids.
+        safe = run_id.replace("/", "_").replace("\\", "_")
+        return self._dir / f"{safe}.json"
+
+    def save(self, checkpoint: Checkpoint) -> None:
+        path = self._path_for(checkpoint.run_id)
+        payload = json.dumps(checkpoint.to_dict(), ensure_ascii=False, indent=2)
+        with self._lock:
+            # Atomic replace: write to a sibling temp file, then rename.
+            fd, tmp_name = tempfile.mkstemp(prefix=".chkpt-", dir=str(self._dir))
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as fp:
+                    fp.write(payload)
+                os.replace(tmp_name, path)
+            except Exception:
+                if os.path.exists(tmp_name):
+                    os.remove(tmp_name)
+                raise
+
+    def load(self, run_id: str) -> Checkpoint | None:
+        path = self._path_for(run_id)
+        with self._lock:
+            if not path.exists():
+                return None
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                return None
+        return Checkpoint.from_dict(data)
+
+    def list_runs(self, *, status: str | None = None) -> list[Checkpoint]:
+        with self._lock:
+            paths = sorted(self._dir.glob("*.json"))
+        out: list[Checkpoint] = []
+        for p in paths:
+            try:
+                data = json.loads(p.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            cp = Checkpoint.from_dict(data)
+            if status is None or cp.status == status:
+                out.append(cp)
+        out.sort(key=lambda c: c.ts, reverse=True)
+        return out
+
+    def delete(self, run_id: str) -> bool:
+        path = self._path_for(run_id)
+        with self._lock:
+            if path.exists():
+                path.unlink()
+                return True
+            return False
+
+
+# ----------------------------------------------------------------------
+# SQLite
+# ----------------------------------------------------------------------
+
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS checkpoints (
+    run_id TEXT PRIMARY KEY,
+    id TEXT NOT NULL,
+    agent_name TEXT,
+    model TEXT,
+    status TEXT NOT NULL,
+    iteration INTEGER NOT NULL DEFAULT 0,
+    ts REAL NOT NULL,
+    data TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_checkpoints_status ON checkpoints(status);
+CREATE INDEX IF NOT EXISTS idx_checkpoints_ts ON checkpoints(ts);
+"""
+
+
+class SQLiteCheckpointStore:
+    """SQLite-backed :class:`CheckpointStore`.
+
+    Args:
+        db_path: Override the default DB location
+            (``~/.prompture/checkpoints/checkpoints.db``).
+    """
+
+    def __init__(self, db_path: str | Path | None = None) -> None:
+        self._db_path = Path(db_path) if db_path else _DEFAULT_DB_PATH
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._init_db()
+
+    def _init_db(self) -> None:
+        with self._lock:
+            conn = sqlite3.connect(str(self._db_path))
+            try:
+                conn.execute("PRAGMA journal_mode=WAL")
+                conn.executescript(_SCHEMA_SQL)
+                conn.commit()
+            finally:
+                conn.close()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self._db_path))
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def save(self, checkpoint: Checkpoint) -> None:
+        data_json = json.dumps(checkpoint.to_dict(), ensure_ascii=False)
+        with self._lock:
+            conn = self._connect()
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO checkpoints
+                        (run_id, id, agent_name, model, status, iteration, ts, data)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(run_id) DO UPDATE SET
+                        id = excluded.id,
+                        agent_name = excluded.agent_name,
+                        model = excluded.model,
+                        status = excluded.status,
+                        iteration = excluded.iteration,
+                        ts = excluded.ts,
+                        data = excluded.data
+                    """,
+                    (
+                        checkpoint.run_id,
+                        checkpoint.id,
+                        checkpoint.agent_name,
+                        checkpoint.model,
+                        checkpoint.status,
+                        checkpoint.iteration,
+                        checkpoint.ts,
+                        data_json,
+                    ),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+    def load(self, run_id: str) -> Checkpoint | None:
+        with self._lock:
+            conn = self._connect()
+            try:
+                row = conn.execute(
+                    "SELECT data FROM checkpoints WHERE run_id = ?",
+                    (run_id,),
+                ).fetchone()
+            finally:
+                conn.close()
+        if row is None:
+            return None
+        return Checkpoint.from_dict(json.loads(row["data"]))
+
+    def list_runs(self, *, status: str | None = None) -> list[Checkpoint]:
+        sql = "SELECT data FROM checkpoints"
+        params: list[Any] = []
+        if status is not None:
+            sql += " WHERE status = ?"
+            params.append(status)
+        sql += " ORDER BY ts DESC"
+        with self._lock:
+            conn = self._connect()
+            try:
+                rows = conn.execute(sql, params).fetchall()
+            finally:
+                conn.close()
+        return [Checkpoint.from_dict(json.loads(r["data"])) for r in rows]
+
+    def delete(self, run_id: str) -> bool:
+        with self._lock:
+            conn = self._connect()
+            try:
+                cursor = conn.execute(
+                    "DELETE FROM checkpoints WHERE run_id = ?",
+                    (run_id,),
+                )
+                conn.commit()
+                return cursor.rowcount > 0
+            finally:
+                conn.close()

--- a/prompture/checkpoints/types.py
+++ b/prompture/checkpoints/types.py
@@ -1,0 +1,108 @@
+"""Types for checkpointed / resumable runs."""
+
+from __future__ import annotations
+
+import enum
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class RunStatus(str, enum.Enum):
+    """Lifecycle states for a checkpointed run.
+
+    Values are stored as plain strings so backends can persist them
+    portably.  Custom states (e.g. ``"awaiting_approval"``) are
+    permitted — the type is only used for display and filtering.
+    """
+
+    running = "running"
+    paused = "paused"
+    completed = "completed"
+    failed = "failed"
+    cancelled = "cancelled"
+
+
+@dataclass
+class Checkpoint:
+    """A JSON-serialisable snapshot of an in-flight run.
+
+    Attributes:
+        run_id: Stable identifier for the run.  A single run may
+            produce many checkpoints over its lifetime; each save
+            overwrites the previous record for the same ``run_id``
+            unless the backend supports versioned history.
+        id: Per-snapshot id (auto-generated UUID4 hex).
+        agent_name: Optional name of the producing agent.
+        model: Model string in ``"provider/model"`` form.
+        messages: Conversation message history.
+        usage: Aggregate usage summary (typically the output of
+            :meth:`UsageSession.summary`).
+        iteration: Current iteration/tool-round/tick index.
+        status: Lifecycle state.  See :class:`RunStatus`.
+        prompt: The original user prompt that started the run.
+        partial_output: Any partially-generated output worth persisting
+            (a streaming text buffer, an incomplete JSON parse, etc.).
+        system_prompt: Captured system prompt so the restored
+            conversation has the same priming.
+        ts: Wall-clock timestamp of the snapshot.
+        version: Snapshot schema version.  Bumped if the on-disk shape
+            changes incompatibly.
+        metadata: Free-form caller-supplied payload (todos, sub-agent
+            specs, retrieval context, etc.).
+    """
+
+    run_id: str
+    messages: list[dict[str, Any]] = field(default_factory=list)
+    usage: dict[str, Any] = field(default_factory=dict)
+    iteration: int = 0
+    status: str = RunStatus.running.value
+    prompt: str = ""
+    partial_output: str = ""
+    system_prompt: str | None = None
+    agent_name: str | None = None
+    model: str | None = None
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    ts: float = field(default_factory=time.time)
+    version: int = 1
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-serialisable representation."""
+        return {
+            "version": self.version,
+            "id": self.id,
+            "run_id": self.run_id,
+            "agent_name": self.agent_name,
+            "model": self.model,
+            "system_prompt": self.system_prompt,
+            "messages": self.messages,
+            "usage": self.usage,
+            "iteration": self.iteration,
+            "status": self.status,
+            "prompt": self.prompt,
+            "partial_output": self.partial_output,
+            "ts": self.ts,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Checkpoint:
+        """Inverse of :meth:`to_dict`.  Unknown keys are ignored."""
+        return cls(
+            run_id=data["run_id"],
+            id=data.get("id", uuid.uuid4().hex),
+            agent_name=data.get("agent_name"),
+            model=data.get("model"),
+            system_prompt=data.get("system_prompt"),
+            messages=list(data.get("messages") or []),
+            usage=dict(data.get("usage") or {}),
+            iteration=int(data.get("iteration", 0)),
+            status=data.get("status", RunStatus.running.value),
+            prompt=data.get("prompt", ""),
+            partial_output=data.get("partial_output", ""),
+            ts=float(data.get("ts", time.time())),
+            version=int(data.get("version", 1)),
+            metadata=dict(data.get("metadata") or {}),
+        )

--- a/prompture/citations/__init__.py
+++ b/prompture/citations/__init__.py
@@ -1,0 +1,44 @@
+"""Citation grounding for Prompture.
+
+Adds claim-level provenance on top of the existing
+:mod:`prompture.rag` retrievers and :class:`~prompture.rag.RAGAnswer`:
+
+- :class:`Source` — a single retrieved passage with a stable id.
+- :class:`Citation` — a span of generated text linked to one or more
+  :class:`Source` ids.
+- :class:`CitedAnswer` — final answer text + sources + citation list
+  + aggregated coverage statistics.
+- :class:`CitationTracker` — wraps a retriever, formats a citation-aware
+  context for the LLM, and parses the response back into typed
+  citations.
+- :func:`extract_citations` — standalone parser for ``[n]``-style
+  bracketed references against a list of sources.
+
+Drops into existing code:
+
+- Wrap any :class:`~prompture.rag.Retriever` to produce ``Source`` ids.
+- Use :meth:`CitationTracker.build_prompt` to assemble a
+  citation-instructed prompt.
+- Parse the LLM response with :meth:`CitationTracker.parse_response` or
+  the free function :func:`extract_citations`.
+"""
+
+from .core import (
+    CITATION_INSTRUCTION,
+    CitationTracker,
+    extract_citations,
+)
+from .types import (
+    Citation,
+    CitedAnswer,
+    Source,
+)
+
+__all__ = [
+    "CITATION_INSTRUCTION",
+    "Citation",
+    "CitationTracker",
+    "CitedAnswer",
+    "Source",
+    "extract_citations",
+]

--- a/prompture/citations/core.py
+++ b/prompture/citations/core.py
@@ -1,0 +1,294 @@
+"""Citation tracker and parser.
+
+The tracker is intentionally retriever-agnostic: pass any iterable of
+:class:`~prompture.rag.Document`, :class:`~prompture.rag.VectorSearchResult`,
+or already-built :class:`Source` records.  It assigns stable ids,
+formats a citation-instructed prompt, and parses the LLM output back
+into typed :class:`Citation` records.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
+
+from .types import Citation, CitedAnswer, Source
+
+if TYPE_CHECKING:
+    from ..rag.documents import Document
+    from ..rag.vectorstores.base import VectorSearchResult
+
+
+CITATION_INSTRUCTION = (
+    "Answer the question using ONLY the numbered sources below. "
+    "Cite every factual claim by appending the source number(s) in square "
+    "brackets immediately after the sentence — e.g. 'Paris is the capital "
+    "of France [1].' or 'Both routes are viable [2, 5].'. "
+    "If the sources do not contain enough information, say so explicitly "
+    "and do not cite anything for that sentence."
+)
+
+_BRACKET_RE = re.compile(r"\[(\d+(?:\s*,\s*\d+)*)\]")
+_SENTENCE_END_RE = re.compile(r"(?<=[.!?])\s+|\n+")
+
+
+def _coerce_sources(items: Iterable[Any], *, start: int = 1) -> list[Source]:
+    """Coerce mixed inputs into a normalised :class:`Source` list.
+
+    Accepted item types:
+
+    - :class:`Source` — used as-is.
+    - :class:`~prompture.rag.documents.Document` — id assigned in order,
+      score left ``None``.
+    - :class:`~prompture.rag.vectorstores.base.VectorSearchResult` —
+      score preserved.
+    - Any object exposing ``content`` and a ``metadata`` mapping — duck
+      typed; matches the loose ``Document``-shaped objects used in
+      tests.
+
+    Sources keep stable string ids starting at *start* (default 1).
+    """
+    out: list[Source] = []
+    next_id = start
+    for item in items:
+        if isinstance(item, Source):
+            out.append(item)
+            continue
+
+        text: str | None = None
+        title: str | None = None
+        url: str | None = None
+        score: float | None = None
+        metadata: dict[str, Any] = {}
+
+        # VectorSearchResult shape: document + score
+        if hasattr(item, "document") and hasattr(item, "score"):
+            doc = item.document
+            text = getattr(doc, "content", None)
+            metadata = dict(getattr(doc, "metadata", {}) or {})
+            score = float(item.score) if item.score is not None else None
+        else:
+            text = getattr(item, "content", None)
+            metadata = dict(getattr(item, "metadata", {}) or {})
+
+        if text is None:
+            raise TypeError(
+                f"Cannot derive source text from {type(item).__name__}; "
+                "supply a Source, Document, or VectorSearchResult."
+            )
+
+        title = metadata.get("title") or metadata.get("source")
+        url = metadata.get("url")
+
+        out.append(
+            Source(
+                id=str(next_id),
+                text=text,
+                title=title,
+                url=url,
+                score=score,
+                metadata=metadata,
+            )
+        )
+        next_id += 1
+    return out
+
+
+def _split_source_ids(group: str) -> list[str]:
+    """Parse the comma-separated id list inside a ``[...]`` marker."""
+    return [s.strip() for s in group.split(",") if s.strip()]
+
+
+def _claim_before(text: str, marker_start: int) -> tuple[str, int]:
+    """Return the sentence (or fragment) ending immediately before *marker_start*.
+
+    Scans backwards from the bracket position to the previous sentence
+    boundary (``.``, ``!``, ``?``, or a newline), returning that span
+    and its start offset in the original text.
+    """
+    upto = text[:marker_start]
+    boundaries = list(_SENTENCE_END_RE.finditer(upto))
+    if boundaries:
+        last = boundaries[-1]
+        claim_start = last.end()
+    else:
+        claim_start = 0
+    claim = upto[claim_start:].strip()
+    return claim, claim_start
+
+
+def extract_citations(text: str, sources: Iterable[Source]) -> tuple[list[Citation], str, set[str]]:
+    """Pull bracketed citation markers out of *text*.
+
+    Args:
+        text: Raw LLM output containing ``[n]`` or ``[n,m]`` markers.
+        sources: The sources made available to the LLM.  Markers
+            referencing ids outside this set are still recorded (they
+            indicate a hallucinated reference) but those ids appear in
+            the returned :class:`Citation.source_ids` unchanged so
+            callers can detect the divergence.
+
+    Returns:
+        A tuple ``(citations, clean_text, cited_ids)`` where
+        ``clean_text`` is *text* with every ``[...]`` marker stripped
+        and ``cited_ids`` is the set of ids that actually appear in at
+        least one valid marker.
+    """
+    sources_by_id = {s.id: s for s in sources}
+    citations: list[Citation] = []
+    cited: set[str] = set()
+
+    for match in _BRACKET_RE.finditer(text):
+        ids = _split_source_ids(match.group(1))
+        claim, claim_start = _claim_before(text, match.start())
+        citations.append(
+            Citation(
+                text=claim,
+                source_ids=ids,
+                start=claim_start,
+                end=match.end(),
+                marker=match.group(0),
+            )
+        )
+        for sid in ids:
+            if sid in sources_by_id:
+                cited.add(sid)
+
+    clean = _BRACKET_RE.sub("", text)
+    # Collapse the double spaces left where ``foo [1] bar`` becomes ``foo  bar``.
+    clean = re.sub(r"[ \t]+", " ", clean).strip()
+    return citations, clean, cited
+
+
+class CitationTracker:
+    """Assigns ids to sources, formats a prompt, and parses citations back out.
+
+    Use directly when you want fine control over how the LLM is invoked
+    (e.g. plugging into :class:`~prompture.agents.Agent`,
+    :class:`~prompture.agents.Conversation`, or a custom driver loop).
+    For end-to-end RAG with citations, compose with
+    :class:`~prompture.rag.RAGPipeline`.
+
+    Args:
+        sources: Any iterable of :class:`Source`, :class:`Document`, or
+            :class:`VectorSearchResult` items.  Ids are assigned in
+            iteration order starting at 1.
+        instruction: Citation directive prepended to the formatted
+            context.  Defaults to :data:`CITATION_INSTRUCTION`.
+        question: Optional question text appended after the context.
+            When ``None`` the prompt ends after the context block — the
+            caller is responsible for adding the question.
+
+    Example::
+
+        tracker = CitationTracker.from_retrieval_results(results)
+        prompt = tracker.build_prompt(question="Who founded the city?")
+        response = driver.generate(prompt, {})
+        answer = tracker.parse_response(response["text"])
+        for c in answer.citations:
+            print(c.text, "→", c.source_ids)
+    """
+
+    def __init__(
+        self,
+        sources: Iterable[Source | Document | VectorSearchResult | Any] | None = None,
+        *,
+        instruction: str = CITATION_INSTRUCTION,
+        question: str | None = None,
+    ) -> None:
+        self._sources: list[Source] = _coerce_sources(sources) if sources is not None else []
+        self._instruction = instruction
+        self._question = question
+
+    # ------------------------------------------------------------------
+    # Constructors
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_retrieval_results(
+        cls,
+        results: Iterable[VectorSearchResult],
+        *,
+        instruction: str = CITATION_INSTRUCTION,
+        question: str | None = None,
+    ) -> CitationTracker:
+        """Build a tracker from raw retriever output."""
+        return cls(sources=results, instruction=instruction, question=question)
+
+    @classmethod
+    def from_documents(
+        cls,
+        documents: Iterable[Document],
+        *,
+        instruction: str = CITATION_INSTRUCTION,
+        question: str | None = None,
+    ) -> CitationTracker:
+        """Build a tracker from :class:`~prompture.rag.Document` objects."""
+        return cls(sources=documents, instruction=instruction, question=question)
+
+    # ------------------------------------------------------------------
+    # Read-only state
+    # ------------------------------------------------------------------
+
+    @property
+    def sources(self) -> list[Source]:
+        """Return a copy of the source list (ids are stable strings)."""
+        return list(self._sources)
+
+    def add_source(self, source: Source | Document | VectorSearchResult | Any) -> Source:
+        """Append a new source and return the typed :class:`Source` record."""
+        coerced = _coerce_sources([source], start=len(self._sources) + 1)[0]
+        self._sources.append(coerced)
+        return coerced
+
+    # ------------------------------------------------------------------
+    # Prompt assembly
+    # ------------------------------------------------------------------
+
+    def build_context(self) -> str:
+        """Render the numbered source block fed to the LLM."""
+        if not self._sources:
+            return "(no sources available)"
+        return "\n\n".join(s.as_context_line() for s in self._sources)
+
+    def build_prompt(self, question: str | None = None) -> str:
+        """Render the full citation-instructed prompt.
+
+        Layout::
+
+            <instruction>
+
+            Sources:
+            [1] title
+            text...
+
+            [2] title
+            text...
+
+            Question: <question>
+
+        When neither *question* nor the tracker's stored question is
+        set, the ``Question:`` line is omitted.
+        """
+        q = question if question is not None else self._question
+        parts: list[str] = [self._instruction.strip(), "", "Sources:", self.build_context()]
+        if q:
+            parts.extend(["", f"Question: {q}"])
+        return "\n".join(parts)
+
+    # ------------------------------------------------------------------
+    # Response parsing
+    # ------------------------------------------------------------------
+
+    def parse_response(self, text: str, *, usage: dict[str, Any] | None = None) -> CitedAnswer:
+        """Parse *text* into a :class:`CitedAnswer` using this tracker's sources."""
+        citations, clean, cited = extract_citations(text, self._sources)
+        return CitedAnswer(
+            answer=text,
+            clean_answer=clean,
+            citations=citations,
+            sources=list(self._sources),
+            cited_source_ids=cited,
+            usage=dict(usage) if usage else {},
+        )

--- a/prompture/citations/types.py
+++ b/prompture/citations/types.py
@@ -1,0 +1,148 @@
+"""Types for citation tracking."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Source:
+    """A single citable passage.
+
+    Attributes:
+        id: Short identifier the LLM is asked to cite (e.g. ``"1"``,
+            ``"2"``).  Stable for the lifetime of a single
+            :class:`~prompture.citations.CitationTracker` invocation.
+        text: The full passage text fed to the LLM.
+        title: Optional human-readable title (filename, document title).
+        url: Optional URL of the source document.
+        score: Optional retrieval score, ``None`` when the source did
+            not come from a scored retriever.
+        metadata: Free-form metadata copied from the underlying
+            :class:`~prompture.rag.Document` (page numbers, section
+            headings, etc.).
+    """
+
+    id: str
+    text: str
+    title: str | None = None
+    url: str | None = None
+    score: float | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def as_context_line(self) -> str:
+        """Render this source as a single ``[id] title — text`` line."""
+        head = f"[{self.id}]"
+        if self.title:
+            head += f" {self.title}"
+        return f"{head}\n{self.text}"
+
+
+@dataclass
+class Citation:
+    """A span of generated text linked to one or more :class:`Source` ids.
+
+    Citations are produced by :func:`~prompture.citations.extract_citations`
+    from bracketed references in the LLM's output.
+
+    Attributes:
+        text: The cited claim — the sentence (or fragment) immediately
+            preceding the bracket reference.
+        source_ids: List of source identifiers cited at this span.
+        start: Character offset of the claim's start in the original
+            answer text.
+        end: Character offset (exclusive) of the bracket marker's end.
+        marker: The literal bracket text from the LLM output
+            (e.g. ``"[1]"``, ``"[1,3]"``).
+    """
+
+    text: str
+    source_ids: list[str]
+    start: int
+    end: int
+    marker: str = ""
+
+    def first_source(self) -> str | None:
+        """Convenience accessor for the first cited source id."""
+        return self.source_ids[0] if self.source_ids else None
+
+
+@dataclass
+class CitedAnswer:
+    """A citation-grounded answer.
+
+    Sits next to :class:`~prompture.rag.RAGAnswer` and is the recommended
+    return type from any flow where the user-facing claim should be
+    traceable to retrieved passages.
+
+    Attributes:
+        answer: The final answer text as written by the LLM, with the
+            bracketed citation markers preserved.
+        clean_answer: ``answer`` with bracket markers stripped — what
+            you'd render in a UI when citations are surfaced separately.
+        citations: Ordered list of :class:`Citation` records.
+        sources: Every source supplied to the LLM (cited or not).
+        cited_source_ids: Set of source ids that were referenced at
+            least once.  Useful for "footnotes" UI rendering.
+        usage: Optional token / cost summary from the LLM call.
+    """
+
+    answer: str
+    clean_answer: str
+    citations: list[Citation] = field(default_factory=list)
+    sources: list[Source] = field(default_factory=list)
+    cited_source_ids: set[str] = field(default_factory=set)
+    usage: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def coverage(self) -> float:
+        """Fraction of supplied sources that the answer actually cited.
+
+        Returns 0.0 when there are no sources.  Useful for evaluating
+        whether the LLM grounded its answer or hallucinated.
+        """
+        if not self.sources:
+            return 0.0
+        return len(self.cited_source_ids) / len(self.sources)
+
+    @property
+    def is_grounded(self) -> bool:
+        """``True`` when the answer contains at least one citation."""
+        return bool(self.citations)
+
+    def uncited_sources(self) -> list[Source]:
+        """Return sources that were supplied but never cited."""
+        return [s for s in self.sources if s.id not in self.cited_source_ids]
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-serialisable representation."""
+        return {
+            "answer": self.answer,
+            "clean_answer": self.clean_answer,
+            "citations": [
+                {
+                    "text": c.text,
+                    "source_ids": c.source_ids,
+                    "start": c.start,
+                    "end": c.end,
+                    "marker": c.marker,
+                }
+                for c in self.citations
+            ],
+            "sources": [
+                {
+                    "id": s.id,
+                    "title": s.title,
+                    "url": s.url,
+                    "score": s.score,
+                    "text": s.text,
+                    "metadata": s.metadata,
+                }
+                for s in self.sources
+            ],
+            "cited_source_ids": sorted(self.cited_source_ids),
+            "coverage": self.coverage,
+            "is_grounded": self.is_grounded,
+            "usage": self.usage,
+        }

--- a/prompture/cli/server.py
+++ b/prompture/cli/server.py
@@ -22,6 +22,18 @@ Plus Prompture-native endpoints:
 ``fastapi``, ``uvicorn``, and ``sse-starlette`` are lazy-imported so the
 module is importable without them installed.
 
+Single-worker constraint
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``_conversations`` and the rate-limit token buckets live in
+**per-process memory**. Running with ``uvicorn --workers N`` where
+``N > 1`` will partition conversations across workers: a request that
+creates conversation ``abc`` on worker 1 followed by a turn that the
+load-balancer routes to worker 2 returns 404. **Run with
+``--workers 1`` (the default) until conversation state is moved to a
+shared backend (Redis / Postgres / etc.).** A multi-worker-safe
+backend is on the roadmap.
+
 Example::
 
     from openai import OpenAI
@@ -37,7 +49,7 @@ import logging
 import time
 import uuid
 from collections import OrderedDict
-from typing import Any, Optional
+from typing import Any
 
 from .._internal.json_encoder import PromptureJSONEncoder
 
@@ -46,13 +58,13 @@ logger = logging.getLogger("prompture.server")
 
 def create_app(
     model_name: str = "openai/gpt-4o-mini",
-    system_prompt: Optional[str] = None,
+    system_prompt: str | None = None,
     tools: Any = None,
-    cors_origins: Optional[list[str]] = None,
-    api_key: Optional[str] = None,
+    cors_origins: list[str] | None = None,
+    api_key: str | None = None,
     max_conversations: int = 1000,
-    allowed_models: Optional[list[str]] = None,
-    rate_limit: Optional[int] = None,
+    allowed_models: list[str] | None = None,
+    rate_limit: int | None = None,
 ) -> Any:
     """Create and return a FastAPI application.
 
@@ -72,6 +84,13 @@ def create_app(
             requests for models outside the list return 403.
         rate_limit: Maximum requests per minute per client IP.  ``None``
             (default) disables rate limiting.
+
+    Note:
+        The returned app keeps conversations and rate-limit buckets in
+        per-process memory. Running multiple uvicorn workers will
+        partition state across processes — same ``conversation_id``
+        can hit a worker that doesn't know about it. Use
+        ``--workers 1`` until shared-state backends land.
     """
     try:
         from fastapi import Depends, FastAPI, HTTPException, Request
@@ -99,6 +118,12 @@ def create_app(
     if api_key is None:
         logger.warning("Server starting without API key authentication — set --api-key to require Bearer auth")
 
+    logger.info(
+        "Server uses in-process state for conversations and rate-limit buckets — "
+        "run with --workers 1 (the default) or conversation_id lookups will return 404 "
+        "when load-balanced across processes."
+    )
+
     # ---- Rate limiting dependency ----
 
     _rate_buckets: dict[str, list[float]] = {}
@@ -123,9 +148,9 @@ def create_app(
 
     class ChatRequest(BaseModel):
         message: str = Field(..., max_length=500_000)
-        conversation_id: Optional[str] = Field(None, max_length=64, pattern=r"^[a-zA-Z0-9_-]+$")
+        conversation_id: str | None = Field(None, max_length=64, pattern=r"^[a-zA-Z0-9_-]+$")
         stream: bool = False
-        options: Optional[dict[str, Any]] = None
+        options: dict[str, Any] | None = None
 
     class ChatResponse(BaseModel):
         message: str
@@ -135,7 +160,7 @@ def create_app(
     class ExtractRequest(BaseModel):
         text: str = Field(..., max_length=500_000)
         schema_def: dict[str, Any] = Field(..., alias="schema")
-        conversation_id: Optional[str] = Field(None, max_length=64, pattern=r"^[a-zA-Z0-9_-]+$")
+        conversation_id: str | None = Field(None, max_length=64, pattern=r"^[a-zA-Z0-9_-]+$")
         model_config = {"populate_by_name": True}
 
     class ExtractResponse(BaseModel):
@@ -152,57 +177,57 @@ def create_app(
 
     class OAIMessage(BaseModel):
         role: str
-        content: Optional[Any] = None  # str or list (multipart) — kept loose
-        name: Optional[str] = None
-        tool_call_id: Optional[str] = None
-        tool_calls: Optional[list[dict[str, Any]]] = None
+        content: Any | None = None  # str or list (multipart) — kept loose
+        name: str | None = None
+        tool_call_id: str | None = None
+        tool_calls: list[dict[str, Any]] | None = None
 
     class OAIChatRequest(BaseModel):
-        model: Optional[str] = None
+        model: str | None = None
         messages: list[OAIMessage] = Field(..., max_length=500)
-        temperature: Optional[float] = None
-        top_p: Optional[float] = None
-        max_tokens: Optional[int] = None
+        temperature: float | None = None
+        top_p: float | None = None
+        max_tokens: int | None = None
         stream: bool = False
         n: int = 1
-        tools: Optional[list[dict[str, Any]]] = None
-        tool_choice: Optional[Any] = None
-        stop: Optional[Any] = None
-        presence_penalty: Optional[float] = None
-        frequency_penalty: Optional[float] = None
-        user: Optional[str] = None
+        tools: list[dict[str, Any]] | None = None
+        tool_choice: Any | None = None
+        stop: Any | None = None
+        presence_penalty: float | None = None
+        frequency_penalty: float | None = None
+        user: str | None = None
 
     class OAICompletionsRequest(BaseModel):
-        model: Optional[str] = None
+        model: str | None = None
         prompt: Any  # str or list
-        temperature: Optional[float] = None
-        top_p: Optional[float] = None
-        max_tokens: Optional[int] = None
+        temperature: float | None = None
+        top_p: float | None = None
+        max_tokens: int | None = None
         stream: bool = False
-        stop: Optional[Any] = None
+        stop: Any | None = None
 
     class OAIEmbeddingsRequest(BaseModel):
-        model: Optional[str] = None
+        model: str | None = None
         input: Any  # str or list[str]
-        encoding_format: Optional[str] = None
-        user: Optional[str] = None
+        encoding_format: str | None = None
+        user: str | None = None
 
     class OAIImageGenRequest(BaseModel):
-        model: Optional[str] = None
+        model: str | None = None
         prompt: str
         n: int = 1
-        size: Optional[str] = "1024x1024"
-        quality: Optional[str] = "standard"
-        style: Optional[str] = None
-        response_format: Optional[str] = "url"  # "url" | "b64_json"
-        user: Optional[str] = None
+        size: str | None = "1024x1024"
+        quality: str | None = "standard"
+        style: str | None = None
+        response_format: str | None = "url"  # "url" | "b64_json"
+        user: str | None = None
 
     class OAISpeechRequest(BaseModel):
-        model: Optional[str] = None
+        model: str | None = None
         input: str = Field(..., max_length=4096)
-        voice: Optional[str] = None
-        response_format: Optional[str] = None  # mp3, opus, wav, ...
-        speed: Optional[float] = None
+        voice: str | None = None
+        response_format: str | None = None  # mp3, opus, wav, ...
+        speed: float | None = None
 
     # ---- App ----
 
@@ -224,7 +249,7 @@ def create_app(
     # In-memory conversation store
     _conversations: OrderedDict[str, AsyncConversation] = OrderedDict()
 
-    tool_registry: Optional[ToolRegistry] = tools
+    tool_registry: ToolRegistry | None = tools
 
     # ---- Helpers ----
 
@@ -235,7 +260,7 @@ def create_app(
                 detail=f"Model '{model}' is not in the allowed models list",
             )
 
-    def _get_or_create_conversation(conv_id: Optional[str]) -> tuple[str, AsyncConversation]:
+    def _get_or_create_conversation(conv_id: str | None) -> tuple[str, AsyncConversation]:
         if conv_id and conv_id in _conversations:
             _conversations.move_to_end(conv_id)
             return conv_id, _conversations[conv_id]
@@ -262,7 +287,7 @@ def create_app(
         can pass it (with any extracted images) to ``conv.ask()``.
         """
         # Find the index of the final user message.
-        final_user_idx: Optional[int] = None
+        final_user_idx: int | None = None
         for i in range(len(messages) - 1, -1, -1):
             if messages[i].role == "user":
                 final_user_idx = i
@@ -273,7 +298,7 @@ def create_app(
         final_msg = messages[final_user_idx]
         last_user_content = _flatten_content(final_msg.content)
         last_user_images = _extract_images(final_msg.content)
-        last_system: Optional[str] = None
+        last_system: str | None = None
 
         for i, msg in enumerate(messages):
             if i == final_user_idx:
@@ -517,7 +542,7 @@ def create_app(
 
         # Surface tool_calls from the last assistant message if the
         # model emitted them without server-side execution.
-        assistant_tool_calls: Optional[list[dict[str, Any]]] = None
+        assistant_tool_calls: list[dict[str, Any]] | None = None
         finish_reason = "stop"
         if conv._messages:
             last_msg = conv._messages[-1]
@@ -745,9 +770,9 @@ def create_app(
     async def openai_audio_transcriptions(
         file: UploadFile = File(...),  # noqa: B008 — FastAPI dependency idiom
         model: str = Form(default=""),
-        language: Optional[str] = Form(default=None),
-        prompt: Optional[str] = Form(default=None),
-        response_format: Optional[str] = Form(default=None),
+        language: str | None = Form(default=None),
+        prompt: str | None = Form(default=None),
+        response_format: str | None = Form(default=None),
     ) -> Any:
         """Speech-to-text — routes to ``get_async_stt_driver_for_model``.
 
@@ -814,14 +839,14 @@ def create_app(
     class CodingAgentRunRequest(BaseModel):
         agent: str
         task: str
-        cwd: Optional[str] = None
+        cwd: str | None = None
         approval_mode: str = "default"
-        model: Optional[str] = None
-        extra_args: Optional[list[str]] = None
+        model: str | None = None
+        extra_args: list[str] | None = None
         timeout: int = 600
         stream: bool = False
         output_format: str = "text"
-        session_id: Optional[str] = None
+        session_id: str | None = None
 
     @app.post("/v1/coding-agents/run")
     async def run_coding_agent_endpoint(req: CodingAgentRunRequest, _: None = Depends(_verify_api_key)) -> Any:

--- a/prompture/cli/server.py
+++ b/prompture/cli/server.py
@@ -39,6 +39,8 @@ import uuid
 from collections import OrderedDict
 from typing import Any, Optional
 
+from .._internal.json_encoder import PromptureJSONEncoder
+
 logger = logging.getLogger("prompture.server")
 
 
@@ -854,7 +856,7 @@ def create_app(
                         extra_args=req.extra_args,
                         session_id=req.session_id,
                     ):
-                        yield {"data": json.dumps(asdict(event), default=str)}
+                        yield {"data": json.dumps(asdict(event), cls=PromptureJSONEncoder)}
                 except ValueError as exc:
                     yield {"data": json.dumps({"type": "error", "error": str(exc)})}
                 yield {"data": json.dumps({"type": "stream_end"})}

--- a/prompture/dataset/__init__.py
+++ b/prompture/dataset/__init__.py
@@ -18,16 +18,49 @@ The output is ready to feed into Unsloth, Axolotl, TRL, or any other
 fine-tuning framework that consumes one of the three formats.
 """
 
+from .dedup import (
+    DedupConfig,
+    apply_dedup,
+    dedup_exact,
+    dedup_semantic,
+    dedup_shingle,
+)
+from .evol import EvolInstruct, EvolOperator, EvolResult
+from .filters import (
+    FilterDecision,
+    FilterStats,
+    QualityFilter,
+    length_filter,
+    refusal_filter,
+    shape_filter,
+)
 from .formats import to_alpaca, to_jsonl, to_sharegpt, write_dataset
 from .schemas import ChatTurn, InstructionPair, QAPair
+from .seed import SelfInstruct, SelfInstructResult
 from .synth import agenerate_qa_dataset, generate_qa_dataset
 
 __all__ = [
     "ChatTurn",
+    "DedupConfig",
+    "EvolInstruct",
+    "EvolOperator",
+    "EvolResult",
+    "FilterDecision",
+    "FilterStats",
     "InstructionPair",
     "QAPair",
+    "QualityFilter",
+    "SelfInstruct",
+    "SelfInstructResult",
     "agenerate_qa_dataset",
+    "apply_dedup",
+    "dedup_exact",
+    "dedup_semantic",
+    "dedup_shingle",
     "generate_qa_dataset",
+    "length_filter",
+    "refusal_filter",
+    "shape_filter",
     "to_alpaca",
     "to_jsonl",
     "to_sharegpt",

--- a/prompture/dataset/dedup.py
+++ b/prompture/dataset/dedup.py
@@ -1,0 +1,344 @@
+"""Dataset deduplication — exact, shingle, and semantic strategies.
+
+Three modes (cheapest first, swap up as the dataset grows or precision
+matters):
+
+* :func:`dedup_exact` — normalised string equality on the question field.
+  O(n). Drops only carbon-copy duplicates. The legacy behaviour.
+* :func:`dedup_shingle` — Jaccard similarity on character k-shingles.
+  O(n²) with an early-exit threshold; fast enough for ~50k items.
+  Catches paraphrased duplicates that exact-matching misses
+  ("What is the capital of France?" vs "What is France's capital?").
+* :func:`dedup_semantic` — embedding-cosine threshold using any embedder
+  that matches the :func:`prompture.extraction.few_shot.FewShotExampleStore`
+  contract. Catches deep paraphrases that share little surface form.
+
+All three preserve insertion order — the first occurrence wins.
+``dedup_*`` functions return ``(kept_pairs, removed_count)`` so
+pipelines can log a drop rate.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Shared key extraction
+# ---------------------------------------------------------------------------
+
+
+def _default_key(pair: Any) -> str:
+    """Return the canonical 'identity' text for a pair.
+
+    Uses the question / instruction field — that's typically what
+    duplicates collide on. Override via the ``key`` argument when
+    you want answer-side dedup or a custom key.
+    """
+    if hasattr(pair, "question"):
+        return str(pair.question or "")
+    if hasattr(pair, "instruction"):
+        return str(pair.instruction or "")
+    if isinstance(pair, dict):
+        return str(pair.get("question") or pair.get("instruction") or "")
+    return str(pair)
+
+
+_NORMALISE_PUNCT = re.compile(r"[^\w\s]")
+
+
+def _normalise(text: str) -> str:
+    """Lowercase, strip punctuation, collapse whitespace.
+
+    Used by exact and shingle dedup so trivial cosmetic variants
+    bucket together.
+    """
+    text = text.casefold()
+    text = _NORMALISE_PUNCT.sub(" ", text)
+    return " ".join(text.split())
+
+
+# ---------------------------------------------------------------------------
+# 1. Exact dedup
+# ---------------------------------------------------------------------------
+
+
+def dedup_exact(
+    pairs: list[Any],
+    *,
+    key: Callable[[Any], str] = _default_key,
+) -> tuple[list[Any], int]:
+    """Drop pairs whose normalised key has been seen.
+
+    Same algorithm as the legacy ``_dedupe`` in ``synth.py`` but
+    promoted to a public function so it composes with the other
+    strategies.
+    """
+    seen: set[str] = set()
+    kept: list[Any] = []
+    removed = 0
+    for pair in pairs:
+        k = _normalise(key(pair))
+        if not k:
+            continue
+        if k in seen:
+            removed += 1
+            continue
+        seen.add(k)
+        kept.append(pair)
+    return kept, removed
+
+
+# ---------------------------------------------------------------------------
+# 2. Shingle / Jaccard near-dup
+# ---------------------------------------------------------------------------
+
+
+def _shingles(text: str, k: int) -> set[str]:
+    """Return the set of overlapping character k-shingles for ``text``.
+
+    Pads with two leading/trailing spaces so the first/last few
+    characters get full coverage.
+    """
+    if k <= 0:
+        return set()
+    padded = f"  {text}  "
+    if len(padded) < k:
+        return {padded}
+    return {padded[i : i + k] for i in range(len(padded) - k + 1)}
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    if not a or not b:
+        return 0.0
+    inter = len(a & b)
+    if inter == 0:
+        return 0.0
+    return inter / len(a | b)
+
+
+def dedup_shingle(
+    pairs: list[Any],
+    *,
+    key: Callable[[Any], str] = _default_key,
+    threshold: float = 0.8,
+    shingle_size: int = 5,
+) -> tuple[list[Any], int]:
+    """Drop pairs whose key shingle-Jaccard exceeds ``threshold`` vs. any prior kept pair.
+
+    Args:
+        pairs: Items to deduplicate.
+        key: Extracts the comparison string from each item.
+        threshold: Jaccard similarity above which two items are
+            considered duplicates. 0.8 catches paraphrases with strong
+            shared phrasing; 0.6 catches looser similarity at the cost
+            of some false positives.
+        shingle_size: Character window size for k-shingles. Larger
+            values are more conservative (require longer shared
+            substrings); 5 is a reasonable default.
+
+    Returns:
+        ``(kept, removed_count)``. ``kept`` preserves the original
+        order — the first occurrence of any near-duplicate wins.
+    """
+    kept_shingles: list[set[str]] = []
+    kept: list[Any] = []
+    removed = 0
+    for pair in pairs:
+        norm_key = _normalise(key(pair))
+        if not norm_key:
+            continue
+        shings = _shingles(norm_key, shingle_size)
+        is_dup = False
+        for prior in kept_shingles:
+            if _jaccard(shings, prior) >= threshold:
+                is_dup = True
+                break
+        if is_dup:
+            removed += 1
+        else:
+            kept.append(pair)
+            kept_shingles.append(shings)
+    return kept, removed
+
+
+# ---------------------------------------------------------------------------
+# 3. Semantic / embedding dedup
+# ---------------------------------------------------------------------------
+
+
+class _Embedder(Protocol):
+    """Minimal embedder contract — matches :class:`EmbeddingDriver`."""
+
+    def embed(self, texts: list[str], options: dict[str, Any]) -> dict[str, Any]:  # pragma: no cover
+        ...
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = 0.0
+    na = 0.0
+    nb = 0.0
+    for x, y in zip(a, b, strict=False):
+        dot += x * y
+        na += x * x
+        nb += y * y
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (math.sqrt(na) * math.sqrt(nb))
+
+
+def dedup_semantic(
+    pairs: list[Any],
+    *,
+    embedder: _Embedder,
+    key: Callable[[Any], str] = _default_key,
+    threshold: float = 0.92,
+    embed_options: dict[str, Any] | None = None,
+) -> tuple[list[Any], int]:
+    """Drop pairs whose key embeddings are within cosine ``threshold`` of any prior kept pair.
+
+    Uses one batched call to ``embedder.embed`` for the full set, then
+    runs O(n²) cosine comparisons with an early exit per pair. For
+    very large datasets (>50k pairs), swap in a vector store + ANN
+    index instead.
+
+    Args:
+        pairs: Items to deduplicate.
+        embedder: Anything with ``embed(texts, options) -> {"embeddings": ...}``.
+            ``FewShotExampleStore``'s default ``_NgramEmbedder`` works
+            for prototyping; use a real embedding driver in production.
+        key: Extracts the comparison string from each item.
+        threshold: Cosine similarity above which two items are
+            duplicates. 0.92 is conservative (catches deep paraphrases
+            without merging genuinely-different-but-related questions);
+            lower for more aggressive dedup.
+        embed_options: Forwarded to ``embedder.embed``.
+
+    Returns:
+        ``(kept, removed_count)``. Order preserved.
+
+    Raises:
+        ValueError: when ``embedder`` returns the wrong number of
+            vectors or an unexpected shape.
+    """
+    if not pairs:
+        return [], 0
+    texts = [key(p) for p in pairs]
+    # Drop pairs with an empty key first — they'd otherwise force a
+    # zero-vector compare that always reports cosine 0.
+    indexed: list[tuple[int, str]] = [(i, t) for i, t in enumerate(texts) if t.strip()]
+    if not indexed:
+        return [], len(pairs)
+
+    response = embedder.embed([t for _, t in indexed], embed_options or {})
+    if not isinstance(response, dict) or "embeddings" not in response:
+        raise ValueError(
+            "Embedder returned an unexpected shape; expected {'embeddings': [...]}, "
+            f"got {type(response).__name__}."
+        )
+    vectors = response["embeddings"]
+    if len(vectors) != len(indexed):
+        raise ValueError(f"Embedder returned {len(vectors)} vectors for {len(indexed)} inputs.")
+
+    embed_by_idx: dict[int, list[float]] = {idx: list(vec) for (idx, _), vec in zip(indexed, vectors, strict=False)}
+
+    kept: list[Any] = []
+    kept_vecs: list[list[float]] = []
+    removed = 0
+    for i, pair in enumerate(pairs):
+        vec = embed_by_idx.get(i)
+        if vec is None:
+            # Empty key — drop quietly (also matches dedup_exact behaviour).
+            removed += 1
+            continue
+        is_dup = False
+        for prior in kept_vecs:
+            if _cosine(vec, prior) >= threshold:
+                is_dup = True
+                break
+        if is_dup:
+            removed += 1
+        else:
+            kept.append(pair)
+            kept_vecs.append(vec)
+    return kept, removed
+
+
+# ---------------------------------------------------------------------------
+# Unified config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DedupConfig:
+    """Pipeline-friendly dedup configuration.
+
+    Pass an instance to :func:`apply_dedup` (or to the synth pipeline's
+    ``dedup`` parameter) instead of remembering which function to call.
+
+    Attributes:
+        strategy: ``"exact"`` | ``"shingle"`` | ``"semantic"`` | ``"none"``.
+        threshold: Similarity threshold (ignored for ``exact`` / ``none``).
+        shingle_size: Only used when ``strategy == "shingle"``.
+        embedder: Required when ``strategy == "semantic"``.
+        embed_options: Forwarded to the embedder.
+        key: Override the default key extractor (question / instruction).
+    """
+
+    strategy: str = "exact"
+    threshold: float = 0.8
+    shingle_size: int = 5
+    embedder: Any = None
+    embed_options: dict[str, Any] | None = None
+    key: Callable[[Any], str] = _default_key
+
+
+def apply_dedup(pairs: list[Any], config: DedupConfig) -> tuple[list[Any], int]:
+    """Run ``config.strategy`` against ``pairs``; return ``(kept, removed_count)``.
+
+    Use this when you've stored a :class:`DedupConfig` and want a
+    single entry point. ``strategy="none"`` is a no-op pass-through.
+    """
+    if config.strategy == "none":
+        return list(pairs), 0
+    if config.strategy == "exact":
+        return dedup_exact(pairs, key=config.key)
+    if config.strategy == "shingle":
+        return dedup_shingle(
+            pairs,
+            key=config.key,
+            threshold=config.threshold,
+            shingle_size=config.shingle_size,
+        )
+    if config.strategy == "semantic":
+        if config.embedder is None:
+            raise ValueError("DedupConfig(strategy='semantic') requires an `embedder`.")
+        return dedup_semantic(
+            pairs,
+            embedder=config.embedder,
+            key=config.key,
+            threshold=config.threshold,
+            embed_options=config.embed_options,
+        )
+    raise ValueError(
+        f"Unknown dedup strategy {config.strategy!r}. "
+        "Choose 'exact', 'shingle', 'semantic', or 'none'."
+    )
+
+
+__all__ = [
+    "DedupConfig",
+    "apply_dedup",
+    "dedup_exact",
+    "dedup_semantic",
+    "dedup_shingle",
+]

--- a/prompture/dataset/dedup.py
+++ b/prompture/dataset/dedup.py
@@ -242,8 +242,7 @@ def dedup_semantic(
     response = embedder.embed([t for _, t in indexed], embed_options or {})
     if not isinstance(response, dict) or "embeddings" not in response:
         raise ValueError(
-            "Embedder returned an unexpected shape; expected {'embeddings': [...]}, "
-            f"got {type(response).__name__}."
+            f"Embedder returned an unexpected shape; expected {{'embeddings': [...]}}, got {type(response).__name__}."
         )
     vectors = response["embeddings"]
     if len(vectors) != len(indexed):
@@ -329,10 +328,7 @@ def apply_dedup(pairs: list[Any], config: DedupConfig) -> tuple[list[Any], int]:
             threshold=config.threshold,
             embed_options=config.embed_options,
         )
-    raise ValueError(
-        f"Unknown dedup strategy {config.strategy!r}. "
-        "Choose 'exact', 'shingle', 'semantic', or 'none'."
-    )
+    raise ValueError(f"Unknown dedup strategy {config.strategy!r}. Choose 'exact', 'shingle', 'semantic', or 'none'.")
 
 
 __all__ = [

--- a/prompture/dataset/evol.py
+++ b/prompture/dataset/evol.py
@@ -217,7 +217,7 @@ class EvolInstruct:
         self.model = model
         self.operator_prompts = dict(prompts)
         self.options = dict(options) if options is not None else {"temperature": 0.7, "max_tokens": 512}
-        self._rng = random.Random(seed)
+        self._rng = random.Random(seed)  # nosec B311 - non-cryptographic dataset sampling
 
     # ------------------------------------------------------------------
     # Public API

--- a/prompture/dataset/evol.py
+++ b/prompture/dataset/evol.py
@@ -211,9 +211,7 @@ class EvolInstruct:
                 raise ValueError(f"operator_prompts missing required key {op!r}.")
             tpl = prompts[op]
             if "{question}" not in tpl or "{answer}" not in tpl:
-                raise ValueError(
-                    f"operator_prompts[{op!r}] must contain '{{question}}' and '{{answer}}' placeholders."
-                )
+                raise ValueError(f"operator_prompts[{op!r}] must contain '{{question}}' and '{{answer}}' placeholders.")
         self.model = model
         self.operator_prompts = dict(prompts)
         self.options = dict(options) if options is not None else {"temperature": 0.7, "max_tokens": 512}

--- a/prompture/dataset/evol.py
+++ b/prompture/dataset/evol.py
@@ -1,0 +1,327 @@
+"""Evol-Instruct — LLM-driven evolution of Q&A pairs along quality axes.
+
+Based on `WizardLM's Evol-Instruct <https://arxiv.org/abs/2304.12244>`_:
+take an existing (question, answer) pair and ask an LLM to rewrite it
+along one of three axes:
+
+* **DEPTH** — make the question more specific, add a constraint, or
+  require a more detailed answer.
+* **BREADTH** — broaden the question's scope (related topic, sibling
+  concept).
+* **REASONING** — turn a recall question into one that demands
+  multi-step inference.
+
+Each evolution is one LLM call, producing one new pair. Compose with
+the existing ``generate_qa_dataset`` output to multiply your training
+set by 2-4× without re-running the expensive ingestion pipeline.
+
+Quick start::
+
+    from prompture.dataset.evol import EvolInstruct
+
+    evol = EvolInstruct(model="openai/gpt-4o")
+    evolved = evol.evolve_batch(qa_pairs, operators=["depth", "breadth"], rounds=1)
+    # len(evolved) == len(qa_pairs) * 2
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from ..extraction.core import extract_with_model
+from .schemas import QAPair
+
+logger = logging.getLogger(__name__)
+
+
+EvolOperator = Literal["depth", "breadth", "reasoning"]
+ALL_OPERATORS: tuple[EvolOperator, ...] = ("depth", "breadth", "reasoning")
+
+
+# ---------------------------------------------------------------------------
+# Operator prompts. ``{question}`` and ``{answer}`` are substituted with
+# the source pair. Each operator is a self-contained instruction so the
+# LLM produces one new pair in a single call.
+# ---------------------------------------------------------------------------
+
+DEFAULT_OPERATOR_PROMPTS: dict[str, str] = {
+    "depth": (
+        "Rewrite the Q&A pair below to make the question MORE SPECIFIC. Add a "
+        "constraint, edge case, or precision requirement that demands a more "
+        "detailed answer. Do not invent facts beyond what the original answer "
+        "implies.\n\n"
+        "ORIGINAL QUESTION: {question}\n"
+        "ORIGINAL ANSWER: {answer}\n\n"
+        "Return ONE JSON object with `question` and `answer` keys. The new "
+        "question must be self-contained; the new answer must remain accurate "
+        "and grounded in the same source domain."
+    ),
+    "breadth": (
+        "Rewrite the Q&A pair below to BROADEN its scope to a sibling concept "
+        "or adjacent topic that someone studying the original would also "
+        "benefit from. The new question must be a genuine sibling — not a "
+        "rephrasing of the same fact.\n\n"
+        "ORIGINAL QUESTION: {question}\n"
+        "ORIGINAL ANSWER: {answer}\n\n"
+        "Return ONE JSON object with `question` and `answer` keys. The new "
+        "question/answer should fit the same domain but cover different "
+        "subject matter."
+    ),
+    "reasoning": (
+        "Rewrite the Q&A pair below into a MULTI-STEP REASONING question. The "
+        "new question should require the responder to chain at least two "
+        "pieces of information or perform a calculation — not just recall a "
+        "single fact.\n\n"
+        "ORIGINAL QUESTION: {question}\n"
+        "ORIGINAL ANSWER: {answer}\n\n"
+        "Return ONE JSON object with `question` and `answer` keys. The new "
+        "answer should show the reasoning steps explicitly."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EvolResult:
+    """Outcome of an :meth:`EvolInstruct.evolve_batch` call.
+
+    Attributes:
+        evolved: List of newly-generated pairs (does NOT include the originals).
+        failures: Count of source pairs where every operator failed
+            (LLM error / unparseable response / empty content). Useful
+            for monitoring evolution quality.
+        meta: Aggregated token / cost meta across all LLM calls.
+    """
+
+    evolved: list[QAPair] = field(default_factory=list)
+    failures: int = 0
+    meta: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# EvolInstruct
+# ---------------------------------------------------------------------------
+
+
+def _parse_pair(text: str) -> QAPair | None:
+    """Pull a single ``{"question": ..., "answer": ...}`` object out of LLM text.
+
+    Tolerant of fenced JSON, prose-embedded JSON, and extra keys.
+    Returns ``None`` when no usable pair can be recovered.
+    """
+    text = (text or "").strip()
+    if not text:
+        return None
+
+    candidates: list[dict[str, Any]] = []
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, dict):
+            candidates.append(parsed)
+    except json.JSONDecodeError:
+        pass
+
+    fence = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, flags=re.DOTALL)
+    if fence:
+        try:
+            parsed = json.loads(fence.group(1))
+            if isinstance(parsed, dict):
+                candidates.append(parsed)
+        except json.JSONDecodeError:
+            pass
+
+    # Embedded JSON in prose — first balanced ``{...}`` substring.
+    if not candidates:
+        start = text.find("{")
+        if start != -1:
+            depth = 0
+            in_string = False
+            escape = False
+            for i in range(start, len(text)):
+                ch = text[i]
+                if escape:
+                    escape = False
+                    continue
+                if ch == "\\":
+                    escape = True
+                    continue
+                if ch == '"':
+                    in_string = not in_string
+                    continue
+                if in_string:
+                    continue
+                if ch == "{":
+                    depth += 1
+                elif ch == "}":
+                    depth -= 1
+                    if depth == 0:
+                        try:
+                            parsed = json.loads(text[start : i + 1])
+                            if isinstance(parsed, dict):
+                                candidates.append(parsed)
+                        except json.JSONDecodeError:
+                            pass
+                        break
+
+    for obj in candidates:
+        q = str(obj.get("question") or obj.get("instruction") or "").strip()
+        a = str(obj.get("answer") or obj.get("output") or "").strip()
+        if q and a:
+            return QAPair(question=q, answer=a)
+    return None
+
+
+class EvolInstruct:
+    """Evolve Q&A pairs along Evol-Instruct's depth / breadth / reasoning axes.
+
+    Args:
+        model: Model string passed to :func:`extract_with_model` — same
+            ``"provider/model"`` form used everywhere else.
+        operator_prompts: Override the operator prompt templates. Each
+            template must contain ``{question}`` and ``{answer}``.
+            Defaults to :data:`DEFAULT_OPERATOR_PROMPTS`.
+        options: Extra options forwarded to ``extract_with_model``.
+            Bumping ``temperature`` to ~0.7 produces more diverse
+            evolutions; ``0.3`` keeps them tight to the source.
+        seed: Optional seed for the per-pair operator chooser when a
+            single operator argument is omitted from :meth:`evolve_pair`.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str,
+        operator_prompts: dict[str, str] | None = None,
+        options: dict[str, Any] | None = None,
+        seed: int | None = None,
+    ) -> None:
+        prompts = operator_prompts if operator_prompts is not None else DEFAULT_OPERATOR_PROMPTS
+        for op in ALL_OPERATORS:
+            if op not in prompts:
+                raise ValueError(f"operator_prompts missing required key {op!r}.")
+            tpl = prompts[op]
+            if "{question}" not in tpl or "{answer}" not in tpl:
+                raise ValueError(
+                    f"operator_prompts[{op!r}] must contain '{{question}}' and '{{answer}}' placeholders."
+                )
+        self.model = model
+        self.operator_prompts = dict(prompts)
+        self.options = dict(options) if options is not None else {"temperature": 0.7, "max_tokens": 512}
+        self._rng = random.Random(seed)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def evolve_pair(self, pair: QAPair, operator: EvolOperator | None = None) -> tuple[QAPair | None, dict[str, Any]]:
+        """Run a single operator against one pair.
+
+        When ``operator`` is ``None`` an operator is chosen uniformly at
+        random from :data:`ALL_OPERATORS` using the configured seed.
+        Returns ``(evolved_pair_or_None, meta)``. ``None`` indicates the
+        LLM call failed or produced unparseable text.
+        """
+        op = operator or self._rng.choice(ALL_OPERATORS)
+        prompt = self.operator_prompts[op].format(question=pair.question, answer=pair.answer)
+        meta: dict[str, Any] = {}
+        try:
+            result = extract_with_model(
+                QAPair,
+                prompt,
+                model_name=self.model,
+                options=self.options,
+            )
+        except Exception as exc:
+            logger.warning("EvolInstruct %s evolution failed: %s", op, exc)
+            return None, meta
+
+        usage = result.get("usage") if isinstance(result, dict) else None
+        if isinstance(usage, dict):
+            for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+                if isinstance(usage.get(key), (int, float)):
+                    meta[key] = meta.get(key, 0) + int(usage[key])
+            if isinstance(usage.get("cost"), (int, float)):
+                meta["cost"] = float(meta.get("cost", 0.0)) + float(usage["cost"])
+
+        # Prefer the validated Pydantic model the extractor returns.
+        evolved: QAPair | None = result.get("model") if isinstance(result, dict) else None
+        if not isinstance(evolved, QAPair):
+            # Fall back to JSON parsing of the raw string in case
+            # extract_with_model normalised an unexpected shape.
+            evolved = _parse_pair(result.get("json_string", "") if isinstance(result, dict) else "")
+        if evolved is None:
+            return None, meta
+        # Drop trivial "evolutions" that are identical to the source.
+        if evolved.question.strip().casefold() == pair.question.strip().casefold():
+            logger.debug("EvolInstruct %s produced an identical question; dropping.", op)
+            return None, meta
+        return evolved, meta
+
+    def evolve_batch(
+        self,
+        pairs: Sequence[QAPair],
+        *,
+        operators: list[EvolOperator] | None = None,
+        rounds: int = 1,
+    ) -> EvolResult:
+        """Evolve every input pair through each requested operator, ``rounds`` times.
+
+        Output count = ``len(pairs) * len(operators) * rounds`` minus
+        any failures. The originals are NOT included — concatenate the
+        result with the input set if you want both.
+
+        Args:
+            pairs: Source pairs.
+            operators: Which axes to apply. ``None`` (default) runs all
+                three. Specify a subset to control cost.
+            rounds: How many sequential evolution passes per operator.
+                Round 2+ evolves the round-1 output, so it intensifies
+                whichever axis you picked. Defaults to 1.
+        """
+        ops = operators or list(ALL_OPERATORS)
+        for op in ops:
+            if op not in ALL_OPERATORS:
+                raise ValueError(f"Unknown operator {op!r}. Choose from {ALL_OPERATORS}.")
+
+        result = EvolResult()
+        meta: dict[str, Any] = {"calls": 0}
+
+        for source in pairs:
+            had_any_success = False
+            for op in ops:
+                current = source
+                for _ in range(rounds):
+                    evolved, call_meta = self.evolve_pair(current, op)
+                    meta["calls"] += 1
+                    if call_meta:
+                        for k, v in call_meta.items():
+                            meta[k] = (meta.get(k) or 0) + v if isinstance(v, (int, float)) else v
+                    if evolved is None:
+                        break
+                    result.evolved.append(evolved)
+                    had_any_success = True
+                    current = evolved  # later rounds compound on the latest
+            if not had_any_success:
+                result.failures += 1
+
+        result.meta = meta
+        return result
+
+
+__all__ = [
+    "ALL_OPERATORS",
+    "DEFAULT_OPERATOR_PROMPTS",
+    "EvolInstruct",
+    "EvolOperator",
+    "EvolResult",
+]

--- a/prompture/dataset/filters.py
+++ b/prompture/dataset/filters.py
@@ -1,0 +1,266 @@
+"""Quality filters for synthetic Q&A datasets.
+
+A small, composable suite of predicates that drop low-value or unsafe
+examples from a generated dataset. Use them via :class:`QualityFilter`
+or call the predicate functions directly when you want fine-grained
+control.
+
+The filters intentionally **don't** require an embedding model or
+extra dependencies for the common path — the refusal detector reuses
+the Phase 6 ``RefusalDetector`` (stdlib-only), and length / shape
+filters are pure Python. Optional semantic predicates are documented
+in :mod:`prompture.dataset.dedup` instead.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass, field
+from typing import Any
+
+from .schemas import InstructionPair, QAPair
+
+logger = logging.getLogger(__name__)
+
+
+# A predicate returns True to KEEP the pair, False to DROP it. ``reason``
+# is a short tag a caller can use for telemetry / debugging.
+PairPredicate = Callable[[Any], "FilterDecision"]
+
+
+@dataclass(frozen=True)
+class FilterDecision:
+    """Outcome of running one predicate against one pair.
+
+    Attributes:
+        keep: True when the pair should pass through.
+        reason: Short snake_case tag explaining the verdict. Useful in
+            telemetry (``"drop:short_answer"``, ``"keep"``).
+    """
+
+    keep: bool
+    reason: str = "keep"
+
+    @classmethod
+    def keep_(cls, reason: str = "keep") -> FilterDecision:
+        return cls(True, reason)
+
+    @classmethod
+    def drop(cls, reason: str) -> FilterDecision:
+        return cls(False, f"drop:{reason}")
+
+
+# ---------------------------------------------------------------------------
+# Helpers — extract the comparable text from any pair shape we support.
+# ---------------------------------------------------------------------------
+
+
+def _question_text(pair: Any) -> str:
+    if isinstance(pair, QAPair):
+        return pair.question or ""
+    if isinstance(pair, InstructionPair):
+        return pair.instruction or ""
+    if isinstance(pair, dict):
+        return str(pair.get("question") or pair.get("instruction") or "")
+    return str(pair)
+
+
+def _answer_text(pair: Any) -> str:
+    if isinstance(pair, QAPair):
+        return pair.answer or ""
+    if isinstance(pair, InstructionPair):
+        return pair.output or ""
+    if isinstance(pair, dict):
+        return str(pair.get("answer") or pair.get("output") or "")
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Built-in predicates
+# ---------------------------------------------------------------------------
+
+
+def length_filter(
+    *,
+    min_question_chars: int = 8,
+    max_question_chars: int | None = 800,
+    min_answer_chars: int = 1,
+    max_answer_chars: int | None = 4000,
+) -> PairPredicate:
+    """Reject pairs whose question or answer falls outside the size window.
+
+    The defaults catch the most common synth failures: empty / one-word
+    questions and runaway answers that spilled an entire chunk back. Pass
+    ``None`` to either ``max_*`` argument to disable the upper bound.
+    """
+
+    def predicate(pair: Any) -> FilterDecision:
+        q = _question_text(pair).strip()
+        a = _answer_text(pair).strip()
+        if len(q) < min_question_chars:
+            return FilterDecision.drop("short_question")
+        if max_question_chars is not None and len(q) > max_question_chars:
+            return FilterDecision.drop("long_question")
+        if len(a) < min_answer_chars:
+            return FilterDecision.drop("short_answer")
+        if max_answer_chars is not None and len(a) > max_answer_chars:
+            return FilterDecision.drop("long_answer")
+        return FilterDecision.keep_()
+
+    return predicate
+
+
+def refusal_filter(detector: Any = None) -> PairPredicate:
+    """Drop pairs whose ANSWER text scans as a refusal.
+
+    Reuses :class:`prompture.refusal.RefusalDetector` (Phase 6). LLMs
+    sometimes regurgitate "I can't help with that" into the dataset
+    when the source content is borderline — those rows are pure noise
+    for a training run. Pass a pre-built detector to override the
+    marker list / language.
+    """
+    if detector is None:
+        from ..refusal import RefusalDetector
+
+        detector = RefusalDetector()
+
+    def predicate(pair: Any) -> FilterDecision:
+        answer = _answer_text(pair).strip()
+        if not answer:
+            return FilterDecision.keep_()
+        result = detector.detect(answer)
+        if getattr(result, "is_refusal", False):
+            return FilterDecision.drop("refusal_in_answer")
+        return FilterDecision.keep_()
+
+    return predicate
+
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def shape_filter() -> PairPredicate:
+    """Reject obvious shape-level junk: empty fields, question without ``?`` *and* without 'how/what/why/etc.', identical Q and A."""
+
+    interrogative = re.compile(r"^\s*(?:who|what|when|where|why|how|which|list|name|describe|explain|define)\b", re.IGNORECASE)
+
+    def predicate(pair: Any) -> FilterDecision:
+        q = _question_text(pair).strip()
+        a = _answer_text(pair).strip()
+        if not q or not a:
+            return FilterDecision.drop("empty_field")
+        if q.casefold() == a.casefold():
+            return FilterDecision.drop("identical_q_and_a")
+        # A question with NEITHER a question mark NOR an interrogative
+        # prefix is probably a malformed statement masquerading as a Q.
+        if "?" not in q and not interrogative.match(q):
+            return FilterDecision.drop("not_a_question")
+        return FilterDecision.keep_()
+
+    return predicate
+
+
+# ---------------------------------------------------------------------------
+# Composite filter
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FilterStats:
+    """Per-reason counts emitted by :meth:`QualityFilter.filter`."""
+
+    total_in: int = 0
+    total_out: int = 0
+    dropped_by_reason: dict[str, int] = field(default_factory=dict)
+
+    def drop_rate(self) -> float:
+        if self.total_in == 0:
+            return 0.0
+        return (self.total_in - self.total_out) / self.total_in
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "total_in": self.total_in,
+            "total_out": self.total_out,
+            "dropped": self.total_in - self.total_out,
+            "drop_rate": round(self.drop_rate(), 4),
+            "dropped_by_reason": dict(self.dropped_by_reason),
+        }
+
+
+class QualityFilter:
+    """Pipeline of predicates applied to each pair in order.
+
+    The first predicate that returns ``keep=False`` wins (short-circuit).
+    Call :meth:`filter` to get a cleaned list back + per-reason stats.
+
+    Args:
+        predicates: Predicates in evaluation order. ``None`` (default)
+            wires the standard trio: :func:`shape_filter`,
+            :func:`length_filter`, :func:`refusal_filter`.
+        refusal_detector: Optional pre-built detector forwarded to
+            :func:`refusal_filter` when the standard trio is used.
+            Ignored when ``predicates`` is explicit.
+
+    Example::
+
+        from prompture.dataset.filters import QualityFilter
+        clean, stats = QualityFilter().filter(pairs)
+        print(stats.to_dict())
+        # {'total_in': 240, 'total_out': 217, 'dropped': 23,
+        #  'drop_rate': 0.0958,
+        #  'dropped_by_reason': {'drop:short_question': 8, ...}}
+    """
+
+    def __init__(
+        self,
+        predicates: list[PairPredicate] | None = None,
+        *,
+        refusal_detector: Any = None,
+    ) -> None:
+        if predicates is None:
+            predicates = [shape_filter(), length_filter(), refusal_filter(refusal_detector)]
+        self.predicates = list(predicates)
+
+    def evaluate(self, pair: Any) -> FilterDecision:
+        """Run every predicate against ``pair``; return the first drop or a clean keep."""
+        for pred in self.predicates:
+            decision = pred(pair)
+            if not decision.keep:
+                return decision
+        return FilterDecision.keep_()
+
+    def filter(self, pairs: Iterable[Any]) -> tuple[list[Any], FilterStats]:
+        """Apply the pipeline to every pair; return ``(kept, stats)``."""
+        stats = FilterStats()
+        kept: list[Any] = []
+        for pair in pairs:
+            stats.total_in += 1
+            decision = self.evaluate(pair)
+            if decision.keep:
+                kept.append(pair)
+                stats.total_out += 1
+            else:
+                stats.dropped_by_reason[decision.reason] = (
+                    stats.dropped_by_reason.get(decision.reason, 0) + 1
+                )
+        return kept, stats
+
+    def iter(self, pairs: Iterable[Any]) -> Iterator[Any]:
+        """Stream-filter — yields kept pairs without buffering. Stats are not tracked."""
+        for pair in pairs:
+            if self.evaluate(pair).keep:
+                yield pair
+
+
+__all__ = [
+    "FilterDecision",
+    "FilterStats",
+    "PairPredicate",
+    "QualityFilter",
+    "length_filter",
+    "refusal_filter",
+    "shape_filter",
+]

--- a/prompture/dataset/filters.py
+++ b/prompture/dataset/filters.py
@@ -144,7 +144,9 @@ _WHITESPACE_RE = re.compile(r"\s+")
 def shape_filter() -> PairPredicate:
     """Reject obvious shape-level junk: empty fields, question without ``?`` *and* without 'how/what/why/etc.', identical Q and A."""
 
-    interrogative = re.compile(r"^\s*(?:who|what|when|where|why|how|which|list|name|describe|explain|define)\b", re.IGNORECASE)
+    interrogative = re.compile(
+        r"^\s*(?:who|what|when|where|why|how|which|list|name|describe|explain|define)\b", re.IGNORECASE
+    )
 
     def predicate(pair: Any) -> FilterDecision:
         q = _question_text(pair).strip()
@@ -243,9 +245,7 @@ class QualityFilter:
                 kept.append(pair)
                 stats.total_out += 1
             else:
-                stats.dropped_by_reason[decision.reason] = (
-                    stats.dropped_by_reason.get(decision.reason, 0) + 1
-                )
+                stats.dropped_by_reason[decision.reason] = stats.dropped_by_reason.get(decision.reason, 0) + 1
         return kept, stats
 
     def iter(self, pairs: Iterable[Any]) -> Iterator[Any]:

--- a/prompture/dataset/seed.py
+++ b/prompture/dataset/seed.py
@@ -52,7 +52,7 @@ DEFAULT_EXPANSION_PROMPT = (
     "would benefit from. Each answer must be complete, accurate, and "
     "self-contained.\n\n"
     "EXAMPLE PAIRS:\n{seed_block}\n\n"
-    "Respond with a single JSON object: {{\"pairs\": [{{\"question\": ..., \"answer\": ...}}, ...]}}"
+    'Respond with a single JSON object: {{"pairs": [{{"question": ..., "answer": ...}}, ...]}}'
 )
 
 

--- a/prompture/dataset/seed.py
+++ b/prompture/dataset/seed.py
@@ -119,7 +119,7 @@ class SelfInstruct:
         self.prompt = prompt
         self.options = dict(options) if options is not None else {"temperature": 0.7, "max_tokens": 1024}
         self.seed_sample_size = seed_sample_size
-        self._rng = seed_random or random.Random()
+        self._rng = seed_random or random.Random()  # nosec B311 - non-cryptographic dataset sampling
 
     # ------------------------------------------------------------------
     # Public API

--- a/prompture/dataset/seed.py
+++ b/prompture/dataset/seed.py
@@ -1,0 +1,286 @@
+"""Self-Instruct seed-based dataset expansion.
+
+Implements the `Self-Instruct <https://arxiv.org/abs/2212.10560>`_
+pattern: given a small set of high-quality "seed" examples, ask the
+LLM to generate more in the same style, then mix the new examples
+back into the seed pool so subsequent rounds see broader inspiration.
+
+Unlike :mod:`evol` (which transforms existing pairs along quality
+axes), this module **generates from scratch** — useful when you have
+a few hand-curated gold examples and need to scale to 1k-10k+ without
+a corpus of source documents.
+
+Quick start::
+
+    from prompture.dataset.seed import SelfInstruct
+    from prompture.dataset.schemas import QAPair
+
+    seeds = [
+        QAPair(question="What is mitosis?", answer="..."),
+        QAPair(question="Define osmosis.", answer="..."),
+    ]
+    expander = SelfInstruct(model="openai/gpt-4o-mini")
+    result = expander.expand(seeds, target_count=50, batch_size=5)
+    print(len(result.pairs))  # ~50, modulo dedup
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..extraction.core import extract_with_model
+from .dedup import dedup_exact
+from .schemas import QAPair, QAPairBatch
+
+logger = logging.getLogger(__name__)
+
+
+#: Default expansion prompt. ``{topic}``, ``{n}``, ``{seed_block}`` are
+#: substituted with the dataset topic (optional), per-call batch size,
+#: and a formatted sample of K seed examples respectively.
+DEFAULT_EXPANSION_PROMPT = (
+    "You are creating training data for an instruction-following model.\n\n"
+    "The dataset focus is: {topic}\n\n"
+    "Below are example Q&A pairs to anchor the style, depth, and topic "
+    "scope. Generate {n} NEW pairs in the same style but covering "
+    "DIFFERENT subject matter. Do not paraphrase the examples — produce "
+    "genuinely new questions that a learner studying the same topic "
+    "would benefit from. Each answer must be complete, accurate, and "
+    "self-contained.\n\n"
+    "EXAMPLE PAIRS:\n{seed_block}\n\n"
+    "Respond with a single JSON object: {{\"pairs\": [{{\"question\": ..., \"answer\": ...}}, ...]}}"
+)
+
+
+@dataclass
+class SelfInstructResult:
+    """Outcome of a :meth:`SelfInstruct.expand` call.
+
+    Attributes:
+        pairs: Generated pairs (does NOT include the original seeds).
+        rounds_completed: How many expansion rounds finished before
+            ``target_count`` was reached or ``max_rounds`` was hit.
+        meta: Aggregated token / cost meta across all LLM calls.
+    """
+
+    pairs: list[QAPair] = field(default_factory=list)
+    rounds_completed: int = 0
+    meta: dict[str, Any] = field(default_factory=dict)
+
+
+def _format_seed_block(seeds: list[QAPair]) -> str:
+    """Render a list of QAPairs as a numbered Q&A block."""
+    parts: list[str] = []
+    for i, seed in enumerate(seeds, 1):
+        parts.append(f"{i}. Q: {seed.question}\n   A: {seed.answer}")
+    return "\n\n".join(parts)
+
+
+class SelfInstruct:
+    """Expand a seed set into a larger Q&A dataset via iterative LLM generation.
+
+    Args:
+        model: Model string passed to :func:`extract_with_model`.
+        topic: Short freeform tag describing the dataset focus (e.g.
+            ``"intro biology study questions"``). Embedded in the
+            prompt so generated content stays on-topic.
+        prompt: Override the expansion-prompt template. Must contain
+            ``{topic}``, ``{n}``, ``{seed_block}``.
+        options: Forwarded to :func:`extract_with_model`. Defaults to
+            ``temperature=0.7`` so each round produces diverse outputs.
+        seed_sample_size: How many seed examples to include in each
+            prompt. Defaults to 8 — too many crowds the context; too
+            few collapses diversity.
+        seed_random: Optional ``random.Random`` for deterministic seed
+            sampling (useful in tests). Defaults to a fresh ``Random()``.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str,
+        topic: str = "general knowledge",
+        prompt: str = DEFAULT_EXPANSION_PROMPT,
+        options: dict[str, Any] | None = None,
+        seed_sample_size: int = 8,
+        seed_random: random.Random | None = None,
+    ) -> None:
+        for placeholder in ("{topic}", "{n}", "{seed_block}"):
+            if placeholder not in prompt:
+                raise ValueError(f"prompt is missing required placeholder {placeholder!r}.")
+        if seed_sample_size < 1:
+            raise ValueError(f"seed_sample_size must be >= 1; got {seed_sample_size}.")
+        self.model = model
+        self.topic = topic
+        self.prompt = prompt
+        self.options = dict(options) if options is not None else {"temperature": 0.7, "max_tokens": 1024}
+        self.seed_sample_size = seed_sample_size
+        self._rng = seed_random or random.Random()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def expand(
+        self,
+        seeds: list[QAPair],
+        *,
+        target_count: int,
+        batch_size: int = 5,
+        max_rounds: int | None = None,
+        feed_back: bool = True,
+        dedup_against_seeds: bool = True,
+    ) -> SelfInstructResult:
+        """Generate up to ``target_count`` new pairs from the seed pool.
+
+        Args:
+            seeds: Hand-curated example pairs. At least one is required.
+            target_count: Stop after this many *new* pairs (post-dedup).
+            batch_size: How many pairs to request per LLM call. Smaller
+                batches give the model more attention per pair; larger
+                batches amortise prompt overhead. Defaults to 5.
+            max_rounds: Hard cap on the number of generation rounds.
+                ``None`` (default) lets the loop run until
+                ``target_count`` is reached.
+            feed_back: When True (default), newly-generated pairs are
+                added to the candidate seed pool so subsequent rounds
+                see broader inspiration. When False, only the original
+                seeds are ever sampled.
+            dedup_against_seeds: When True (default), generated pairs
+                that exactly-match a seed's question (normalised) are
+                dropped. Disable when you want exact paraphrases.
+
+        Returns:
+            :class:`SelfInstructResult` with the new pairs, rounds
+            completed, and aggregated meta.
+
+        Raises:
+            ValueError: when ``seeds`` is empty or ``target_count`` < 1.
+        """
+        if not seeds:
+            raise ValueError("Self-Instruct requires at least one seed.")
+        if target_count < 1:
+            raise ValueError(f"target_count must be >= 1; got {target_count}.")
+
+        result = SelfInstructResult()
+        meta = {"calls": 0}
+        # Pool starts as the seeds; new pairs join when feed_back=True.
+        pool: list[QAPair] = list(seeds)
+
+        # Maximum rounds to attempt — bounded so a buggy LLM can't loop forever.
+        cap = max_rounds if max_rounds is not None else max(20, (target_count // max(batch_size, 1)) * 3)
+
+        while len(result.pairs) < target_count and result.rounds_completed < cap:
+            sample = self._sample_seeds(pool)
+            new_pairs, call_meta = self._one_round(sample, n=batch_size)
+            meta["calls"] += 1
+            for k, v in call_meta.items():
+                if isinstance(v, (int, float)):
+                    meta[k] = (meta.get(k) or 0) + v
+            result.rounds_completed += 1
+
+            if not new_pairs:
+                logger.debug("Self-Instruct round %d produced no pairs.", result.rounds_completed)
+                continue
+
+            # Drop anything that collides with the existing dataset (seeds + result).
+            candidates: list[QAPair] = list(result.pairs)
+            if dedup_against_seeds:
+                candidates.extend(seeds)
+            dedup_input = candidates + new_pairs
+            kept, _removed = dedup_exact(dedup_input)
+            # ``kept`` includes the prior items in order — slice off the front.
+            fresh = kept[len(candidates) :]
+
+            # Respect target_count exactly.
+            room = target_count - len(result.pairs)
+            fresh = fresh[:room]
+
+            result.pairs.extend(fresh)
+            if feed_back:
+                pool.extend(fresh)
+
+            if not fresh:
+                logger.debug(
+                    "Self-Instruct round %d: %d candidate(s) but all duplicates after dedup.",
+                    result.rounds_completed,
+                    len(new_pairs),
+                )
+
+        result.meta = meta
+        return result
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _sample_seeds(self, pool: list[QAPair]) -> list[QAPair]:
+        """Return up to ``seed_sample_size`` shuffled samples from ``pool``."""
+        if len(pool) <= self.seed_sample_size:
+            return list(pool)
+        return self._rng.sample(pool, self.seed_sample_size)
+
+    def _one_round(
+        self,
+        seed_sample: list[QAPair],
+        *,
+        n: int,
+    ) -> tuple[list[QAPair], dict[str, Any]]:
+        """Run one expansion LLM call. Returns ``(new_pairs, call_meta)``."""
+        rendered = self.prompt.format(
+            topic=self.topic,
+            n=n,
+            seed_block=_format_seed_block(seed_sample),
+        )
+        try:
+            result = extract_with_model(
+                QAPairBatch,
+                rendered,
+                model_name=self.model,
+                options=self.options,
+            )
+        except Exception as exc:
+            logger.warning("Self-Instruct expansion call failed: %s", exc)
+            return [], {}
+
+        usage = result.get("usage") if isinstance(result, dict) else None
+        call_meta: dict[str, Any] = {}
+        if isinstance(usage, dict):
+            for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+                if isinstance(usage.get(key), (int, float)):
+                    call_meta[key] = int(usage[key])
+            if isinstance(usage.get("cost"), (int, float)):
+                call_meta["cost"] = float(usage["cost"])
+
+        batch = result.get("model") if isinstance(result, dict) else None
+        if isinstance(batch, QAPairBatch):
+            return list(batch.pairs), call_meta
+
+        # Fallback: parse raw JSON string.
+        text = result.get("json_string", "") if isinstance(result, dict) else ""
+        try:
+            obj = json.loads(text)
+        except json.JSONDecodeError:
+            return [], call_meta
+        raw_pairs = obj.get("pairs") if isinstance(obj, dict) else None
+        if not isinstance(raw_pairs, list):
+            return [], call_meta
+        out: list[QAPair] = []
+        for item in raw_pairs:
+            if isinstance(item, dict):
+                q = str(item.get("question") or "").strip()
+                a = str(item.get("answer") or "").strip()
+                if q and a:
+                    out.append(QAPair(question=q, answer=a))
+        return out, call_meta
+
+
+__all__ = [
+    "DEFAULT_EXPANSION_PROMPT",
+    "SelfInstruct",
+    "SelfInstructResult",
+]

--- a/prompture/dataset/synth.py
+++ b/prompture/dataset/synth.py
@@ -4,9 +4,19 @@ generator.
 The function :func:`generate_qa_dataset` walks a source (file path,
 glob, list of paths, or a list of pre-loaded ``Document`` objects),
 chunks each document, and asks an LLM to emit several question/answer
-pairs grounded in each chunk.  Results are aggregated, de-duplicated by
-question text, and optionally written to disk in JSONL, ShareGPT, or
-Alpaca format.
+pairs grounded in each chunk.  Results are aggregated, optionally
+quality-filtered, de-duplicated, and written to disk in JSONL,
+ShareGPT, or Alpaca format.
+
+Phase 8C extensions (all opt-in, default-off):
+
+* ``personas`` — run each chunk through multiple :class:`Persona`
+  voices for stylistic diversity in the generated set.
+* ``quality_filter`` — drop short / runaway / refusal-flavoured
+  pairs via :class:`prompture.dataset.QualityFilter`.
+* ``dedup`` — choose between exact / shingle / semantic dedup via
+  :class:`prompture.dataset.DedupConfig`. The legacy ``dedupe=True``
+  argument is preserved and maps to exact dedup.
 """
 
 from __future__ import annotations
@@ -20,6 +30,8 @@ from typing import Any, Literal
 from ..extraction.async_core import extract_with_model as _async_extract_with_model
 from ..extraction.core import extract_with_model
 from ..rag.documents import Document
+from .dedup import DedupConfig, apply_dedup
+from .filters import QualityFilter
 from .formats import to_alpaca, to_jsonl, to_sharegpt, write_dataset
 from .schemas import QAPair, QAPairBatch
 
@@ -88,15 +100,74 @@ def _chunk_documents(docs: list[Document], chunker: Any) -> list[Document]:
 
 
 def _dedupe(pairs: list[QAPair]) -> list[QAPair]:
-    """Drop pairs with the same (normalised) question text."""
-    seen: set[str] = set()
-    out: list[QAPair] = []
-    for p in pairs:
-        key = " ".join(p.question.lower().split())
-        if key and key not in seen:
-            seen.add(key)
-            out.append(p)
-    return out
+    """Drop pairs with the same (normalised) question text.
+
+    .. deprecated:: 1.2.0
+        Use :func:`prompture.dataset.dedup_exact` (or the unified
+        :class:`DedupConfig`) directly. Retained for backward compatibility
+        only.
+    """
+    from .dedup import dedup_exact
+
+    kept, _removed = dedup_exact(pairs)
+    return kept
+
+
+def _resolve_personas(personas: list[Any] | None) -> list[tuple[str, str]]:
+    """Normalise an optional list of personas into ``(name, prefix)`` tuples.
+
+    Returns ``[("(none)", "")]`` when ``personas`` is missing — the
+    chunk-processing loop iterates the list, so this preserves the
+    "one call per chunk" default behaviour cleanly.
+    """
+    if not personas:
+        return [("(none)", "")]
+    voices: list[tuple[str, str]] = []
+    for persona in personas:
+        # Lazy import to keep this module dep-free when personas aren't used.
+        try:
+            from ..agents.persona import Persona
+        except ImportError:
+            Persona = None  # type: ignore[assignment, misc]
+
+        if Persona is not None and isinstance(persona, Persona):
+            name = persona.name or "persona"
+            prefix = persona.render()
+        elif isinstance(persona, str):
+            name = "string-persona"
+            prefix = persona
+        elif hasattr(persona, "render"):
+            name = getattr(persona, "name", None) or "persona"
+            prefix = persona.render()
+        else:
+            name = str(persona)
+            prefix = str(persona)
+        voices.append((name, prefix))
+    return voices
+
+
+def _render_prompt(
+    prompt_template: str,
+    n_per_chunk: int,
+    chunk: Document,
+    persona_prefix: str,
+) -> str:
+    """Format ``prompt_template`` and prepend ``persona_prefix`` when given."""
+    base = prompt_template.format(n=n_per_chunk, chunk=chunk.content)
+    if not persona_prefix:
+        return base
+    return f"{persona_prefix.strip()}\n\n{base}"
+
+
+def _resolve_dedup(dedup: DedupConfig | None, legacy_dedupe: bool) -> DedupConfig:
+    """Reconcile the new ``dedup`` config with the legacy ``dedupe`` flag.
+
+    Explicit ``dedup`` always wins. Otherwise: ``dedupe=True`` maps to
+    ``DedupConfig(strategy="exact")``; ``False`` maps to ``"none"``.
+    """
+    if dedup is not None:
+        return dedup
+    return DedupConfig(strategy="exact" if legacy_dedupe else "none")
 
 
 def _format_records(
@@ -130,7 +201,11 @@ def generate_qa_dataset(
     on_chunk: Any = None,
     max_chunks: int | None = None,
     dedupe: bool = True,
-) -> list[QAPair]:
+    personas: list[Any] | None = None,
+    quality_filter: QualityFilter | None = None,
+    dedup: DedupConfig | None = None,
+    return_stats: bool = False,
+) -> list[QAPair] | tuple[list[QAPair], dict[str, Any]]:
     """Generate a synthetic Q&A dataset from *source*.
 
     Args:
@@ -154,11 +229,32 @@ def generate_qa_dataset(
         max_chunks: Stop after this many chunks (useful for previewing
             a large corpus).
         dedupe: Drop pairs with duplicate questions (case-insensitive,
-            whitespace-normalised).  Default ``True``.
+            whitespace-normalised). Equivalent to ``dedup=DedupConfig(strategy="exact")``.
+            Defaults to ``True``. Ignored when ``dedup`` is supplied
+            explicitly.
+        personas: Optional list of :class:`prompture.agents.Persona`
+            (or anything exposing ``.render()`` and ``.name``). When
+            set, every chunk is processed once per persona — the
+            persona's rendered text is prepended to the prompt so the
+            generated pairs reflect each persona's voice. Multiplies
+            the LLM call budget by ``len(personas)``.
+        quality_filter: Optional :class:`QualityFilter`. Applied
+            *after* generation but *before* dedup. When ``None``, no
+            filtering happens. Pass ``QualityFilter()`` to enable the
+            shape + length + refusal filter trio.
+        dedup: Optional :class:`DedupConfig` overriding the legacy
+            ``dedupe`` flag. Choose ``"exact"`` (cheap, the default
+            via ``dedupe=True``), ``"shingle"`` (paraphrase-aware), or
+            ``"semantic"`` (embedding-based).
+        return_stats: When True, returns ``(pairs, stats_dict)``
+            instead of just ``pairs``. ``stats_dict`` carries
+            ``"raw_count"``, ``"filter"``, and ``"dedup_removed"``
+            keys for observability.
 
     Returns:
-        The list of :class:`QAPair` instances actually emitted.  When
-        ``output_path`` is set, the file is also written.
+        The list of :class:`QAPair` instances actually emitted. When
+        ``output_path`` is set, the file is also written. When
+        ``return_stats=True``, returns ``(pairs, stats)``.
 
     Example::
 
@@ -178,36 +274,52 @@ def generate_qa_dataset(
         logger.warning("No chunks produced from source — nothing to generate.")
         return []
 
+    persona_voices = _resolve_personas(personas)
+
     all_pairs: list[QAPair] = []
     for i, chunk in enumerate(chunks):
         if on_chunk is not None:
             on_chunk(i, len(chunks), chunk)
-        prompt = prompt_template.format(n=n_per_chunk, chunk=chunk.content)
-        try:
-            result = extract_with_model(
-                QAPairBatch,
-                prompt,
-                model_name=model,
-                options=options,
-            )
-            batch: QAPairBatch = result["model"]
-            all_pairs.extend(batch.pairs)
-        except Exception as exc:  # pragma: no cover — best-effort across many chunks
-            logger.warning(
-                "Chunk %d/%d (source=%s) failed: %s",
-                i + 1,
-                len(chunks),
-                chunk.metadata.get("source", "?"),
-                exc,
-            )
+        for persona_name, persona_prefix in persona_voices:
+            prompt = _render_prompt(prompt_template, n_per_chunk, chunk, persona_prefix)
+            try:
+                result = extract_with_model(
+                    QAPairBatch,
+                    prompt,
+                    model_name=model,
+                    options=options,
+                )
+                batch: QAPairBatch = result["model"]
+                all_pairs.extend(batch.pairs)
+            except Exception as exc:  # pragma: no cover — best-effort across many chunks
+                logger.warning(
+                    "Chunk %d/%d persona=%r (source=%s) failed: %s",
+                    i + 1,
+                    len(chunks),
+                    persona_name,
+                    chunk.metadata.get("source", "?"),
+                    exc,
+                )
 
-    if dedupe:
-        all_pairs = _dedupe(all_pairs)
+    raw_count = len(all_pairs)
+    stats: dict[str, Any] = {"raw_count": raw_count}
+
+    if quality_filter is not None:
+        all_pairs, filter_stats = quality_filter.filter(all_pairs)
+        stats["filter"] = filter_stats.to_dict()
+
+    dedup_cfg = _resolve_dedup(dedup, dedupe)
+    if dedup_cfg.strategy != "none":
+        all_pairs, removed = apply_dedup(all_pairs, dedup_cfg)
+        stats["dedup_removed"] = removed
+        stats["dedup_strategy"] = dedup_cfg.strategy
 
     if output_path is not None:
         records = _format_records(all_pairs, output_format)
         write_dataset(records, output_path)
 
+    if return_stats:
+        return all_pairs, stats
     return all_pairs
 
 
@@ -230,12 +342,22 @@ async def agenerate_qa_dataset(
     max_chunks: int | None = None,
     dedupe: bool = True,
     concurrency: int = 4,
-) -> list[QAPair]:
+    personas: list[Any] | None = None,
+    quality_filter: QualityFilter | None = None,
+    dedup: DedupConfig | None = None,
+    return_stats: bool = False,
+) -> list[QAPair] | tuple[list[QAPair], dict[str, Any]]:
     """Async variant of :func:`generate_qa_dataset` with bounded concurrency.
 
-    Same arguments plus:
+    Same arguments as :func:`generate_qa_dataset` plus:
+
         concurrency: Maximum number of chunks processed concurrently.
-            Defaults to 4.  Use 1 for serial async execution.
+            Defaults to 4. Use 1 for serial async execution.
+
+    ``personas``, ``quality_filter``, ``dedup``, ``return_stats``
+    behave identically to the sync version. With multiple personas
+    the semaphore still caps total parallel calls — the personas are
+    fanned out within each chunk's task slot.
     """
     docs = _resolve_source(source)
     chunks = _chunk_documents(docs, chunker)
@@ -243,41 +365,57 @@ async def agenerate_qa_dataset(
         chunks = chunks[:max_chunks]
     if not chunks:
         logger.warning("No chunks produced from source — nothing to generate.")
-        return []
+        return ([], {"raw_count": 0}) if return_stats else []
 
+    persona_voices = _resolve_personas(personas)
     semaphore = asyncio.Semaphore(concurrency)
 
     async def _process(idx: int, chunk: Document) -> list[QAPair]:
         if on_chunk is not None:
             on_chunk(idx, len(chunks), chunk)
-        async with semaphore:
-            prompt = prompt_template.format(n=n_per_chunk, chunk=chunk.content)
-            try:
-                result = await _async_extract_with_model(
-                    QAPairBatch,
-                    prompt,
-                    model_name=model,
-                    options=options,
-                )
-                return list(result["model"].pairs)
-            except Exception as exc:  # pragma: no cover
-                logger.warning(
-                    "Chunk %d/%d (source=%s) failed: %s",
-                    idx + 1,
-                    len(chunks),
-                    chunk.metadata.get("source", "?"),
-                    exc,
-                )
-                return []
+        out: list[QAPair] = []
+        for persona_name, persona_prefix in persona_voices:
+            async with semaphore:
+                prompt = _render_prompt(prompt_template, n_per_chunk, chunk, persona_prefix)
+                try:
+                    result = await _async_extract_with_model(
+                        QAPairBatch,
+                        prompt,
+                        model_name=model,
+                        options=options,
+                    )
+                    out.extend(result["model"].pairs)
+                except Exception as exc:  # pragma: no cover
+                    logger.warning(
+                        "Chunk %d/%d persona=%r (source=%s) failed: %s",
+                        idx + 1,
+                        len(chunks),
+                        persona_name,
+                        chunk.metadata.get("source", "?"),
+                        exc,
+                    )
+        return out
 
     batches = await asyncio.gather(*[_process(i, c) for i, c in enumerate(chunks)])
     all_pairs: list[QAPair] = [p for batch in batches for p in batch]
 
-    if dedupe:
-        all_pairs = _dedupe(all_pairs)
+    raw_count = len(all_pairs)
+    stats: dict[str, Any] = {"raw_count": raw_count}
+
+    if quality_filter is not None:
+        all_pairs, filter_stats = quality_filter.filter(all_pairs)
+        stats["filter"] = filter_stats.to_dict()
+
+    dedup_cfg = _resolve_dedup(dedup, dedupe)
+    if dedup_cfg.strategy != "none":
+        all_pairs, removed = apply_dedup(all_pairs, dedup_cfg)
+        stats["dedup_removed"] = removed
+        stats["dedup_strategy"] = dedup_cfg.strategy
 
     if output_path is not None:
         records = _format_records(all_pairs, output_format)
         write_dataset(records, output_path)
 
+    if return_stats:
+        return all_pairs, stats
     return all_pairs

--- a/prompture/dataset/synth.py
+++ b/prompture/dataset/synth.py
@@ -15,7 +15,7 @@ import asyncio
 import glob as _glob
 import logging
 from pathlib import Path
-from typing import Any, Literal, Union
+from typing import Any, Literal
 
 from ..extraction.async_core import extract_with_model as _async_extract_with_model
 from ..extraction.core import extract_with_model
@@ -43,7 +43,7 @@ DEFAULT_PROMPT_TEMPLATE = (
 
 
 def _resolve_source(
-    source: Union[str, Path, list[Union[str, Path]], list[Document]],
+    source: str | Path | list[str | Path] | list[Document],
 ) -> list[Document]:
     """Turn any accepted *source* shape into a flat list of ``Document``."""
     from ..rag.loader_registry import get_loader_for_path
@@ -66,7 +66,7 @@ def _resolve_source(
     return docs
 
 
-def _expand_paths(items: list[Union[str, Path]]) -> list[Path]:
+def _expand_paths(items: list[str | Path]) -> list[Path]:
     out: list[Path] = []
     for item in items:
         s = str(item)
@@ -118,13 +118,13 @@ def _format_records(
 
 
 def generate_qa_dataset(
-    source: Union[str, Path, list[Union[str, Path]], list[Document]],
+    source: str | Path | list[str | Path] | list[Document],
     *,
     model: str,
     n_per_chunk: int = 3,
     chunker: Any = None,
     prompt_template: str = DEFAULT_PROMPT_TEMPLATE,
-    output_path: Union[str, Path, None] = None,
+    output_path: str | Path | None = None,
     output_format: OutputFormat = "jsonl",
     options: dict[str, Any] | None = None,
     on_chunk: Any = None,
@@ -217,13 +217,13 @@ def generate_qa_dataset(
 
 
 async def agenerate_qa_dataset(
-    source: Union[str, Path, list[Union[str, Path]], list[Document]],
+    source: str | Path | list[str | Path] | list[Document],
     *,
     model: str,
     n_per_chunk: int = 3,
     chunker: Any = None,
     prompt_template: str = DEFAULT_PROMPT_TEMPLATE,
-    output_path: Union[str, Path, None] = None,
+    output_path: str | Path | None = None,
     output_format: OutputFormat = "jsonl",
     options: dict[str, Any] | None = None,
     on_chunk: Any = None,

--- a/prompture/drivers/_openai_compat.py
+++ b/prompture/drivers/_openai_compat.py
@@ -1,0 +1,139 @@
+"""Shared request-shaping helpers for OpenAI-compatible drivers.
+
+The OpenAI Chat Completions wire format is the de-facto standard for
+local inference servers (vLLM, LMStudio, Ollama-in-OpenAI-mode,
+Aphrodite, OpenRouter, Together, Fireworks, ...). Most of those
+servers also accept *vendor-specific* extra fields for advanced
+features the OpenAI spec doesn't cover — most importantly,
+**logit-level constrained decoding** for guaranteed schema validity.
+
+This module centralises the "translate Prompture-side options into
+the right OpenAI-compatible request payload" logic so every driver
+applies the same defaults and respects the same escape hatches.
+
+Two knobs callers care about:
+
+* ``guided_decoding`` (``bool`` | ``str``) — when truthy and a
+  ``json_schema`` is provided, also writes vLLM's ``guided_json`` (and
+  optionally ``guided_decoding_backend``) at the top level of the
+  request body. Servers that don't recognise the keys ignore them, so
+  this is safe to send to any OpenAI-compatible endpoint.
+
+* ``extra_body`` (``dict``) — caller-supplied dict merged into the
+  request body verbatim. The OpenAI Python SDK exposes the same
+  ``extra_body`` escape hatch; Prompture mirrors it so users can pass
+  any vendor field we don't know about yet
+  (``min_p``, ``repetition_penalty``, ``guided_grammar``, ...).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..infra.cost_mixin import prepare_strict_schema
+
+#: vLLM-style guided-decoding backends. ``True`` accepts the server
+#: default; passing a string pins a specific implementation.
+_VLLM_BACKENDS: frozenset[str] = frozenset({"outlines", "lm-format-enforcer", "xgrammar"})
+
+
+def build_response_format(json_schema: dict[str, Any] | None) -> dict[str, Any]:
+    """Build the OpenAI ``response_format`` object for a strict json_schema mode.
+
+    Returns the dict to assign to ``data["response_format"]``. When
+    ``json_schema`` is ``None`` the caller should fall back to
+    ``{"type": "json_object"}`` for loose JSON mode (we don't return
+    that here because it's a one-liner at the call site).
+    """
+    schema_copy = prepare_strict_schema(json_schema) if json_schema is not None else {}
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "extraction",
+            "strict": True,
+            "schema": schema_copy,
+        },
+    }
+
+
+def apply_guided_decoding(
+    payload: dict[str, Any],
+    *,
+    json_schema: dict[str, Any] | None,
+    guided_decoding: Any,
+) -> None:
+    """Inject vLLM-style top-level ``guided_json`` fields when requested.
+
+    Args:
+        payload: The request body to mutate in place. Must be the
+            outer dict the driver sends (where ``model`` /
+            ``messages`` already live).
+        json_schema: The schema the user wants to enforce. ``None`` is
+            a no-op.
+        guided_decoding: User-supplied flag.
+
+            * ``False`` / ``None`` — no-op, leaves ``payload`` alone.
+            * ``True`` — adds ``guided_json=<schema>`` (server picks
+              its own backend).
+            * One of ``"outlines"`` / ``"lm-format-enforcer"`` /
+              ``"xgrammar"`` — also sets
+              ``guided_decoding_backend`` to that string.
+
+    Unknown string values are accepted and passed through verbatim —
+    vLLM releases occasionally add new backends, and Prompture
+    shouldn't have to ship a release every time.
+    """
+    if not guided_decoding or json_schema is None:
+        return
+    payload["guided_json"] = json_schema
+    if isinstance(guided_decoding, str):
+        # Honour explicit backend choice. We don't reject unknown
+        # strings; future vLLM versions can introduce new backends.
+        payload["guided_decoding_backend"] = guided_decoding
+
+
+def merge_extra_body(payload: dict[str, Any], options: dict[str, Any]) -> None:
+    """Mirror the OpenAI SDK's ``extra_body`` escape hatch.
+
+    Spreads ``options["extra_body"]`` (when it's a dict) into
+    ``payload``. User-supplied keys win — this is intentional so the
+    escape hatch can override anything Prompture set above, including
+    ``response_format``.
+    """
+    extra = options.get("extra_body")
+    if isinstance(extra, dict):
+        payload.update(extra)
+
+
+def apply_structured_output(
+    payload: dict[str, Any],
+    options: dict[str, Any],
+) -> None:
+    """One-call wrapper that's safe to drop at the end of every driver's
+    request-shaping block.
+
+    Reads ``json_mode`` / ``json_schema`` / ``guided_decoding`` /
+    ``extra_body`` out of ``options``, mutates ``payload`` in place.
+    Existing drivers can keep their own ``response_format`` logic if
+    they prefer; this helper is opt-in.
+    """
+    json_schema = options.get("json_schema")
+    if options.get("json_mode"):
+        if json_schema is not None:
+            payload["response_format"] = build_response_format(json_schema)
+        else:
+            payload["response_format"] = {"type": "json_object"}
+    apply_guided_decoding(
+        payload,
+        json_schema=json_schema,
+        guided_decoding=options.get("guided_decoding"),
+    )
+    merge_extra_body(payload, options)
+
+
+__all__ = [
+    "apply_guided_decoding",
+    "apply_structured_output",
+    "build_response_format",
+    "merge_extra_body",
+]

--- a/prompture/drivers/_openai_compat_stream.py
+++ b/prompture/drivers/_openai_compat_stream.py
@@ -344,11 +344,211 @@ async def astream_openai_compat_tool_call(
         yield ev
 
 
+# ----------------------------------------------------------------------
+# Raw-HTTP variants for drivers that POST directly instead of using
+# the OpenAI SDK (grok, openrouter, moonshot, mistral, modelscope, zai,
+# cachibot, ...). Same event output, parses SSE lines from a streaming
+# requests / httpx response.
+# ----------------------------------------------------------------------
+
+
+def _dict_to_chunk(d: Any) -> Any:
+    """Convert a JSON-decoded dict (and nested dicts/lists) to a
+    namespace-like object so ``_process_chunk`` (which uses attribute
+    access throughout) works on raw HTTP payloads without changes."""
+    from types import SimpleNamespace
+
+    if isinstance(d, dict):
+        return SimpleNamespace(**{k: _dict_to_chunk(v) for k, v in d.items()})
+    if isinstance(d, list):
+        return [_dict_to_chunk(item) for item in d]
+    return d
+
+
+def _build_raw_http_payload(
+    driver: Any,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]],
+    options: dict[str, Any],
+    *,
+    provider: str,
+    default_max_tokens: int,
+    default_temperature: float,
+) -> tuple[str, dict[str, Any]]:
+    """Build (model, payload) for a raw-HTTP OpenAI-compat call.
+
+    Pulls ``tokens_param`` / ``supports_temperature`` from the driver's
+    ``_get_model_config(provider, model)``. Adds ``stream`` and
+    ``stream_options.include_usage`` so the final chunk carries usage.
+    """
+    model = options.get("model", driver.model)
+    model_config = driver._get_model_config(provider, model)
+    tokens_param = model_config["tokens_param"]
+    supports_temperature = model_config["supports_temperature"]
+
+    opts = {"temperature": default_temperature, "max_tokens": default_max_tokens, **options}
+
+    payload: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "tools": tools,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    payload[tokens_param] = opts.get("max_tokens", default_max_tokens)
+    if supports_temperature and "temperature" in opts:
+        payload["temperature"] = opts["temperature"]
+    if "tool_choice" in options:
+        payload["tool_choice"] = options["tool_choice"]
+
+    return model, payload
+
+
+def _bearer_headers(api_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+
+def stream_raw_http_compat_tool_call(
+    driver: Any,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]],
+    options: dict[str, Any],
+    *,
+    provider: str,
+    url: str | None = None,
+    headers: dict[str, str] | None = None,
+    default_max_tokens: int = 4096,
+    default_temperature: float = 1.0,
+    timeout: int = 120,
+) -> Iterator[Any]:
+    """Generic sync streaming-tool implementation for raw-HTTP OpenAI-compat
+    drivers (those that call ``requests.post(/chat/completions)`` instead
+    of using the OpenAI SDK).
+
+    Defaults assume the driver exposes:
+    - ``self.api_base`` — base URL (no trailing ``/chat/completions``)
+    - ``self.api_key`` — used as ``Authorization: Bearer <key>``
+
+    Override *url* or *headers* if the driver uses a different shape.
+    """
+    import requests
+
+    from ..agents.live_events import MessageStop
+
+    model, payload = _build_raw_http_payload(
+        driver, messages, tools, options,
+        provider=provider,
+        default_max_tokens=default_max_tokens,
+        default_temperature=default_temperature,
+    )
+    resolved_url = url or f"{driver.api_base}/chat/completions"
+    resolved_headers = headers or _bearer_headers(driver.api_key)
+
+    state = _fresh_state()
+    with requests.post(
+        resolved_url,
+        headers=resolved_headers,
+        json=payload,
+        stream=True,
+        timeout=timeout,
+    ) as resp:
+        resp.raise_for_status()
+        for raw_line in resp.iter_lines(decode_unicode=True):
+            if not raw_line:
+                continue
+            line = raw_line.strip()
+            if not line.startswith("data:"):
+                continue
+            data = line[len("data:"):].strip()
+            if data == "[DONE]":
+                break
+            try:
+                chunk_dict = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+            chunk = _dict_to_chunk(chunk_dict)
+            yield from _process_chunk(chunk, state)
+
+    yield from _finalize_tool_use_stops(state)
+    cost = driver._calculate_cost(
+        provider, model,
+        state["prompt_tokens"], state["completion_tokens"],
+        cached_tokens=state["cached_prompt_tokens"],
+    )
+    yield MessageStop(stop_reason=state["finish_reason"], usage=_build_meta(state, model, cost))
+
+
+async def astream_raw_http_compat_tool_call(
+    driver: Any,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]],
+    options: dict[str, Any],
+    *,
+    provider: str,
+    url: str | None = None,
+    headers: dict[str, str] | None = None,
+    default_max_tokens: int = 4096,
+    default_temperature: float = 1.0,
+    timeout: float = 120.0,
+) -> AsyncIterator[Any]:
+    """Async sibling of :func:`stream_raw_http_compat_tool_call` using
+    ``httpx.AsyncClient.stream``."""
+    import httpx
+
+    from ..agents.live_events import MessageStop
+
+    model, payload = _build_raw_http_payload(
+        driver, messages, tools, options,
+        provider=provider,
+        default_max_tokens=default_max_tokens,
+        default_temperature=default_temperature,
+    )
+    resolved_url = url or f"{driver.api_base}/chat/completions"
+    resolved_headers = headers or _bearer_headers(driver.api_key)
+
+    state = _fresh_state()
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        async with client.stream(
+            "POST",
+            resolved_url,
+            headers=resolved_headers,
+            json=payload,
+        ) as resp:
+            resp.raise_for_status()
+            async for raw_line in resp.aiter_lines():
+                if not raw_line:
+                    continue
+                line = raw_line.strip()
+                if not line.startswith("data:"):
+                    continue
+                data = line[len("data:"):].strip()
+                if data == "[DONE]":
+                    break
+                try:
+                    chunk_dict = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+                chunk = _dict_to_chunk(chunk_dict)
+                for ev in _process_chunk(chunk, state):
+                    yield ev
+
+    for ev in _finalize_tool_use_stops(state):
+        yield ev
+    cost = driver._calculate_cost(
+        provider, model,
+        state["prompt_tokens"], state["completion_tokens"],
+        cached_tokens=state["cached_prompt_tokens"],
+    )
+    yield MessageStop(stop_reason=state["finish_reason"], usage=_build_meta(state, model, cost))
+
+
 __all__ = [
     "AsyncCostFn",
     "CostFn",
     "aiter_openai_compat_live_events",
     "astream_openai_compat_tool_call",
+    "astream_raw_http_compat_tool_call",
     "iter_openai_compat_live_events",
     "stream_openai_compat_tool_call",
+    "stream_raw_http_compat_tool_call",
 ]

--- a/prompture/drivers/_openai_compat_stream.py
+++ b/prompture/drivers/_openai_compat_stream.py
@@ -1,0 +1,354 @@
+"""Shared streaming-tool helpers for OpenAI-compatible drivers.
+
+Any provider that speaks the OpenAI ``chat.completions`` wire format
+(Groq, Grok, DeepSeek, Moonshot, Mistral, OpenRouter, Azure, ModelScope,
+ZAI, MiniMax, LMStudio, Cachibot, and the generic
+``OpenAICompatibleDriver``) can opt into native interleaved streaming-tool
+support with a 3-line override::
+
+    # sync driver
+    class GroqDriver(...):
+        supports_streaming_tool_use = True
+
+        def generate_messages_with_tools_stream(self, messages, tools, options):
+            from ._openai_compat_stream import stream_openai_compat_tool_call
+            yield from stream_openai_compat_tool_call(
+                self, messages, tools, options, provider="groq"
+            )
+
+    # async driver
+    class AsyncGroqDriver(...):
+        supports_streaming_tool_use = True
+
+        async def generate_messages_with_tools_stream(self, messages, tools, options):
+            from ._openai_compat_stream import astream_openai_compat_tool_call
+            async for ev in astream_openai_compat_tool_call(
+                self, messages, tools, options, provider="groq"
+            ):
+                yield ev
+
+The high-level helpers expect the driver to have:
+
+- ``self.client`` — an OpenAI (or AsyncOpenAI) SDK client
+- ``self.model`` — default model string
+- ``self._get_model_config(provider, model)`` — for ``tokens_param`` and
+  ``supports_temperature`` (provided by ``CostMixin``)
+- ``self._calculate_cost(provider, model, prompt_tokens, completion_tokens, cached_tokens=...)``
+  — provided by ``CostMixin``
+
+If a driver builds request kwargs differently (vision blocks, custom
+headers, etc.), use the lower-level
+:func:`iter_openai_compat_live_events` / :func:`aiter_openai_compat_live_events`
+directly and pass your own stream object.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+CostFn = Callable[[int, int, int], float]
+"""``(prompt_tokens, completion_tokens, cached_prompt_tokens) -> cost_usd``"""
+
+AsyncCostFn = Callable[[int, int, int], Awaitable[float] | float]
+"""Sync OR async variant of :data:`CostFn`. The async helper awaits when needed."""
+
+
+def _extract_cached_tokens(usage: Any) -> int:
+    """Pull cached prompt-token count from an OpenAI-shaped usage object."""
+    if usage is None:
+        return 0
+    details = getattr(usage, "prompt_tokens_details", None)
+    if details is None:
+        return 0
+    try:
+        return int(getattr(details, "cached_tokens", 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _process_chunk(
+    chunk: Any,
+    state: dict[str, Any],
+) -> Iterator[Any]:
+    """Process one OpenAI-compat stream chunk into zero or more LiveEvents.
+
+    ``state`` is a mutable bag the caller threads across chunks; this keeps
+    the sync and async helpers aligned without duplicating event logic.
+    Mutates: ``state["prompt_tokens"]``, ``state["completion_tokens"]``,
+    ``state["cached_prompt_tokens"]``, ``state["finish_reason"]``,
+    ``state["tool_calls"]`` (dict indexed by tool-call slot).
+    """
+    from ..agents.live_events import TextDelta, ToolInputDelta, ToolUseStart
+
+    if getattr(chunk, "usage", None):
+        state["prompt_tokens"] = chunk.usage.prompt_tokens or 0
+        state["completion_tokens"] = chunk.usage.completion_tokens or 0
+        state["cached_prompt_tokens"] = _extract_cached_tokens(chunk.usage)
+
+    if not getattr(chunk, "choices", None):
+        return
+
+    choice = chunk.choices[0]
+    delta = getattr(choice, "delta", None)
+    if delta is None:
+        fr = getattr(choice, "finish_reason", None)
+        if fr:
+            state["finish_reason"] = fr
+        return
+
+    content = getattr(delta, "content", None) or ""
+    if content:
+        yield TextDelta(text=content)
+
+    delta_tool_calls = getattr(delta, "tool_calls", None) or []
+    for tc in delta_tool_calls:
+        idx = getattr(tc, "index", 0) or 0
+        bucket: dict[str, Any] = state["tool_calls"].setdefault(
+            idx,
+            {"id": "", "name": "", "args_fragments": [], "start_emitted": False},
+        )
+        tc_id = getattr(tc, "id", None)
+        if tc_id and not bucket["id"]:
+            bucket["id"] = tc_id
+        fn = getattr(tc, "function", None)
+        if fn is not None:
+            fn_name = getattr(fn, "name", None)
+            if fn_name and not bucket["name"]:
+                bucket["name"] = fn_name
+            fn_args = getattr(fn, "arguments", None)
+            if fn_args:
+                bucket["args_fragments"].append(fn_args)
+        if not bucket["start_emitted"] and bucket["id"] and bucket["name"]:
+            bucket["start_emitted"] = True
+            yield ToolUseStart(id=bucket["id"], name=bucket["name"])
+        if bucket["start_emitted"] and fn is not None:
+            fn_args_now = getattr(fn, "arguments", None)
+            if fn_args_now:
+                yield ToolInputDelta(id=bucket["id"], fragment=fn_args_now)
+
+    fr = getattr(choice, "finish_reason", None)
+    if fr:
+        state["finish_reason"] = fr
+
+
+def _finalize_tool_use_stops(state: dict[str, Any]) -> Iterator[Any]:
+    """After the stream ends, emit ``ToolUseStop`` per accumulated tool."""
+    from ..agents.live_events import ToolUseStart, ToolUseStop
+
+    for idx in sorted(state["tool_calls"].keys()):
+        bucket = state["tool_calls"][idx]
+        if not bucket["start_emitted"] and bucket["id"] and bucket["name"]:
+            yield ToolUseStart(id=bucket["id"], name=bucket["name"])
+            bucket["start_emitted"] = True
+        args_str = "".join(bucket["args_fragments"])
+        try:
+            parsed = json.loads(args_str) if args_str else {}
+            if not isinstance(parsed, dict):
+                parsed = {}
+        except json.JSONDecodeError:
+            logger.warning(
+                "Failed to parse streamed tool input for %s: %r",
+                bucket["name"],
+                args_str[:200],
+            )
+            parsed = {}
+        yield ToolUseStop(id=bucket["id"], name=bucket["name"], input=parsed)
+
+
+def _build_meta(state: dict[str, Any], model: str, cost: float) -> dict[str, Any]:
+    return {
+        "prompt_tokens": state["prompt_tokens"],
+        "completion_tokens": state["completion_tokens"],
+        "total_tokens": state["prompt_tokens"] + state["completion_tokens"],
+        "cached_prompt_tokens": state["cached_prompt_tokens"],
+        "cost": round(cost, 6),
+        "model_name": model,
+    }
+
+
+def _fresh_state() -> dict[str, Any]:
+    return {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "cached_prompt_tokens": 0,
+        "finish_reason": "stop",
+        "tool_calls": {},
+    }
+
+
+def iter_openai_compat_live_events(
+    stream: Iterator[Any],
+    *,
+    model: str,
+    cost_fn: CostFn,
+) -> Iterator[Any]:
+    """Consume a sync OpenAI-compat ``chat.completions`` stream with tools
+    and yield :class:`~prompture.agents.live_events.LiveEvent`.
+
+    Yields ``TextDelta`` for content deltas, ``ToolUseStart`` /
+    ``ToolInputDelta`` / ``ToolUseStop`` for tool calls (input JSON is
+    assembled from per-chunk fragments), and a final ``MessageStop`` with
+    usage and cost via *cost_fn*.
+
+    The caller is responsible for creating the stream
+    (``client.chat.completions.create(stream=True, stream_options={"include_usage": True}, ...)``)
+    so the helper stays driver-agnostic. Set
+    ``stream_options={"include_usage": True}`` to populate usage in the
+    final chunk; without it ``cost_fn`` will receive zeros.
+    """
+    from ..agents.live_events import MessageStop
+
+    state = _fresh_state()
+    for chunk in stream:
+        yield from _process_chunk(chunk, state)
+    yield from _finalize_tool_use_stops(state)
+    cost = cost_fn(
+        state["prompt_tokens"],
+        state["completion_tokens"],
+        state["cached_prompt_tokens"],
+    )
+    yield MessageStop(stop_reason=state["finish_reason"], usage=_build_meta(state, model, cost))
+
+
+async def aiter_openai_compat_live_events(
+    stream: AsyncIterator[Any],
+    *,
+    model: str,
+    cost_fn: AsyncCostFn,
+) -> AsyncIterator[Any]:
+    """Async sibling of :func:`iter_openai_compat_live_events`.
+
+    *cost_fn* may be sync or async; the helper awaits when needed.
+    """
+    import inspect
+
+    from ..agents.live_events import MessageStop
+
+    state = _fresh_state()
+    async for chunk in stream:
+        for ev in _process_chunk(chunk, state):
+            yield ev
+    for ev in _finalize_tool_use_stops(state):
+        yield ev
+    raw_cost = cost_fn(
+        state["prompt_tokens"],
+        state["completion_tokens"],
+        state["cached_prompt_tokens"],
+    )
+    cost = await raw_cost if inspect.isawaitable(raw_cost) else raw_cost
+    yield MessageStop(stop_reason=state["finish_reason"], usage=_build_meta(state, model, cost))
+
+
+# ----------------------------------------------------------------------
+# High-level one-call helpers for OpenAI-compat drivers
+# ----------------------------------------------------------------------
+
+
+def stream_openai_compat_tool_call(
+    driver: Any,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]],
+    options: dict[str, Any],
+    *,
+    provider: str,
+    default_max_tokens: int = 4096,
+    default_temperature: float = 1.0,
+) -> Iterator[Any]:
+    """Generic sync streaming-tool implementation for any OpenAI-compat driver.
+
+    Looks up the driver's model config, builds the chat-completions request
+    with ``stream=True``, opens the stream, and yields ``LiveEvent`` via
+    :func:`iter_openai_compat_live_events`.
+
+    The driver must satisfy the contract described in this module's
+    docstring. *provider* is the pricing-table key (e.g. ``"groq"``).
+    """
+    from .openai_driver import _build_openai_base_kwargs
+
+    model = options.get("model", driver.model)
+    model_config = driver._get_model_config(provider, model)
+    tokens_param = model_config["tokens_param"]
+    supports_temperature = model_config["supports_temperature"]
+
+    opts = {"temperature": default_temperature, "max_tokens": default_max_tokens, **options}
+    kwargs = _build_openai_base_kwargs(
+        model,
+        messages,
+        opts,
+        tokens_param,
+        supports_temperature,
+        default_max_tokens,
+        extra={
+            "tools": tools,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        },
+    )
+
+    stream = driver.client.chat.completions.create(**kwargs)
+
+    def cost_fn(prompt_tokens: int, completion_tokens: int, cached_tokens: int) -> float:
+        return driver._calculate_cost(
+            provider, model, prompt_tokens, completion_tokens, cached_tokens=cached_tokens
+        )
+
+    yield from iter_openai_compat_live_events(stream, model=model, cost_fn=cost_fn)
+
+
+async def astream_openai_compat_tool_call(
+    driver: Any,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]],
+    options: dict[str, Any],
+    *,
+    provider: str,
+    default_max_tokens: int = 4096,
+    default_temperature: float = 1.0,
+) -> AsyncIterator[Any]:
+    """Async sibling of :func:`stream_openai_compat_tool_call`."""
+    from .openai_driver import _build_openai_base_kwargs
+
+    model = options.get("model", driver.model)
+    model_config = driver._get_model_config(provider, model)
+    tokens_param = model_config["tokens_param"]
+    supports_temperature = model_config["supports_temperature"]
+
+    opts = {"temperature": default_temperature, "max_tokens": default_max_tokens, **options}
+    kwargs = _build_openai_base_kwargs(
+        model,
+        messages,
+        opts,
+        tokens_param,
+        supports_temperature,
+        default_max_tokens,
+        extra={
+            "tools": tools,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        },
+    )
+
+    stream = await driver.client.chat.completions.create(**kwargs)
+
+    def cost_fn(prompt_tokens: int, completion_tokens: int, cached_tokens: int) -> float:
+        return driver._calculate_cost(
+            provider, model, prompt_tokens, completion_tokens, cached_tokens=cached_tokens
+        )
+
+    async for ev in aiter_openai_compat_live_events(stream, model=model, cost_fn=cost_fn):
+        yield ev
+
+
+__all__ = [
+    "AsyncCostFn",
+    "CostFn",
+    "aiter_openai_compat_live_events",
+    "astream_openai_compat_tool_call",
+    "iter_openai_compat_live_events",
+    "stream_openai_compat_tool_call",
+]

--- a/prompture/drivers/_openai_compat_stream.py
+++ b/prompture/drivers/_openai_compat_stream.py
@@ -293,9 +293,7 @@ def stream_openai_compat_tool_call(
     stream = driver.client.chat.completions.create(**kwargs)
 
     def cost_fn(prompt_tokens: int, completion_tokens: int, cached_tokens: int) -> float:
-        return driver._calculate_cost(
-            provider, model, prompt_tokens, completion_tokens, cached_tokens=cached_tokens
-        )
+        return driver._calculate_cost(provider, model, prompt_tokens, completion_tokens, cached_tokens=cached_tokens)
 
     yield from iter_openai_compat_live_events(stream, model=model, cost_fn=cost_fn)
 
@@ -336,9 +334,7 @@ async def astream_openai_compat_tool_call(
     stream = await driver.client.chat.completions.create(**kwargs)
 
     def cost_fn(prompt_tokens: int, completion_tokens: int, cached_tokens: int) -> float:
-        return driver._calculate_cost(
-            provider, model, prompt_tokens, completion_tokens, cached_tokens=cached_tokens
-        )
+        return driver._calculate_cost(provider, model, prompt_tokens, completion_tokens, cached_tokens=cached_tokens)
 
     async for ev in aiter_openai_compat_live_events(stream, model=model, cost_fn=cost_fn):
         yield ev
@@ -436,7 +432,10 @@ def stream_raw_http_compat_tool_call(
     from ..agents.live_events import MessageStop
 
     model, payload = _build_raw_http_payload(
-        driver, messages, tools, options,
+        driver,
+        messages,
+        tools,
+        options,
         provider=provider,
         default_max_tokens=default_max_tokens,
         default_temperature=default_temperature,
@@ -459,7 +458,7 @@ def stream_raw_http_compat_tool_call(
             line = raw_line.strip()
             if not line.startswith("data:"):
                 continue
-            data = line[len("data:"):].strip()
+            data = line[len("data:") :].strip()
             if data == "[DONE]":
                 break
             try:
@@ -471,8 +470,10 @@ def stream_raw_http_compat_tool_call(
 
     yield from _finalize_tool_use_stops(state)
     cost = driver._calculate_cost(
-        provider, model,
-        state["prompt_tokens"], state["completion_tokens"],
+        provider,
+        model,
+        state["prompt_tokens"],
+        state["completion_tokens"],
         cached_tokens=state["cached_prompt_tokens"],
     )
     yield MessageStop(stop_reason=state["finish_reason"], usage=_build_meta(state, model, cost))
@@ -498,7 +499,10 @@ async def astream_raw_http_compat_tool_call(
     from ..agents.live_events import MessageStop
 
     model, payload = _build_raw_http_payload(
-        driver, messages, tools, options,
+        driver,
+        messages,
+        tools,
+        options,
         provider=provider,
         default_max_tokens=default_max_tokens,
         default_temperature=default_temperature,
@@ -507,36 +511,40 @@ async def astream_raw_http_compat_tool_call(
     resolved_headers = headers or _bearer_headers(driver.api_key)
 
     state = _fresh_state()
-    async with httpx.AsyncClient(timeout=timeout) as client:
-        async with client.stream(
+    async with (
+        httpx.AsyncClient(timeout=timeout) as client,
+        client.stream(
             "POST",
             resolved_url,
             headers=resolved_headers,
             json=payload,
-        ) as resp:
-            resp.raise_for_status()
-            async for raw_line in resp.aiter_lines():
-                if not raw_line:
-                    continue
-                line = raw_line.strip()
-                if not line.startswith("data:"):
-                    continue
-                data = line[len("data:"):].strip()
-                if data == "[DONE]":
-                    break
-                try:
-                    chunk_dict = json.loads(data)
-                except json.JSONDecodeError:
-                    continue
-                chunk = _dict_to_chunk(chunk_dict)
-                for ev in _process_chunk(chunk, state):
-                    yield ev
+        ) as resp,
+    ):
+        resp.raise_for_status()
+        async for raw_line in resp.aiter_lines():
+            if not raw_line:
+                continue
+            line = raw_line.strip()
+            if not line.startswith("data:"):
+                continue
+            data = line[len("data:") :].strip()
+            if data == "[DONE]":
+                break
+            try:
+                chunk_dict = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+            chunk = _dict_to_chunk(chunk_dict)
+            for ev in _process_chunk(chunk, state):
+                yield ev
 
     for ev in _finalize_tool_use_stops(state):
         yield ev
     cost = driver._calculate_cost(
-        provider, model,
-        state["prompt_tokens"], state["completion_tokens"],
+        provider,
+        model,
+        state["prompt_tokens"],
+        state["completion_tokens"],
         cached_tokens=state["cached_prompt_tokens"],
     )
     yield MessageStop(stop_reason=state["finish_reason"], usage=_build_meta(state, model, cost))

--- a/prompture/drivers/airllm_driver.py
+++ b/prompture/drivers/airllm_driver.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Optional
+from typing import Any
 
 from .base import Driver
 
@@ -16,7 +16,7 @@ class AirLLMDriver(Driver):
 
     MODEL_PRICING = {"default": {"prompt": 0.0, "completion": 0.0}}
 
-    def __init__(self, model: str = "meta-llama/Llama-2-7b-hf", compression: Optional[str] = None):
+    def __init__(self, model: str = "meta-llama/Llama-2-7b-hf", compression: str | None = None):
         """
         Args:
             model: HuggingFace repo ID (e.g. ``"meta-llama/Llama-2-70b-hf"``).
@@ -64,7 +64,7 @@ class AirLLMDriver(Driver):
     # ------------------------------------------------------------------
     # Driver interface
     # ------------------------------------------------------------------
-    def generate(self, prompt: str, options: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    def generate(self, prompt: str, options: dict[str, Any] | None = None) -> dict[str, Any]:
         self._ensure_loaded()
 
         merged_options = self.options.copy()

--- a/prompture/drivers/assemblyai_stt_driver.py
+++ b/prompture/drivers/assemblyai_stt_driver.py
@@ -15,7 +15,7 @@ from typing import Any
 
 try:
     import httpx
-except Exception:
+except ImportError:
     httpx = None  # type: ignore[assignment]
 
 from .stt_base import STTDriver

--- a/prompture/drivers/async_assemblyai_stt_driver.py
+++ b/prompture/drivers/async_assemblyai_stt_driver.py
@@ -9,7 +9,7 @@ from typing import Any
 
 try:
     import httpx
-except Exception:
+except ImportError:
     httpx = None  # type: ignore[assignment]
 
 from .assemblyai_stt_driver import _format_result

--- a/prompture/drivers/async_azure_driver.py
+++ b/prompture/drivers/async_azure_driver.py
@@ -12,12 +12,12 @@ from typing import Any
 
 try:
     from openai import AsyncAzureOpenAI
-except Exception:
+except ImportError:
     AsyncAzureOpenAI = None  # type: ignore[misc, assignment]
 
 try:
     import anthropic
-except Exception:
+except ImportError:
     anthropic = None  # type: ignore[assignment]
 
 from ..infra.cost_mixin import CostMixin, prepare_strict_schema

--- a/prompture/drivers/async_base.py
+++ b/prompture/drivers/async_base.py
@@ -36,6 +36,7 @@ class AsyncDriver(ABC):
     supports_messages: bool = False
     supports_tool_use: bool = False
     supports_streaming: bool = False
+    supports_streaming_tool_use: bool = False
     supports_vision: bool = False
 
     callbacks: DriverCallbacks | None = None
@@ -88,6 +89,64 @@ class AsyncDriver(ABC):
         raise NotImplementedError(f"{self.__class__.__name__} does not support streaming")
         # yield is needed to make this an async generator
         yield  # pragma: no cover
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    async def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> AsyncIterator[Any]:
+        """Yield :class:`~prompture.agents.live_events.LiveEvent` for one
+        assistant turn (async). Async sibling of
+        :meth:`Driver.generate_messages_with_tools_stream`.
+
+        Default: wraps the buffered async
+        :meth:`generate_messages_with_tools` into a synthetic event sequence
+        so every async driver supports the new path uniformly. Drivers that
+        natively stream interleaved tool use should override this and set
+        ``supports_streaming_tool_use = True``.
+        """
+        from ..agents.live_events import (
+            MessageStop,
+            TextDelta,
+            ThinkingDelta,
+            ToolInputDelta,
+            ToolUseStart,
+            ToolUseStop,
+        )
+
+        resp = await self.generate_messages_with_tools(messages, tools, options)
+        text = resp.get("text", "") or ""
+        reasoning = resp.get("reasoning_content")
+        tool_calls = resp.get("tool_calls", []) or []
+        stop_reason = resp.get("stop_reason", "end_turn") or "end_turn"
+        meta = resp.get("meta", {}) or {}
+
+        if reasoning:
+            yield ThinkingDelta(text=reasoning)
+        if text:
+            yield TextDelta(text=text)
+
+        import json as _json
+
+        for tc in tool_calls:
+            tc_id = tc.get("id", "") or ""
+            tc_name = tc.get("name", "") or ""
+            tc_args = tc.get("arguments", {}) or {}
+            yield ToolUseStart(id=tc_id, name=tc_name)
+            try:
+                fragment = _json.dumps(tc_args)
+            except (TypeError, ValueError):
+                fragment = "{}"
+            if fragment and fragment != "{}":
+                yield ToolInputDelta(id=tc_id, fragment=fragment)
+            yield ToolUseStop(id=tc_id, name=tc_name, input=tc_args)
+
+        yield MessageStop(stop_reason=stop_reason, usage=meta)
 
     # ------------------------------------------------------------------
     # Hook-aware wrappers

--- a/prompture/drivers/async_cachibot_driver.py
+++ b/prompture/drivers/async_cachibot_driver.py
@@ -30,6 +30,7 @@ _DEFAULT_ENDPOINT = "https://cachibot.ai/api/v1"
 class AsyncCachiBotDriver(CostMixin, AsyncDriver):
     supports_json_mode = True
     supports_tool_use = True
+    supports_streaming_tool_use = True
     supports_streaming = True
     supports_vision = True
 
@@ -203,6 +204,25 @@ class AsyncCachiBotDriver(CostMixin, AsyncDriver):
             "tool_calls": tool_calls_out,
             "stop_reason": stop_reason,
         }
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    async def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ):
+        """Async streaming-tool via the shared raw-HTTP helper."""
+        from ._openai_compat_stream import astream_raw_http_compat_tool_call
+
+        async for ev in astream_raw_http_compat_tool_call(
+            self, messages, tools, options, provider="cachibot"
+        ):
+            yield ev
+
 
     # ------------------------------------------------------------------
     # Streaming

--- a/prompture/drivers/async_cachibot_driver.py
+++ b/prompture/drivers/async_cachibot_driver.py
@@ -218,11 +218,8 @@ class AsyncCachiBotDriver(CostMixin, AsyncDriver):
         """Async streaming-tool via the shared raw-HTTP helper."""
         from ._openai_compat_stream import astream_raw_http_compat_tool_call
 
-        async for ev in astream_raw_http_compat_tool_call(
-            self, messages, tools, options, provider="cachibot"
-        ):
+        async for ev in astream_raw_http_compat_tool_call(self, messages, tools, options, provider="cachibot"):
             yield ev
-
 
     # ------------------------------------------------------------------
     # Streaming

--- a/prompture/drivers/async_cartesia_tts_driver.py
+++ b/prompture/drivers/async_cartesia_tts_driver.py
@@ -8,7 +8,7 @@ from typing import Any
 
 try:
     import httpx
-except Exception:
+except ImportError:
     httpx = None  # type: ignore[assignment]
 
 from .async_tts_base import AsyncTTSDriver

--- a/prompture/drivers/async_claude_driver.py
+++ b/prompture/drivers/async_claude_driver.py
@@ -16,6 +16,8 @@ from ..infra.cost_mixin import CostMixin
 from .async_base import AsyncDriver
 from .claude_driver import (
     ClaudeDriver,
+    _apply_cache_control_to_system,
+    _apply_cache_control_to_tools,
     _build_anthropic_json_mode_tool_def,
     _build_anthropic_meta,
     _build_anthropic_stream_done,
@@ -74,6 +76,7 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
         model = options.get("model", self.model)
+        cache_prompt = opts.get("cache_prompt", True)
 
         # Validate capabilities against models.dev metadata
         self._validate_model_capabilities(
@@ -95,16 +98,21 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
         }
         if supports_temperature:
             common_kwargs["temperature"] = opts["temperature"]
-        if system_content:
-            common_kwargs["system"] = system_content
+        wrapped_system = _apply_cache_control_to_system(system_content, cache_prompt=cache_prompt)
+        if wrapped_system is not None:
+            common_kwargs["system"] = wrapped_system
 
         # Native JSON mode: use tool-use for schema enforcement
         if options.get("json_mode"):
             json_schema = options.get("json_schema")
             if json_schema:
+                json_mode_tools = _apply_cache_control_to_tools(
+                    [_build_anthropic_json_mode_tool_def(json_schema)],
+                    cache_prompt=cache_prompt,
+                )
                 resp = await client.messages.create(  # type: ignore[call-overload]
                     **common_kwargs,
-                    tools=[_build_anthropic_json_mode_tool_def(json_schema)],
+                    tools=json_mode_tools,
                     tool_choice={"type": "tool", "name": "extract_json"},
                 )
                 text = ""
@@ -162,6 +170,7 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
         model = options.get("model", self.model)
+        cache_prompt = opts.get("cache_prompt", True)
 
         self._validate_model_capabilities("claude", model, using_tool_use=True)
 
@@ -170,7 +179,9 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
         client = self.client
 
         system_content, api_messages = _extract_anthropic_system_and_messages(messages)
-        anthropic_tools = _convert_tools_to_anthropic(tools)
+        anthropic_tools = _apply_cache_control_to_tools(
+            _convert_tools_to_anthropic(tools), cache_prompt=cache_prompt
+        )
 
         kwargs: dict[str, Any] = {
             "model": model,
@@ -180,8 +191,9 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
         }
         if supports_temperature:
             kwargs["temperature"] = opts["temperature"]
-        if system_content:
-            kwargs["system"] = system_content
+        wrapped_system = _apply_cache_control_to_system(system_content, cache_prompt=cache_prompt)
+        if wrapped_system is not None:
+            kwargs["system"] = wrapped_system
 
         resp = await client.messages.create(**kwargs)
 
@@ -224,6 +236,7 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
         model = options.get("model", self.model)
+        cache_prompt = opts.get("cache_prompt", True)
         supports_temperature = self._get_model_config("claude", model)["supports_temperature"]
         client = self.client
 
@@ -236,8 +249,9 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
         }
         if supports_temperature:
             kwargs["temperature"] = opts["temperature"]
-        if system_content:
-            kwargs["system"] = system_content
+        wrapped_system = _apply_cache_control_to_system(system_content, cache_prompt=cache_prompt)
+        if wrapped_system is not None:
+            kwargs["system"] = wrapped_system
 
         full_text = ""
         full_reasoning = ""

--- a/prompture/drivers/async_claude_driver.py
+++ b/prompture/drivers/async_claude_driver.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from collections.abc import AsyncIterator
 from typing import Any
@@ -26,6 +27,8 @@ from .claude_driver import (
     _extract_anthropic_system_and_messages,
     _extract_anthropic_text_and_tool_calls,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class AsyncClaudeDriver(CostMixin, AsyncDriver):
@@ -76,8 +79,7 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
             from ..exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "anthropic package not installed. "
-                'Install it with: pip install "prompture[anthropic]"'
+                'anthropic package not installed. Install it with: pip install "prompture[anthropic]"'
             )
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
@@ -175,8 +177,7 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
             from ..exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "anthropic package not installed. "
-                'Install it with: pip install "prompture[anthropic]"'
+                'anthropic package not installed. Install it with: pip install "prompture[anthropic]"'
             )
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
@@ -190,9 +191,7 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
         client = self.client
 
         system_content, api_messages = _extract_anthropic_system_and_messages(messages)
-        anthropic_tools = _apply_cache_control_to_tools(
-            _convert_tools_to_anthropic(tools), cache_prompt=cache_prompt
-        )
+        anthropic_tools = _apply_cache_control_to_tools(_convert_tools_to_anthropic(tools), cache_prompt=cache_prompt)
 
         kwargs: dict[str, Any] = {
             "model": model,
@@ -246,8 +245,7 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
             from ..exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "anthropic package not installed. "
-                'Install it with: pip install "prompture[anthropic]"'
+                'anthropic package not installed. Install it with: pip install "prompture[anthropic]"'
             )
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
@@ -338,8 +336,7 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
             from ..exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "anthropic package not installed. "
-                'Install it with: pip install "prompture[anthropic]"'
+                'anthropic package not installed. Install it with: pip install "prompture[anthropic]"'
             )
 
         from ..agents.live_events import (
@@ -358,9 +355,7 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
         client = self.client
 
         system_content, api_messages = _extract_anthropic_system_and_messages(messages)
-        anthropic_tools = _apply_cache_control_to_tools(
-            _convert_tools_to_anthropic(tools), cache_prompt=cache_prompt
-        )
+        anthropic_tools = _apply_cache_control_to_tools(_convert_tools_to_anthropic(tools), cache_prompt=cache_prompt)
 
         kwargs: dict[str, Any] = {
             "model": model,

--- a/prompture/drivers/async_claude_driver.py
+++ b/prompture/drivers/async_claude_driver.py
@@ -38,6 +38,21 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
     def __init__(self, api_key: str | None = None, model: str = "claude-haiku-4-5-20251001"):
         self.api_key = api_key or os.getenv("CLAUDE_API_KEY")
         self.model = model or os.getenv("CLAUDE_MODEL_NAME", "claude-haiku-4-5-20251001")
+        if anthropic is None:
+            self.client = None
+            return
+        if not self.api_key:
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "CLAUDE_API_KEY is not set. Provide api_key=... or set the "
+                "CLAUDE_API_KEY environment variable. "
+                "See https://github.com/jhd3197/prompture#configuration"
+            )
+        # Cache one AsyncAnthropic client for the lifetime of this driver so
+        # we reuse its HTTP/2 connection pool instead of building a fresh TLS
+        # session per request.
+        self.client = anthropic.AsyncAnthropic(api_key=self.api_key)
 
     supports_messages = True
 
@@ -54,7 +69,7 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
         return await self._do_generate(self._prepare_messages(messages), options)
 
     async def _do_generate(self, messages: list[dict[str, str]], options: dict[str, Any]) -> dict[str, Any]:
-        if anthropic is None:
+        if self.client is None:
             raise RuntimeError("anthropic package not installed")
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
@@ -69,7 +84,7 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
 
         supports_temperature = self._get_model_config("claude", model)["supports_temperature"]
 
-        client = anthropic.AsyncAnthropic(api_key=self.api_key)
+        client = self.client
 
         system_content, api_messages = _extract_anthropic_system_and_messages(messages)
 
@@ -142,7 +157,7 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
         options: dict[str, Any],
     ) -> dict[str, Any]:
         """Generate a response that may include tool calls (Anthropic)."""
-        if anthropic is None:
+        if self.client is None:
             raise RuntimeError("anthropic package not installed")
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
@@ -152,7 +167,7 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
 
         supports_temperature = self._get_model_config("claude", model)["supports_temperature"]
 
-        client = anthropic.AsyncAnthropic(api_key=self.api_key)
+        client = self.client
 
         system_content, api_messages = _extract_anthropic_system_and_messages(messages)
         anthropic_tools = _convert_tools_to_anthropic(tools)
@@ -204,13 +219,13 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
         options: dict[str, Any],
     ) -> AsyncIterator[dict[str, Any]]:
         """Yield response chunks via Anthropic streaming API."""
-        if anthropic is None:
+        if self.client is None:
             raise RuntimeError("anthropic package not installed")
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
         model = options.get("model", self.model)
         supports_temperature = self._get_model_config("claude", model)["supports_temperature"]
-        client = anthropic.AsyncAnthropic(api_key=self.api_key)
+        client = self.client
 
         system_content, api_messages = _extract_anthropic_system_and_messages(messages)
 

--- a/prompture/drivers/async_claude_driver.py
+++ b/prompture/drivers/async_claude_driver.py
@@ -9,7 +9,7 @@ from typing import Any
 
 try:
     import anthropic
-except Exception:
+except ImportError:
     anthropic = None  # type: ignore[assignment]
 
 from ..infra.cost_mixin import CostMixin
@@ -72,7 +72,12 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
 
     async def _do_generate(self, messages: list[dict[str, str]], options: dict[str, Any]) -> dict[str, Any]:
         if self.client is None:
-            raise RuntimeError("anthropic package not installed")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "anthropic package not installed. "
+                'Install it with: pip install "prompture[anthropic]"'
+            )
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
         model = options.get("model", self.model)
@@ -166,7 +171,12 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
     ) -> dict[str, Any]:
         """Generate a response that may include tool calls (Anthropic)."""
         if self.client is None:
-            raise RuntimeError("anthropic package not installed")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "anthropic package not installed. "
+                'Install it with: pip install "prompture[anthropic]"'
+            )
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
         model = options.get("model", self.model)
@@ -232,7 +242,12 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
     ) -> AsyncIterator[dict[str, Any]]:
         """Yield response chunks via Anthropic streaming API."""
         if self.client is None:
-            raise RuntimeError("anthropic package not installed")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "anthropic package not installed. "
+                'Install it with: pip install "prompture[anthropic]"'
+            )
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
         model = options.get("model", self.model)

--- a/prompture/drivers/async_claude_driver.py
+++ b/prompture/drivers/async_claude_driver.py
@@ -33,6 +33,7 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
     supports_json_schema = True
     supports_tool_use = True
     supports_streaming = True
+    supports_streaming_tool_use = True
     supports_vision = True
 
     MODEL_PRICING = ClaudeDriver.MODEL_PRICING
@@ -317,3 +318,154 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
             cached_prompt_tokens=cache_read,
             cache_creation_tokens=cache_create,
         )
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    async def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> AsyncIterator[Any]:
+        """Async sibling of :meth:`ClaudeDriver.generate_messages_with_tools_stream`.
+
+        Maps Anthropic SSE events to :class:`LiveEvent` for one turn,
+        preserving interleaved text + thinking + tool_use ordering.
+        """
+        if self.client is None:
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "anthropic package not installed. "
+                'Install it with: pip install "prompture[anthropic]"'
+            )
+
+        from ..agents.live_events import (
+            MessageStop,
+            TextDelta,
+            ThinkingDelta,
+            ToolInputDelta,
+            ToolUseStart,
+            ToolUseStop,
+        )
+
+        opts = {**{"temperature": 0.0, "max_tokens": 4096}, **options}
+        model = options.get("model", self.model)
+        cache_prompt = opts.get("cache_prompt", True)
+        supports_temperature = self._get_model_config("claude", model)["supports_temperature"]
+        client = self.client
+
+        system_content, api_messages = _extract_anthropic_system_and_messages(messages)
+        anthropic_tools = _apply_cache_control_to_tools(
+            _convert_tools_to_anthropic(tools), cache_prompt=cache_prompt
+        )
+
+        kwargs: dict[str, Any] = {
+            "model": model,
+            "messages": api_messages,
+            "max_tokens": opts["max_tokens"],
+            "tools": anthropic_tools,
+        }
+        if supports_temperature:
+            kwargs["temperature"] = opts["temperature"]
+        wrapped_system = _apply_cache_control_to_system(system_content, cache_prompt=cache_prompt)
+        if wrapped_system is not None:
+            kwargs["system"] = wrapped_system
+
+        block_kinds: dict[int, str] = {}
+        tool_block_info: dict[int, dict[str, Any]] = {}
+        tool_input_buffers: dict[int, list[str]] = {}
+
+        base_input = 0
+        cache_read = 0
+        cache_create = 0
+        completion_tokens = 0
+        stop_reason = "end_turn"
+
+        async with client.messages.stream(**kwargs) as stream:
+            async for event in stream:
+                ev_type = getattr(event, "type", "")
+                if ev_type == "message_start":
+                    usage = getattr(getattr(event, "message", None), "usage", None)
+                    if usage is not None:
+                        base_input = getattr(usage, "input_tokens", 0) or 0
+                        cache_read, cache_create = _extract_anthropic_cache_tokens(usage)
+                elif ev_type == "content_block_start":
+                    idx = getattr(event, "index", 0)
+                    block = getattr(event, "content_block", None)
+                    kind = getattr(block, "type", "") if block is not None else ""
+                    block_kinds[idx] = kind
+                    if kind == "tool_use":
+                        tool_id = getattr(block, "id", "") or ""
+                        tool_name = getattr(block, "name", "") or ""
+                        tool_block_info[idx] = {"id": tool_id, "name": tool_name}
+                        tool_input_buffers[idx] = []
+                        yield ToolUseStart(id=tool_id, name=tool_name)
+                elif ev_type == "content_block_delta":
+                    idx = getattr(event, "index", 0)
+                    delta = getattr(event, "delta", None)
+                    delta_type = getattr(delta, "type", "") if delta is not None else ""
+                    if delta_type == "text_delta":
+                        text_piece = getattr(delta, "text", "") or ""
+                        if text_piece:
+                            yield TextDelta(text=text_piece)
+                    elif delta_type == "thinking_delta":
+                        thinking_piece = getattr(delta, "thinking", "") or ""
+                        if thinking_piece:
+                            yield ThinkingDelta(text=thinking_piece)
+                    elif delta_type == "input_json_delta":
+                        fragment = getattr(delta, "partial_json", "") or ""
+                        info = tool_block_info.get(idx)
+                        if fragment and info is not None:
+                            tool_input_buffers.setdefault(idx, []).append(fragment)
+                            yield ToolInputDelta(id=info["id"], fragment=fragment)
+                elif ev_type == "content_block_stop":
+                    idx = getattr(event, "index", 0)
+                    if block_kinds.get(idx) == "tool_use":
+                        info = tool_block_info.get(idx, {})
+                        buf = "".join(tool_input_buffers.get(idx, []))
+                        try:
+                            parsed = json.loads(buf) if buf else {}
+                            if not isinstance(parsed, dict):
+                                parsed = {}
+                        except json.JSONDecodeError:
+                            logger.warning(
+                                "Failed to parse streamed tool input for %s: %r",
+                                info.get("name", "?"),
+                                buf[:200],
+                            )
+                            parsed = {}
+                        yield ToolUseStop(
+                            id=info.get("id", ""),
+                            name=info.get("name", ""),
+                            input=parsed,
+                        )
+                elif ev_type == "message_delta":
+                    usage = getattr(event, "usage", None)
+                    if usage is not None:
+                        completion_tokens = getattr(usage, "output_tokens", 0) or completion_tokens
+                    sr = getattr(getattr(event, "delta", None), "stop_reason", None)
+                    if sr:
+                        stop_reason = sr
+
+        prompt_tokens = base_input + cache_read + cache_create
+        total_cost = self._calculate_cost(
+            "claude",
+            model,
+            prompt_tokens,
+            completion_tokens,
+            cached_tokens=cache_read,
+            cache_creation_tokens=cache_create,
+        )
+        meta = {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+            "cached_prompt_tokens": cache_read,
+            "cache_creation_tokens": cache_create,
+            "cost": round(total_cost, 6),
+            "model_name": model,
+        }
+        yield MessageStop(stop_reason=stop_reason, usage=meta)

--- a/prompture/drivers/async_deepgram_stt_driver.py
+++ b/prompture/drivers/async_deepgram_stt_driver.py
@@ -8,7 +8,7 @@ from typing import Any
 
 try:
     import httpx
-except Exception:
+except ImportError:
     httpx = None  # type: ignore[assignment]
 
 from .async_stt_base import AsyncSTTDriver

--- a/prompture/drivers/async_deepgram_tts_driver.py
+++ b/prompture/drivers/async_deepgram_tts_driver.py
@@ -8,7 +8,7 @@ from typing import Any
 
 try:
     import httpx
-except Exception:
+except ImportError:
     httpx = None  # type: ignore[assignment]
 
 from .async_tts_base import AsyncTTSDriver

--- a/prompture/drivers/async_elevenlabs_stt_driver.py
+++ b/prompture/drivers/async_elevenlabs_stt_driver.py
@@ -8,7 +8,7 @@ from typing import Any
 
 try:
     import httpx
-except Exception:
+except ImportError:
     httpx = None  # type: ignore[assignment]
 
 from ..infra.cost_mixin import AudioCostMixin

--- a/prompture/drivers/async_elevenlabs_tts_driver.py
+++ b/prompture/drivers/async_elevenlabs_tts_driver.py
@@ -9,7 +9,7 @@ from typing import Any
 
 try:
     import httpx
-except Exception:
+except ImportError:
     httpx = None  # type: ignore[assignment]
 
 from ..infra.cost_mixin import AudioCostMixin

--- a/prompture/drivers/async_google_driver.py
+++ b/prompture/drivers/async_google_driver.py
@@ -38,8 +38,7 @@ class AsyncGoogleDriver(CostMixin, AsyncDriver):
             from ..exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "google-genai package is not installed. "
-                'Install it with: pip install "prompture[google]"'
+                'google-genai package is not installed. Install it with: pip install "prompture[google]"'
             )
         self.api_key = api_key or os.getenv("GOOGLE_API_KEY")
         if not self.api_key:

--- a/prompture/drivers/async_google_driver.py
+++ b/prompture/drivers/async_google_driver.py
@@ -38,7 +38,13 @@ class AsyncGoogleDriver(CostMixin, AsyncDriver):
             raise RuntimeError("google-genai package is not installed. Install it with: pip install google-genai")
         self.api_key = api_key or os.getenv("GOOGLE_API_KEY")
         if not self.api_key:
-            raise ValueError("Google API key not found. Set GOOGLE_API_KEY env var or pass api_key to constructor")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "GOOGLE_API_KEY is not set. Provide api_key=... or set the "
+                "GOOGLE_API_KEY environment variable. "
+                "See https://github.com/jhd3197/prompture#configuration"
+            )
         self.model = model
         self._client = genai.Client(api_key=self.api_key)
         self.options: dict[str, Any] = {}

--- a/prompture/drivers/async_google_driver.py
+++ b/prompture/drivers/async_google_driver.py
@@ -11,7 +11,7 @@ from typing import Any
 try:
     from google import genai
     from google.genai import types
-except Exception:
+except ImportError:
     genai = None  # type: ignore[assignment]
     types = None  # type: ignore[assignment]
 
@@ -35,7 +35,12 @@ class AsyncGoogleDriver(CostMixin, AsyncDriver):
 
     def __init__(self, api_key: str | None = None, model: str = "gemini-1.5-pro"):
         if genai is None:
-            raise RuntimeError("google-genai package is not installed. Install it with: pip install google-genai")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "google-genai package is not installed. "
+                'Install it with: pip install "prompture[google]"'
+            )
         self.api_key = api_key or os.getenv("GOOGLE_API_KEY")
         if not self.api_key:
             from ..exceptions import ConfigurationError
@@ -230,7 +235,9 @@ class AsyncGoogleDriver(CostMixin, AsyncDriver):
 
         except Exception as e:
             logger.error(f"Google API request failed: {e}")
-            raise RuntimeError(f"Google API request failed: {e}") from e
+            from ..exceptions import DriverError
+
+            raise DriverError(f"Google API request failed: {e}") from e
 
     # ------------------------------------------------------------------
     # Tool use
@@ -334,7 +341,9 @@ class AsyncGoogleDriver(CostMixin, AsyncDriver):
 
         except Exception as e:
             logger.error(f"Google API tool call request failed: {e}")
-            raise RuntimeError(f"Google API tool call request failed: {e}") from e
+            from ..exceptions import DriverError
+
+            raise DriverError(f"Google API tool call request failed: {e}") from e
 
     # ------------------------------------------------------------------
     # Streaming
@@ -378,4 +387,6 @@ class AsyncGoogleDriver(CostMixin, AsyncDriver):
 
         except Exception as e:
             logger.error(f"Google API streaming request failed: {e}")
-            raise RuntimeError(f"Google API streaming request failed: {e}") from e
+            from ..exceptions import DriverError
+
+            raise DriverError(f"Google API streaming request failed: {e}") from e

--- a/prompture/drivers/async_google_vertexai_driver.py
+++ b/prompture/drivers/async_google_vertexai_driver.py
@@ -15,13 +15,13 @@ from typing import Any
 try:
     from google import genai
     from google.genai import types
-except Exception:
+except ImportError:
     genai = None  # type: ignore[assignment]
     types = None  # type: ignore[assignment]
 
 try:
     from anthropic import AsyncAnthropicVertex
-except Exception:
+except ImportError:
     AsyncAnthropicVertex = None  # type: ignore[assignment]
 
 from ..infra.cost_mixin import CostMixin

--- a/prompture/drivers/async_grok_driver.py
+++ b/prompture/drivers/async_grok_driver.py
@@ -19,6 +19,9 @@ logger = logging.getLogger(__name__)
 class AsyncGrokDriver(CostMixin, AsyncDriver):
     supports_json_mode = True
     supports_tool_use = True
+    supports_streaming = True
+    supports_streaming_tool_use = True
+
     supports_vision = True
 
     MODEL_PRICING = GrokDriver.MODEL_PRICING
@@ -218,3 +221,22 @@ class AsyncGrokDriver(CostMixin, AsyncDriver):
         if choice["message"].get("reasoning_content") is not None:
             result["reasoning_content"] = choice["message"]["reasoning_content"]
         return result
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    async def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ):
+        """Async streaming-tool via the shared raw-HTTP helper."""
+        from ._openai_compat_stream import astream_raw_http_compat_tool_call
+
+        async for ev in astream_raw_http_compat_tool_call(
+            self, messages, tools, options, provider="grok"
+        ):
+            yield ev
+

--- a/prompture/drivers/async_grok_driver.py
+++ b/prompture/drivers/async_grok_driver.py
@@ -19,7 +19,6 @@ logger = logging.getLogger(__name__)
 class AsyncGrokDriver(CostMixin, AsyncDriver):
     supports_json_mode = True
     supports_tool_use = True
-    supports_streaming = True
     supports_streaming_tool_use = True
 
     supports_vision = True
@@ -235,8 +234,5 @@ class AsyncGrokDriver(CostMixin, AsyncDriver):
         """Async streaming-tool via the shared raw-HTTP helper."""
         from ._openai_compat_stream import astream_raw_http_compat_tool_call
 
-        async for ev in astream_raw_http_compat_tool_call(
-            self, messages, tools, options, provider="grok"
-        ):
+        async for ev in astream_raw_http_compat_tool_call(self, messages, tools, options, provider="grok"):
             yield ev
-

--- a/prompture/drivers/async_grok_img_gen_driver.py
+++ b/prompture/drivers/async_grok_img_gen_driver.py
@@ -8,7 +8,7 @@ from typing import Any
 
 try:
     from openai import AsyncOpenAI
-except Exception:
+except ImportError:
     AsyncOpenAI = None  # type: ignore[misc, assignment]
 
 from ..infra.cost_mixin import ImageCostMixin

--- a/prompture/drivers/async_groq_driver.py
+++ b/prompture/drivers/async_groq_driver.py
@@ -29,10 +29,18 @@ class AsyncGroqDriver(CostMixin, AsyncDriver):
     def __init__(self, api_key: str | None = None, model: str = "llama2-70b-4096"):
         self.api_key = api_key or os.getenv("GROQ_API_KEY")
         self.model = model
-        if groq is not None:
-            self.client: Any = groq.AsyncClient(api_key=self.api_key)
-        else:
-            self.client = None
+        if groq is None:
+            self.client: Any = None
+            return
+        if not self.api_key:
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "GROQ_API_KEY is not set. Provide api_key=... or set the "
+                "GROQ_API_KEY environment variable. "
+                "See https://github.com/jhd3197/prompture#configuration"
+            )
+        self.client: Any = groq.AsyncClient(api_key=self.api_key)
 
     supports_messages = True
 

--- a/prompture/drivers/async_groq_driver.py
+++ b/prompture/drivers/async_groq_driver.py
@@ -22,7 +22,6 @@ logger = logging.getLogger(__name__)
 class AsyncGroqDriver(CostMixin, AsyncDriver):
     supports_json_mode = True
     supports_tool_use = True
-    supports_streaming = True
     supports_streaming_tool_use = True
     supports_vision = True
 
@@ -62,10 +61,7 @@ class AsyncGroqDriver(CostMixin, AsyncDriver):
         if self.client is None:
             from ..exceptions import ConfigurationError
 
-            raise ConfigurationError(
-                "groq package is not installed. "
-                'Install it with: pip install "prompture[groq]"'
-            )
+            raise ConfigurationError('groq package is not installed. Install it with: pip install "prompture[groq]"')
 
         model = options.get("model", self.model)
 
@@ -141,10 +137,7 @@ class AsyncGroqDriver(CostMixin, AsyncDriver):
         if self.client is None:
             from ..exceptions import ConfigurationError
 
-            raise ConfigurationError(
-                "groq package is not installed. "
-                'Install it with: pip install "prompture[groq]"'
-            )
+            raise ConfigurationError('groq package is not installed. Install it with: pip install "prompture[groq]"')
 
         model = options.get("model", self.model)
         model_config = self._get_model_config("groq", model)
@@ -233,14 +226,9 @@ class AsyncGroqDriver(CostMixin, AsyncDriver):
         if self.client is None:
             from ..exceptions import ConfigurationError
 
-            raise ConfigurationError(
-                "groq package is not installed. "
-                'Install it with: pip install "prompture[groq]"'
-            )
+            raise ConfigurationError('groq package is not installed. Install it with: pip install "prompture[groq]"')
 
         from ._openai_compat_stream import astream_openai_compat_tool_call
 
-        async for ev in astream_openai_compat_tool_call(
-            self, messages, tools, options, provider="groq"
-        ):
+        async for ev in astream_openai_compat_tool_call(self, messages, tools, options, provider="groq"):
             yield ev

--- a/prompture/drivers/async_groq_driver.py
+++ b/prompture/drivers/async_groq_driver.py
@@ -22,6 +22,8 @@ logger = logging.getLogger(__name__)
 class AsyncGroqDriver(CostMixin, AsyncDriver):
     supports_json_mode = True
     supports_tool_use = True
+    supports_streaming = True
+    supports_streaming_tool_use = True
     supports_vision = True
 
     MODEL_PRICING = GroqDriver.MODEL_PRICING
@@ -216,3 +218,29 @@ class AsyncGroqDriver(CostMixin, AsyncDriver):
         if reasoning_content is not None:
             result["reasoning_content"] = reasoning_content
         return result
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    async def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ):
+        """Async streaming-tool via the shared OpenAI-compat helper."""
+        if self.client is None:
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "groq package is not installed. "
+                'Install it with: pip install "prompture[groq]"'
+            )
+
+        from ._openai_compat_stream import astream_openai_compat_tool_call
+
+        async for ev in astream_openai_compat_tool_call(
+            self, messages, tools, options, provider="groq"
+        ):
+            yield ev

--- a/prompture/drivers/async_groq_driver.py
+++ b/prompture/drivers/async_groq_driver.py
@@ -8,7 +8,7 @@ from typing import Any
 
 try:
     import groq
-except Exception:
+except ImportError:
     groq = None  # type: ignore[assignment]
 
 from ..infra.cost_mixin import CostMixin
@@ -58,7 +58,12 @@ class AsyncGroqDriver(CostMixin, AsyncDriver):
 
     async def _do_generate(self, messages: list[dict[str, str]], options: dict[str, Any]) -> dict[str, Any]:
         if self.client is None:
-            raise RuntimeError("groq package is not installed")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "groq package is not installed. "
+                'Install it with: pip install "prompture[groq]"'
+            )
 
         model = options.get("model", self.model)
 
@@ -132,7 +137,12 @@ class AsyncGroqDriver(CostMixin, AsyncDriver):
     ) -> dict[str, Any]:
         """Generate a response that may include tool calls."""
         if self.client is None:
-            raise RuntimeError("groq package is not installed")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "groq package is not installed. "
+                'Install it with: pip install "prompture[groq]"'
+            )
 
         model = options.get("model", self.model)
         model_config = self._get_model_config("groq", model)

--- a/prompture/drivers/async_lmstudio_driver.py
+++ b/prompture/drivers/async_lmstudio_driver.py
@@ -87,6 +87,16 @@ class AsyncLMStudioDriver(AsyncDriver):
                 # LM Studio rejects "json_object" type.
                 pass
 
+        # vLLM-style guided_json pass-through + generic extra_body escape hatch.
+        from ._openai_compat import apply_guided_decoding, merge_extra_body
+
+        apply_guided_decoding(
+            payload,
+            json_schema=merged_options.get("json_schema"),
+            guided_decoding=merged_options.get("guided_decoding"),
+        )
+        merge_extra_body(payload, merged_options)
+
         async with httpx.AsyncClient() as client:
             try:
                 r = await client.post(self.endpoint, json=payload, headers=self._headers, timeout=120)

--- a/prompture/drivers/async_mistral_driver.py
+++ b/prompture/drivers/async_mistral_driver.py
@@ -197,8 +197,5 @@ class AsyncMistralDriver(CostMixin, AsyncDriver):
         """Async streaming-tool via the shared raw-HTTP helper."""
         from ._openai_compat_stream import astream_raw_http_compat_tool_call
 
-        async for ev in astream_raw_http_compat_tool_call(
-            self, messages, tools, options, provider="mistral"
-        ):
+        async for ev in astream_raw_http_compat_tool_call(self, messages, tools, options, provider="mistral"):
             yield ev
-

--- a/prompture/drivers/async_mistral_driver.py
+++ b/prompture/drivers/async_mistral_driver.py
@@ -20,6 +20,8 @@ class AsyncMistralDriver(CostMixin, AsyncDriver):
     supports_json_mode = True
     supports_json_schema = True
     supports_tool_use = True
+    supports_streaming = True
+    supports_streaming_tool_use = True
     supports_streaming = False
     supports_vision = True
     supports_messages = True
@@ -181,3 +183,22 @@ class AsyncMistralDriver(CostMixin, AsyncDriver):
             "tool_calls": tool_calls_out,
             "stop_reason": stop_reason,
         }
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    async def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ):
+        """Async streaming-tool via the shared raw-HTTP helper."""
+        from ._openai_compat_stream import astream_raw_http_compat_tool_call
+
+        async for ev in astream_raw_http_compat_tool_call(
+            self, messages, tools, options, provider="mistral"
+        ):
+            yield ev
+

--- a/prompture/drivers/async_modelscope_driver.py
+++ b/prompture/drivers/async_modelscope_driver.py
@@ -24,6 +24,7 @@ class AsyncModelScopeDriver(CostMixin, AsyncDriver):
     supports_json_mode = True
     supports_json_schema = False
     supports_tool_use = True
+    supports_streaming_tool_use = True
     supports_streaming = True
     supports_vision = False
 
@@ -219,6 +220,25 @@ class AsyncModelScopeDriver(CostMixin, AsyncDriver):
             "tool_calls": tool_calls_out,
             "stop_reason": stop_reason,
         }
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    async def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ):
+        """Async streaming-tool via the shared raw-HTTP helper."""
+        from ._openai_compat_stream import astream_raw_http_compat_tool_call
+
+        async for ev in astream_raw_http_compat_tool_call(
+            self, messages, tools, options, provider="modelscope"
+        ):
+            yield ev
+
 
     # ------------------------------------------------------------------
     # Streaming

--- a/prompture/drivers/async_modelscope_driver.py
+++ b/prompture/drivers/async_modelscope_driver.py
@@ -234,11 +234,8 @@ class AsyncModelScopeDriver(CostMixin, AsyncDriver):
         """Async streaming-tool via the shared raw-HTTP helper."""
         from ._openai_compat_stream import astream_raw_http_compat_tool_call
 
-        async for ev in astream_raw_http_compat_tool_call(
-            self, messages, tools, options, provider="modelscope"
-        ):
+        async for ev in astream_raw_http_compat_tool_call(self, messages, tools, options, provider="modelscope"):
             yield ev
-
 
     # ------------------------------------------------------------------
     # Streaming

--- a/prompture/drivers/async_moonshot_driver.py
+++ b/prompture/drivers/async_moonshot_driver.py
@@ -29,6 +29,8 @@ class AsyncMoonshotDriver(CostMixin, AsyncDriver):
     supports_json_mode = True
     supports_json_schema = True
     supports_tool_use = True
+    supports_streaming_tool_use = True
+
     supports_streaming = True
     supports_vision = True
 
@@ -338,6 +340,25 @@ class AsyncMoonshotDriver(CostMixin, AsyncDriver):
             result["reasoning_content"] = message["reasoning_content"]
 
         return result
+
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    async def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ):
+        """Async streaming-tool via the shared raw-HTTP helper."""
+        from ._openai_compat_stream import astream_raw_http_compat_tool_call
+
+        async for ev in astream_raw_http_compat_tool_call(
+            self, messages, tools, options, provider="moonshot"
+        ):
+            yield ev
 
     # ------------------------------------------------------------------
     # Streaming

--- a/prompture/drivers/async_moonshot_driver.py
+++ b/prompture/drivers/async_moonshot_driver.py
@@ -341,7 +341,6 @@ class AsyncMoonshotDriver(CostMixin, AsyncDriver):
 
         return result
 
-
     # ------------------------------------------------------------------
     # Live streaming with interleaved tool calls
     # ------------------------------------------------------------------
@@ -355,9 +354,7 @@ class AsyncMoonshotDriver(CostMixin, AsyncDriver):
         """Async streaming-tool via the shared raw-HTTP helper."""
         from ._openai_compat_stream import astream_raw_http_compat_tool_call
 
-        async for ev in astream_raw_http_compat_tool_call(
-            self, messages, tools, options, provider="moonshot"
-        ):
+        async for ev in astream_raw_http_compat_tool_call(self, messages, tools, options, provider="moonshot"):
             yield ev
 
     # ------------------------------------------------------------------

--- a/prompture/drivers/async_ollama_driver.py
+++ b/prompture/drivers/async_ollama_driver.py
@@ -168,9 +168,13 @@ class AsyncOllamaDriver(AsyncDriver):
             "stream": False,
         }
 
-        if merged_options.get("json_mode"):
-            json_schema = merged_options.get("json_schema")
-            payload["format"] = json_schema if json_schema else "json"
+        # Native JSON mode / structured output (Ollama >=0.5 accepts a JSON
+        # schema dict directly in `format`). A schema implies JSON mode.
+        json_schema = merged_options.get("json_schema")
+        if json_schema is not None:
+            payload["format"] = json_schema
+        elif merged_options.get("json_mode"):
+            payload["format"] = "json"
 
         if "temperature" in merged_options:
             payload["temperature"] = merged_options["temperature"]

--- a/prompture/drivers/async_openai_compatible_driver.py
+++ b/prompture/drivers/async_openai_compatible_driver.py
@@ -98,6 +98,8 @@ class AsyncOpenAICompatibleDriver(CostMixin, AsyncDriver):
         if supports_temperature and "temperature" in opts:
             data["temperature"] = opts["temperature"]
 
+        from ._openai_compat import apply_guided_decoding, merge_extra_body
+
         if options.get("json_mode"):
             json_schema = options.get("json_schema")
             if json_schema:
@@ -112,6 +114,14 @@ class AsyncOpenAICompatibleDriver(CostMixin, AsyncDriver):
                 }
             else:
                 data["response_format"] = {"type": "json_object"}
+
+        # vLLM-style FSM-constrained decoding pass-through (8A-lite).
+        apply_guided_decoding(
+            data,
+            json_schema=options.get("json_schema"),
+            guided_decoding=options.get("guided_decoding"),
+        )
+        merge_extra_body(data, options)
 
         async with httpx.AsyncClient() as client:
             try:

--- a/prompture/drivers/async_openai_driver.py
+++ b/prompture/drivers/async_openai_driver.py
@@ -32,6 +32,7 @@ class AsyncOpenAIDriver(CostMixin, AsyncDriver):
     supports_json_schema = True
     supports_tool_use = True
     supports_streaming = True
+    supports_streaming_tool_use = True
     supports_vision = True
 
     MODEL_PRICING = OpenAIDriver.MODEL_PRICING
@@ -231,3 +232,29 @@ class AsyncOpenAIDriver(CostMixin, AsyncDriver):
         yield _build_openai_stream_done(
             model, full_text, prompt_tokens, completion_tokens, total_cost, cached_prompt_tokens
         )
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    async def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> AsyncIterator[Any]:
+        """Async streaming-tool via the shared OpenAI-compat helper."""
+        if self.client is None:
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "openai package (>=1.0.0) is not installed. "
+                'Install it with: pip install "prompture[openai]"'
+            )
+
+        from ._openai_compat_stream import astream_openai_compat_tool_call
+
+        async for ev in astream_openai_compat_tool_call(
+            self, messages, tools, options, provider="openai"
+        ):
+            yield ev

--- a/prompture/drivers/async_openai_driver.py
+++ b/prompture/drivers/async_openai_driver.py
@@ -39,10 +39,18 @@ class AsyncOpenAIDriver(CostMixin, AsyncDriver):
     def __init__(self, api_key: str | None = None, model: str = "gpt-4o-mini"):
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
         self.model = model
-        if AsyncOpenAI is not None:
-            self.client = AsyncOpenAI(api_key=self.api_key)
-        else:
+        if AsyncOpenAI is None:
             self.client = None
+            return
+        if not self.api_key:
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "OPENAI_API_KEY is not set. Provide api_key=... or set the "
+                "OPENAI_API_KEY environment variable. "
+                "See https://github.com/jhd3197/prompture#configuration"
+            )
+        self.client = AsyncOpenAI(api_key=self.api_key)
 
     supports_messages = True
 

--- a/prompture/drivers/async_openai_driver.py
+++ b/prompture/drivers/async_openai_driver.py
@@ -9,7 +9,7 @@ from typing import Any
 
 try:
     from openai import AsyncOpenAI
-except Exception:
+except ImportError:
     AsyncOpenAI = None  # type: ignore[misc, assignment]
 
 from ..infra.cost_mixin import CostMixin
@@ -68,7 +68,12 @@ class AsyncOpenAIDriver(CostMixin, AsyncDriver):
 
     async def _do_generate(self, messages: list[dict[str, str]], options: dict[str, Any]) -> dict[str, Any]:
         if self.client is None:
-            raise RuntimeError("openai package (>=1.0.0) is not installed")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "openai package (>=1.0.0) is not installed. "
+                'Install it with: pip install "prompture[openai]"'
+            )
 
         model = options.get("model", self.model)
 
@@ -123,7 +128,12 @@ class AsyncOpenAIDriver(CostMixin, AsyncDriver):
     ) -> dict[str, Any]:
         """Generate a response that may include tool calls."""
         if self.client is None:
-            raise RuntimeError("openai package (>=1.0.0) is not installed")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "openai package (>=1.0.0) is not installed. "
+                'Install it with: pip install "prompture[openai]"'
+            )
 
         model = options.get("model", self.model)
         model_config = self._get_model_config("openai", model)
@@ -171,7 +181,12 @@ class AsyncOpenAIDriver(CostMixin, AsyncDriver):
     ) -> AsyncIterator[dict[str, Any]]:
         """Yield response chunks via OpenAI streaming API."""
         if self.client is None:
-            raise RuntimeError("openai package (>=1.0.0) is not installed")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "openai package (>=1.0.0) is not installed. "
+                'Install it with: pip install "prompture[openai]"'
+            )
 
         model = options.get("model", self.model)
         model_config = self._get_model_config("openai", model)

--- a/prompture/drivers/async_openai_driver.py
+++ b/prompture/drivers/async_openai_driver.py
@@ -72,8 +72,7 @@ class AsyncOpenAIDriver(CostMixin, AsyncDriver):
             from ..exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "openai package (>=1.0.0) is not installed. "
-                'Install it with: pip install "prompture[openai]"'
+                'openai package (>=1.0.0) is not installed. Install it with: pip install "prompture[openai]"'
             )
 
         model = options.get("model", self.model)
@@ -132,8 +131,7 @@ class AsyncOpenAIDriver(CostMixin, AsyncDriver):
             from ..exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "openai package (>=1.0.0) is not installed. "
-                'Install it with: pip install "prompture[openai]"'
+                'openai package (>=1.0.0) is not installed. Install it with: pip install "prompture[openai]"'
             )
 
         model = options.get("model", self.model)
@@ -185,8 +183,7 @@ class AsyncOpenAIDriver(CostMixin, AsyncDriver):
             from ..exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "openai package (>=1.0.0) is not installed. "
-                'Install it with: pip install "prompture[openai]"'
+                'openai package (>=1.0.0) is not installed. Install it with: pip install "prompture[openai]"'
             )
 
         model = options.get("model", self.model)
@@ -248,13 +245,10 @@ class AsyncOpenAIDriver(CostMixin, AsyncDriver):
             from ..exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "openai package (>=1.0.0) is not installed. "
-                'Install it with: pip install "prompture[openai]"'
+                'openai package (>=1.0.0) is not installed. Install it with: pip install "prompture[openai]"'
             )
 
         from ._openai_compat_stream import astream_openai_compat_tool_call
 
-        async for ev in astream_openai_compat_tool_call(
-            self, messages, tools, options, provider="openai"
-        ):
+        async for ev in astream_openai_compat_tool_call(self, messages, tools, options, provider="openai"):
             yield ev

--- a/prompture/drivers/async_openai_embedding_driver.py
+++ b/prompture/drivers/async_openai_embedding_driver.py
@@ -8,7 +8,7 @@ from typing import Any
 
 try:
     from openai import AsyncOpenAI
-except Exception:
+except ImportError:
     AsyncOpenAI = None  # type: ignore[misc, assignment]
 
 from ..infra.cost_mixin import EmbeddingCostMixin

--- a/prompture/drivers/async_openai_img_gen_driver.py
+++ b/prompture/drivers/async_openai_img_gen_driver.py
@@ -8,7 +8,7 @@ from typing import Any
 
 try:
     from openai import AsyncOpenAI
-except Exception:
+except ImportError:
     AsyncOpenAI = None  # type: ignore[misc, assignment]
 
 from ..infra.cost_mixin import ImageCostMixin

--- a/prompture/drivers/async_openai_stt_driver.py
+++ b/prompture/drivers/async_openai_stt_driver.py
@@ -9,7 +9,7 @@ from typing import Any
 
 try:
     from openai import AsyncOpenAI
-except Exception:
+except ImportError:
     AsyncOpenAI = None  # type: ignore[misc, assignment]
 
 from ..infra.cost_mixin import AudioCostMixin

--- a/prompture/drivers/async_openai_tts_driver.py
+++ b/prompture/drivers/async_openai_tts_driver.py
@@ -9,7 +9,7 @@ from typing import Any
 
 try:
     from openai import AsyncOpenAI
-except Exception:
+except ImportError:
     AsyncOpenAI = None  # type: ignore[misc, assignment]
 
 from ..infra.cost_mixin import AudioCostMixin

--- a/prompture/drivers/async_openrouter_driver.py
+++ b/prompture/drivers/async_openrouter_driver.py
@@ -236,7 +236,6 @@ class AsyncOpenRouterDriver(CostMixin, AsyncDriver):
             result["reasoning_content"] = choice["message"]["reasoning_content"]
         return result
 
-
     # ------------------------------------------------------------------
     # Live streaming with interleaved tool calls
     # ------------------------------------------------------------------
@@ -250,9 +249,7 @@ class AsyncOpenRouterDriver(CostMixin, AsyncDriver):
         """Async streaming-tool via the shared raw-HTTP helper."""
         from ._openai_compat_stream import astream_raw_http_compat_tool_call
 
-        async for ev in astream_raw_http_compat_tool_call(
-            self, messages, tools, options, provider="openrouter"
-        ):
+        async for ev in astream_raw_http_compat_tool_call(self, messages, tools, options, provider="openrouter"):
             yield ev
 
     # ------------------------------------------------------------------

--- a/prompture/drivers/async_openrouter_driver.py
+++ b/prompture/drivers/async_openrouter_driver.py
@@ -94,6 +94,16 @@ class AsyncOpenRouterDriver(CostMixin, AsyncDriver):
             else:
                 data["response_format"] = {"type": "json_object"}
 
+        # vLLM-style guided_json pass-through + extra_body escape hatch.
+        from ._openai_compat import apply_guided_decoding, merge_extra_body
+
+        apply_guided_decoding(
+            data,
+            json_schema=options.get("json_schema"),
+            guided_decoding=options.get("guided_decoding"),
+        )
+        merge_extra_body(data, options)
+
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.post(

--- a/prompture/drivers/async_openrouter_driver.py
+++ b/prompture/drivers/async_openrouter_driver.py
@@ -22,6 +22,8 @@ class AsyncOpenRouterDriver(CostMixin, AsyncDriver):
     supports_json_mode = True
     supports_json_schema = True
     supports_tool_use = True
+    supports_streaming_tool_use = True
+
     supports_streaming = True
     supports_vision = True
 
@@ -233,6 +235,25 @@ class AsyncOpenRouterDriver(CostMixin, AsyncDriver):
         if choice["message"].get("reasoning_content") is not None:
             result["reasoning_content"] = choice["message"]["reasoning_content"]
         return result
+
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    async def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ):
+        """Async streaming-tool via the shared raw-HTTP helper."""
+        from ._openai_compat_stream import astream_raw_http_compat_tool_call
+
+        async for ev in astream_raw_http_compat_tool_call(
+            self, messages, tools, options, provider="openrouter"
+        ):
+            yield ev
 
     # ------------------------------------------------------------------
     # Streaming

--- a/prompture/drivers/async_zai_driver.py
+++ b/prompture/drivers/async_zai_driver.py
@@ -24,6 +24,7 @@ class AsyncZaiDriver(CostMixin, AsyncDriver):
     supports_json_mode = True
     supports_json_schema = True
     supports_tool_use = True
+    supports_streaming_tool_use = True
     supports_streaming = True
     supports_vision = True
 
@@ -236,6 +237,25 @@ class AsyncZaiDriver(CostMixin, AsyncDriver):
             "tool_calls": tool_calls_out,
             "stop_reason": stop_reason,
         }
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    async def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ):
+        """Async streaming-tool via the shared raw-HTTP helper."""
+        from ._openai_compat_stream import astream_raw_http_compat_tool_call
+
+        async for ev in astream_raw_http_compat_tool_call(
+            self, messages, tools, options, provider="zai"
+        ):
+            yield ev
+
 
     # ------------------------------------------------------------------
     # Streaming

--- a/prompture/drivers/async_zai_driver.py
+++ b/prompture/drivers/async_zai_driver.py
@@ -251,11 +251,8 @@ class AsyncZaiDriver(CostMixin, AsyncDriver):
         """Async streaming-tool via the shared raw-HTTP helper."""
         from ._openai_compat_stream import astream_raw_http_compat_tool_call
 
-        async for ev in astream_raw_http_compat_tool_call(
-            self, messages, tools, options, provider="zai"
-        ):
+        async for ev in astream_raw_http_compat_tool_call(self, messages, tools, options, provider="zai"):
             yield ev
-
 
     # ------------------------------------------------------------------
     # Streaming

--- a/prompture/drivers/azure_config.py
+++ b/prompture/drivers/azure_config.py
@@ -27,7 +27,8 @@ Usage::
 from __future__ import annotations
 
 import threading
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 # Model prefix → backend type
 AZURE_BACKEND_MAP: dict[str, str] = {

--- a/prompture/drivers/azure_driver.py
+++ b/prompture/drivers/azure_driver.py
@@ -16,12 +16,12 @@ from typing import Any
 
 try:
     from openai import AzureOpenAI
-except Exception:
+except ImportError:
     AzureOpenAI = None  # type: ignore[misc, assignment]
 
 try:
     import anthropic
-except Exception:
+except ImportError:
     anthropic = None  # type: ignore[assignment]
 
 from ..infra.cost_mixin import CostMixin, prepare_strict_schema

--- a/prompture/drivers/base.py
+++ b/prompture/drivers/base.py
@@ -153,6 +153,7 @@ class Driver(ABC):
     supports_messages: bool = False
     supports_tool_use: bool = False
     supports_streaming: bool = False
+    supports_streaming_tool_use: bool = False
     supports_vision: bool = False
 
     callbacks: DriverCallbacks | None = None
@@ -228,6 +229,70 @@ class Driver(ABC):
         ``supports_streaming = True``.
         """
         raise NotImplementedError(f"{self.__class__.__name__} does not support streaming")
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> Iterator[Any]:
+        """Yield :class:`~prompture.agents.live_events.LiveEvent` for one
+        assistant turn that may interleave text and tool calls.
+
+        The driver is responsible only for one turn — from the model deciding
+        what to say/call to ``MessageStop``. The conversation layer drives the
+        outer loop, executes tools, and re-invokes this method for the next
+        turn.
+
+        Default implementation: wraps the buffered
+        :meth:`generate_messages_with_tools` into a synthetic event sequence
+        so callers always get a uniform interface, even on drivers that don't
+        natively stream tool use. Drivers that DO support native interleaved
+        streaming should override this and set
+        ``supports_streaming_tool_use = True`` — they'll feel like Claude Code
+        (narration between tool calls) instead of "buffered then dumped".
+        """
+        from ..agents.live_events import (
+            MessageStop,
+            TextDelta,
+            ThinkingDelta,
+            ToolInputDelta,
+            ToolUseStart,
+            ToolUseStop,
+        )
+
+        resp = self.generate_messages_with_tools(messages, tools, options)
+        text = resp.get("text", "") or ""
+        reasoning = resp.get("reasoning_content")
+        tool_calls = resp.get("tool_calls", []) or []
+        stop_reason = resp.get("stop_reason", "end_turn") or "end_turn"
+        meta = resp.get("meta", {}) or {}
+
+        if reasoning:
+            yield ThinkingDelta(text=reasoning)
+        if text:
+            yield TextDelta(text=text)
+
+        import json as _json
+
+        for tc in tool_calls:
+            tc_id = tc.get("id", "") or ""
+            tc_name = tc.get("name", "") or ""
+            tc_args = tc.get("arguments", {}) or {}
+            yield ToolUseStart(id=tc_id, name=tc_name)
+            try:
+                fragment = _json.dumps(tc_args)
+            except (TypeError, ValueError):
+                fragment = "{}"
+            if fragment and fragment != "{}":
+                yield ToolInputDelta(id=tc_id, fragment=fragment)
+            yield ToolUseStop(id=tc_id, name=tc_name, input=tc_args)
+
+        yield MessageStop(stop_reason=stop_reason, usage=meta)
 
     # ------------------------------------------------------------------
     # Hook-aware wrappers

--- a/prompture/drivers/cachibot_driver.py
+++ b/prompture/drivers/cachibot_driver.py
@@ -275,10 +275,7 @@ class CachiBotDriver(CostMixin, Driver):
         """Stream one turn as :class:`LiveEvent` via the shared raw-HTTP helper."""
         from ._openai_compat_stream import stream_raw_http_compat_tool_call
 
-        yield from stream_raw_http_compat_tool_call(
-            self, messages, tools, options, provider="cachibot"
-        )
-
+        yield from stream_raw_http_compat_tool_call(self, messages, tools, options, provider="cachibot")
 
     # ------------------------------------------------------------------
     # Streaming

--- a/prompture/drivers/cachibot_driver.py
+++ b/prompture/drivers/cachibot_driver.py
@@ -18,7 +18,7 @@ from typing import Any
 
 try:
     import requests as _requests
-except Exception:
+except ImportError:
     _requests = None
 
 from ..infra.cost_mixin import CostMixin

--- a/prompture/drivers/cachibot_driver.py
+++ b/prompture/drivers/cachibot_driver.py
@@ -32,6 +32,7 @@ _DEFAULT_ENDPOINT = "https://cachibot.ai/api/v1"
 class CachiBotDriver(CostMixin, Driver):
     supports_json_mode = True
     supports_tool_use = True
+    supports_streaming_tool_use = True
     supports_streaming = True
     supports_vision = True
 
@@ -260,6 +261,24 @@ class CachiBotDriver(CostMixin, Driver):
             "tool_calls": tool_calls_out,
             "stop_reason": stop_reason,
         }
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ):
+        """Stream one turn as :class:`LiveEvent` via the shared raw-HTTP helper."""
+        from ._openai_compat_stream import stream_raw_http_compat_tool_call
+
+        yield from stream_raw_http_compat_tool_call(
+            self, messages, tools, options, provider="cachibot"
+        )
+
 
     # ------------------------------------------------------------------
     # Streaming

--- a/prompture/drivers/cartesia_tts_driver.py
+++ b/prompture/drivers/cartesia_tts_driver.py
@@ -17,7 +17,7 @@ from typing import Any
 
 try:
     import httpx
-except Exception:
+except ImportError:
     httpx = None  # type: ignore[assignment]
 
 from .tts_base import TTSDriver

--- a/prompture/drivers/claude_driver.py
+++ b/prompture/drivers/claude_driver.py
@@ -289,6 +289,7 @@ class ClaudeDriver(CostMixin, Driver):
     supports_json_schema = True
     supports_tool_use = True
     supports_streaming = True
+    supports_streaming_tool_use = True
     supports_vision = True
 
     # All pricing and model config now resolved from JSON rate files (KB) and
@@ -618,3 +619,163 @@ class ClaudeDriver(CostMixin, Driver):
             cached_prompt_tokens=cache_read,
             cache_creation_tokens=cache_create,
         )
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> Iterator[Any]:
+        """Stream one Anthropic turn as :class:`LiveEvent`, with native
+        interleaved text and tool_use blocks.
+
+        Maps Anthropic SSE events:
+        - ``message_start`` → captures input/cache token counts
+        - ``content_block_start`` (text|tool_use|thinking) → tracks block index
+          and emits ``ToolUseStart`` for tool_use blocks
+        - ``content_block_delta`` (text_delta|input_json_delta|thinking_delta)
+          → emits ``TextDelta`` / ``ToolInputDelta`` / ``ThinkingDelta``
+        - ``content_block_stop`` → emits ``ToolUseStop`` (with parsed input)
+          for tool_use blocks
+        - ``message_delta`` → captures output tokens and stop_reason
+        - finally yields ``MessageStop`` with cost + usage
+        """
+        if anthropic is None:
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "anthropic package not installed. "
+                'Install it with: pip install "prompture[anthropic]"'
+            )
+
+        from ..agents.live_events import (
+            MessageStop,
+            TextDelta,
+            ThinkingDelta,
+            ToolInputDelta,
+            ToolUseStart,
+            ToolUseStop,
+        )
+
+        opts = {**{"temperature": 0.0, "max_tokens": 4096}, **options}
+        model = options.get("model", self.model)
+        cache_prompt = opts.get("cache_prompt", True)
+        supports_temperature = self._get_model_config("claude", model)["supports_temperature"]
+        client = anthropic.Anthropic(api_key=self.api_key)
+
+        system_content, api_messages = _extract_anthropic_system_and_messages(messages)
+        anthropic_tools = _apply_cache_control_to_tools(
+            _convert_tools_to_anthropic(tools), cache_prompt=cache_prompt
+        )
+
+        kwargs: dict[str, Any] = {
+            "model": model,
+            "messages": api_messages,
+            "max_tokens": opts["max_tokens"],
+            "tools": anthropic_tools,
+        }
+        if supports_temperature:
+            kwargs["temperature"] = opts["temperature"]
+        wrapped_system = _apply_cache_control_to_system(system_content, cache_prompt=cache_prompt)
+        if wrapped_system is not None:
+            kwargs["system"] = wrapped_system
+
+        block_kinds: dict[int, str] = {}
+        tool_block_info: dict[int, dict[str, Any]] = {}
+        tool_input_buffers: dict[int, list[str]] = {}
+
+        base_input = 0
+        cache_read = 0
+        cache_create = 0
+        completion_tokens = 0
+        stop_reason = "end_turn"
+
+        with client.messages.stream(**kwargs) as stream:
+            for event in stream:
+                ev_type = getattr(event, "type", "")
+                if ev_type == "message_start":
+                    usage = getattr(getattr(event, "message", None), "usage", None)
+                    if usage is not None:
+                        base_input = getattr(usage, "input_tokens", 0) or 0
+                        cache_read, cache_create = _extract_anthropic_cache_tokens(usage)
+                elif ev_type == "content_block_start":
+                    idx = getattr(event, "index", 0)
+                    block = getattr(event, "content_block", None)
+                    kind = getattr(block, "type", "") if block is not None else ""
+                    block_kinds[idx] = kind
+                    if kind == "tool_use":
+                        tool_id = getattr(block, "id", "") or ""
+                        tool_name = getattr(block, "name", "") or ""
+                        tool_block_info[idx] = {"id": tool_id, "name": tool_name}
+                        tool_input_buffers[idx] = []
+                        yield ToolUseStart(id=tool_id, name=tool_name)
+                elif ev_type == "content_block_delta":
+                    idx = getattr(event, "index", 0)
+                    delta = getattr(event, "delta", None)
+                    delta_type = getattr(delta, "type", "") if delta is not None else ""
+                    if delta_type == "text_delta":
+                        text_piece = getattr(delta, "text", "") or ""
+                        if text_piece:
+                            yield TextDelta(text=text_piece)
+                    elif delta_type == "thinking_delta":
+                        thinking_piece = getattr(delta, "thinking", "") or ""
+                        if thinking_piece:
+                            yield ThinkingDelta(text=thinking_piece)
+                    elif delta_type == "input_json_delta":
+                        fragment = getattr(delta, "partial_json", "") or ""
+                        info = tool_block_info.get(idx)
+                        if fragment and info is not None:
+                            tool_input_buffers.setdefault(idx, []).append(fragment)
+                            yield ToolInputDelta(id=info["id"], fragment=fragment)
+                elif ev_type == "content_block_stop":
+                    idx = getattr(event, "index", 0)
+                    if block_kinds.get(idx) == "tool_use":
+                        info = tool_block_info.get(idx, {})
+                        buf = "".join(tool_input_buffers.get(idx, []))
+                        try:
+                            parsed = json.loads(buf) if buf else {}
+                            if not isinstance(parsed, dict):
+                                parsed = {}
+                        except json.JSONDecodeError:
+                            logger.warning(
+                                "Failed to parse streamed tool input for %s: %r",
+                                info.get("name", "?"),
+                                buf[:200],
+                            )
+                            parsed = {}
+                        yield ToolUseStop(
+                            id=info.get("id", ""),
+                            name=info.get("name", ""),
+                            input=parsed,
+                        )
+                elif ev_type == "message_delta":
+                    usage = getattr(event, "usage", None)
+                    if usage is not None:
+                        completion_tokens = getattr(usage, "output_tokens", 0) or completion_tokens
+                    sr = getattr(getattr(event, "delta", None), "stop_reason", None)
+                    if sr:
+                        stop_reason = sr
+
+        prompt_tokens = base_input + cache_read + cache_create
+        total_cost = self._calculate_cost(
+            "claude",
+            model,
+            prompt_tokens,
+            completion_tokens,
+            cached_tokens=cache_read,
+            cache_creation_tokens=cache_create,
+        )
+        meta = {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+            "cached_prompt_tokens": cache_read,
+            "cache_creation_tokens": cache_create,
+            "cost": round(total_cost, 6),
+            "model_name": model,
+        }
+        yield MessageStop(stop_reason=stop_reason, usage=meta)

--- a/prompture/drivers/claude_driver.py
+++ b/prompture/drivers/claude_driver.py
@@ -218,6 +218,16 @@ class ClaudeDriver(CostMixin, Driver):
     def __init__(self, api_key: str | None = None, model: str = "claude-haiku-4-5-20251001"):
         self.api_key = api_key or os.getenv("CLAUDE_API_KEY")
         self.model = model or os.getenv("CLAUDE_MODEL_NAME", "claude-haiku-4-5-20251001")
+        # Only validate when the SDK is installed — when anthropic is missing we
+        # surface that at call time so plain import-and-discover still works.
+        if anthropic is not None and not self.api_key:
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "CLAUDE_API_KEY is not set. Provide api_key=... or set the "
+                "CLAUDE_API_KEY environment variable. "
+                "See https://github.com/jhd3197/prompture#configuration"
+            )
 
     @classmethod
     def list_models(cls, *, api_key: str | None = None, timeout: int = 10, **kw: object) -> list[str] | None:

--- a/prompture/drivers/claude_driver.py
+++ b/prompture/drivers/claude_driver.py
@@ -12,7 +12,7 @@ import requests
 
 try:
     import anthropic
-except Exception:
+except ImportError:
     anthropic = None  # type: ignore[assignment]
 
 from ..infra.cost_mixin import CostMixin
@@ -353,7 +353,12 @@ class ClaudeDriver(CostMixin, Driver):
 
     def _do_generate(self, messages: list[dict[str, Any]], options: dict[str, Any]) -> dict[str, Any]:
         if anthropic is None:
-            raise RuntimeError("anthropic package not installed")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "anthropic package not installed. "
+                'Install it with: pip install "prompture[anthropic]"'
+            )
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
         model = options.get("model", self.model)
@@ -467,7 +472,12 @@ class ClaudeDriver(CostMixin, Driver):
     ) -> dict[str, Any]:
         """Generate a response that may include tool calls (Anthropic)."""
         if anthropic is None:
-            raise RuntimeError("anthropic package not installed")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "anthropic package not installed. "
+                'Install it with: pip install "prompture[anthropic]"'
+            )
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
         model = options.get("model", self.model)
@@ -533,7 +543,12 @@ class ClaudeDriver(CostMixin, Driver):
     ) -> Iterator[dict[str, Any]]:
         """Yield response chunks via Anthropic streaming API."""
         if anthropic is None:
-            raise RuntimeError("anthropic package not installed")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "anthropic package not installed. "
+                'Install it with: pip install "prompture[anthropic]"'
+            )
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
         model = options.get("model", self.model)

--- a/prompture/drivers/claude_driver.py
+++ b/prompture/drivers/claude_driver.py
@@ -357,8 +357,7 @@ class ClaudeDriver(CostMixin, Driver):
             from ..exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "anthropic package not installed. "
-                'Install it with: pip install "prompture[anthropic]"'
+                'anthropic package not installed. Install it with: pip install "prompture[anthropic]"'
             )
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
@@ -476,8 +475,7 @@ class ClaudeDriver(CostMixin, Driver):
             from ..exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "anthropic package not installed. "
-                'Install it with: pip install "prompture[anthropic]"'
+                'anthropic package not installed. Install it with: pip install "prompture[anthropic]"'
             )
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
@@ -491,9 +489,7 @@ class ClaudeDriver(CostMixin, Driver):
         client = anthropic.Anthropic(api_key=self.api_key)
 
         system_content, api_messages = _extract_anthropic_system_and_messages(messages)
-        anthropic_tools = _apply_cache_control_to_tools(
-            _convert_tools_to_anthropic(tools), cache_prompt=cache_prompt
-        )
+        anthropic_tools = _apply_cache_control_to_tools(_convert_tools_to_anthropic(tools), cache_prompt=cache_prompt)
 
         kwargs: dict[str, Any] = {
             "model": model,
@@ -547,8 +543,7 @@ class ClaudeDriver(CostMixin, Driver):
             from ..exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "anthropic package not installed. "
-                'Install it with: pip install "prompture[anthropic]"'
+                'anthropic package not installed. Install it with: pip install "prompture[anthropic]"'
             )
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
@@ -648,8 +643,7 @@ class ClaudeDriver(CostMixin, Driver):
             from ..exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "anthropic package not installed. "
-                'Install it with: pip install "prompture[anthropic]"'
+                'anthropic package not installed. Install it with: pip install "prompture[anthropic]"'
             )
 
         from ..agents.live_events import (
@@ -668,9 +662,7 @@ class ClaudeDriver(CostMixin, Driver):
         client = anthropic.Anthropic(api_key=self.api_key)
 
         system_content, api_messages = _extract_anthropic_system_and_messages(messages)
-        anthropic_tools = _apply_cache_control_to_tools(
-            _convert_tools_to_anthropic(tools), cache_prompt=cache_prompt
-        )
+        anthropic_tools = _apply_cache_control_to_tools(_convert_tools_to_anthropic(tools), cache_prompt=cache_prompt)
 
         kwargs: dict[str, Any] = {
             "model": model,

--- a/prompture/drivers/claude_driver.py
+++ b/prompture/drivers/claude_driver.py
@@ -175,6 +175,86 @@ def _build_anthropic_json_mode_tool_def(json_schema: dict[str, Any]) -> dict[str
     }
 
 
+# ----------------------------------------------------------------------
+# Prompt caching (Anthropic "ephemeral" cache_control blocks)
+#
+# Anthropic prompt caching delivers ~80% input-cost savings for stable
+# system prompts and tool definitions: cache_creation runs at 1.25x the
+# normal input rate, but cache_read runs at 0.1x. The cache lives for
+# ~5 minutes. Setting ``cache_control: {"type": "ephemeral"}`` on a
+# block tells the API to cache everything up to and including that
+# block.
+#
+# Minimum cacheable block size (Anthropic):
+#   * 1024 tokens for Sonnet / Opus
+#   * 2048 tokens for Haiku
+# Blocks below the minimum are silently ignored — no error, just no
+# cache hit. To avoid pointless cache_control churn we only mark a
+# block when it's "substantial enough to be worth trying":
+# CACHE_PROMPT_MIN_CHARS ≈ 1024 tokens × 4 chars/token.
+# ----------------------------------------------------------------------
+
+CACHE_PROMPT_MIN_CHARS = 4000
+
+
+def _apply_cache_control_to_system(
+    system_text: str | None,
+    *,
+    cache_prompt: bool,
+    min_chars: int = CACHE_PROMPT_MIN_CHARS,
+) -> str | list[dict[str, Any]] | None:
+    """Wrap the system prompt as a cacheable text block when worthwhile.
+
+    Returns the original string unchanged for short prompts (caching
+    would be silently dropped by the API). For longer prompts, returns
+    a single-element list ``[{"type": "text", "text": ..., "cache_control": ...}]``
+    that the Anthropic Messages API accepts in place of a plain string.
+
+    Returns ``None`` for an empty / missing system prompt so callers
+    can simply omit the ``system=`` kwarg.
+    """
+    if not system_text:
+        return None
+    if not cache_prompt or len(system_text) < min_chars:
+        return system_text
+    return [
+        {
+            "type": "text",
+            "text": system_text,
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+
+
+def _apply_cache_control_to_tools(
+    tools: list[dict[str, Any]],
+    *,
+    cache_prompt: bool,
+    min_chars: int = CACHE_PROMPT_MIN_CHARS,
+) -> list[dict[str, Any]]:
+    """Tag the last tool dict with cache_control when the bundle is large.
+
+    Anthropic only honours one cache_control marker per logical section.
+    Putting it on the *last* tool extends the cached prefix through the
+    entire tools block. The cost of trying-and-being-ignored is tiny
+    (a few bytes per request), so we apply it whenever the combined
+    JSON for the tools meets ``min_chars``.
+
+    Returns a new list (and shallow-copies the last tool dict) so the
+    caller's tool definitions aren't mutated.
+    """
+    if not cache_prompt or not tools:
+        return tools
+    combined_len = sum(len(json.dumps(t, default=str)) for t in tools)
+    if combined_len < min_chars:
+        return tools
+    result = list(tools)
+    last = dict(result[-1])
+    last["cache_control"] = {"type": "ephemeral"}
+    result[-1] = last
+    return result
+
+
 def _build_anthropic_stream_done(
     model: str,
     full_text: str,
@@ -277,6 +357,7 @@ class ClaudeDriver(CostMixin, Driver):
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
         model = options.get("model", self.model)
+        cache_prompt = opts.get("cache_prompt", True)
 
         # Validate capabilities against models.dev metadata
         self._validate_model_capabilities(
@@ -307,16 +388,21 @@ class ClaudeDriver(CostMixin, Driver):
         }
         if supports_temperature:
             common_kwargs["temperature"] = opts["temperature"]
-        if system_content:
-            common_kwargs["system"] = system_content
+        wrapped_system = _apply_cache_control_to_system(system_content, cache_prompt=cache_prompt)
+        if wrapped_system is not None:
+            common_kwargs["system"] = wrapped_system
 
         # Native JSON mode: use tool-use for schema enforcement
         if options.get("json_mode"):
             json_schema = options.get("json_schema")
             if json_schema:
+                json_mode_tools = _apply_cache_control_to_tools(
+                    [_build_anthropic_json_mode_tool_def(json_schema)],
+                    cache_prompt=cache_prompt,
+                )
                 resp = client.messages.create(  # type: ignore[call-overload]
                     **common_kwargs,
-                    tools=[_build_anthropic_json_mode_tool_def(json_schema)],
+                    tools=json_mode_tools,
                     tool_choice={"type": "tool", "name": "extract_json"},
                 )
                 text = ""
@@ -385,6 +471,7 @@ class ClaudeDriver(CostMixin, Driver):
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
         model = options.get("model", self.model)
+        cache_prompt = opts.get("cache_prompt", True)
 
         self._validate_model_capabilities("claude", model, using_tool_use=True)
 
@@ -393,7 +480,9 @@ class ClaudeDriver(CostMixin, Driver):
         client = anthropic.Anthropic(api_key=self.api_key)
 
         system_content, api_messages = _extract_anthropic_system_and_messages(messages)
-        anthropic_tools = _convert_tools_to_anthropic(tools)
+        anthropic_tools = _apply_cache_control_to_tools(
+            _convert_tools_to_anthropic(tools), cache_prompt=cache_prompt
+        )
 
         kwargs: dict[str, Any] = {
             "model": model,
@@ -403,8 +492,9 @@ class ClaudeDriver(CostMixin, Driver):
         }
         if supports_temperature:
             kwargs["temperature"] = opts["temperature"]
-        if system_content:
-            kwargs["system"] = system_content
+        wrapped_system = _apply_cache_control_to_system(system_content, cache_prompt=cache_prompt)
+        if wrapped_system is not None:
+            kwargs["system"] = wrapped_system
 
         resp = client.messages.create(**kwargs)
 
@@ -447,6 +537,7 @@ class ClaudeDriver(CostMixin, Driver):
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
         model = options.get("model", self.model)
+        cache_prompt = opts.get("cache_prompt", True)
         supports_temperature = self._get_model_config("claude", model)["supports_temperature"]
         client = anthropic.Anthropic(api_key=self.api_key)
 
@@ -459,8 +550,9 @@ class ClaudeDriver(CostMixin, Driver):
         }
         if supports_temperature:
             kwargs["temperature"] = opts["temperature"]
-        if system_content:
-            kwargs["system"] = system_content
+        wrapped_system = _apply_cache_control_to_system(system_content, cache_prompt=cache_prompt)
+        if wrapped_system is not None:
+            kwargs["system"] = wrapped_system
 
         full_text = ""
         full_reasoning = ""

--- a/prompture/drivers/cohere_driver.py
+++ b/prompture/drivers/cohere_driver.py
@@ -39,7 +39,12 @@ class CohereDriver(CostMixin, Driver):
     def __init__(self, api_key: str | None = None, model: str = "command-r-plus"):
         self.api_key = api_key or os.getenv("COHERE_API_KEY")
         if not self.api_key:
-            raise ValueError("Cohere API key not found. Set COHERE_API_KEY env var.")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "COHERE_API_KEY is not set. Provide api_key=... or set the "
+                "COHERE_API_KEY environment variable."
+            )
         self.model = model
         self.base_url = "https://api.cohere.com/v2"
         self.headers = {
@@ -81,7 +86,9 @@ class CohereDriver(CostMixin, Driver):
 
     def _do_generate(self, messages: list[dict[str, Any]], options: dict[str, Any]) -> dict[str, Any]:
         if not self.api_key:
-            raise RuntimeError("Cohere API key not found")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError("COHERE_API_KEY is not set.")
 
         model = options.get("model", self.model)
         model_config = self._get_model_config("cohere", model)
@@ -131,9 +138,15 @@ class CohereDriver(CostMixin, Driver):
             error_msg = f"Cohere API request failed: {e!s}"
             if body:
                 error_msg += f"\nResponse: {body}"
-            raise RuntimeError(error_msg) from e
+            from ..exceptions import DriverError
+
+            err = DriverError(error_msg)
+            err.status_code = e.response.status_code if e.response is not None else None
+            raise err from e
         except requests.exceptions.RequestException as e:
-            raise RuntimeError(f"Cohere API request failed: {e!s}") from e
+            from ..exceptions import DriverError
+
+            raise DriverError(f"Cohere API request failed: {e!s}") from e
 
         message = resp.get("message", {}) or {}
         text = self._extract_text(message)
@@ -166,7 +179,9 @@ class CohereDriver(CostMixin, Driver):
         options: dict[str, Any],
     ) -> dict[str, Any]:
         if not self.api_key:
-            raise RuntimeError("Cohere API key not found")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError("COHERE_API_KEY is not set.")
 
         model = options.get("model", self.model)
         model_config = self._get_model_config("cohere", model)
@@ -202,9 +217,15 @@ class CohereDriver(CostMixin, Driver):
             error_msg = f"Cohere API request failed: {e!s}"
             if body:
                 error_msg += f"\nResponse: {body}"
-            raise RuntimeError(error_msg) from e
+            from ..exceptions import DriverError
+
+            err = DriverError(error_msg)
+            err.status_code = e.response.status_code if e.response is not None else None
+            raise err from e
         except requests.exceptions.RequestException as e:
-            raise RuntimeError(f"Cohere API request failed: {e!s}") from e
+            from ..exceptions import DriverError
+
+            raise DriverError(f"Cohere API request failed: {e!s}") from e
 
         message = resp.get("message", {}) or {}
         text = self._extract_text(message)

--- a/prompture/drivers/cohere_driver.py
+++ b/prompture/drivers/cohere_driver.py
@@ -42,8 +42,7 @@ class CohereDriver(CostMixin, Driver):
             from ..exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "COHERE_API_KEY is not set. Provide api_key=... or set the "
-                "COHERE_API_KEY environment variable."
+                "COHERE_API_KEY is not set. Provide api_key=... or set the COHERE_API_KEY environment variable."
             )
         self.model = model
         self.base_url = "https://api.cohere.com/v2"

--- a/prompture/drivers/deepgram_stt_driver.py
+++ b/prompture/drivers/deepgram_stt_driver.py
@@ -13,7 +13,7 @@ from typing import Any
 
 try:
     import httpx
-except Exception:
+except ImportError:
     httpx = None  # type: ignore[assignment]
 
 from .stt_base import STTDriver

--- a/prompture/drivers/deepgram_tts_driver.py
+++ b/prompture/drivers/deepgram_tts_driver.py
@@ -8,7 +8,7 @@ from typing import Any
 
 try:
     import httpx
-except Exception:
+except ImportError:
     httpx = None  # type: ignore[assignment]
 
 from .tts_base import TTSDriver

--- a/prompture/drivers/driver_registry.py
+++ b/prompture/drivers/driver_registry.py
@@ -8,8 +8,7 @@ that standardises registration, lookup, and plugin loading for any modality
 from __future__ import annotations
 
 import logging
-import sys
-from typing import Callable
+from collections.abc import Callable
 
 logger = logging.getLogger("prompture.drivers.registry")
 
@@ -100,14 +99,9 @@ class DriverRegistry:
             return 0
 
         count = 0
-        if sys.version_info >= (3, 10):
-            from importlib.metadata import entry_points
+        from importlib.metadata import entry_points
 
-            eps = entry_points(group=self._entry_point_group)
-        else:
-            from importlib.metadata import entry_points
-
-            eps = entry_points().get(self._entry_point_group, [])
+        eps = entry_points(group=self._entry_point_group)
 
         for ep in eps:
             try:

--- a/prompture/drivers/elevenlabs_stt_driver.py
+++ b/prompture/drivers/elevenlabs_stt_driver.py
@@ -8,7 +8,7 @@ from typing import Any
 
 try:
     import httpx
-except Exception:
+except ImportError:
     httpx = None  # type: ignore[assignment]
 
 from ..infra.cost_mixin import AudioCostMixin

--- a/prompture/drivers/elevenlabs_tts_driver.py
+++ b/prompture/drivers/elevenlabs_tts_driver.py
@@ -9,7 +9,7 @@ from typing import Any
 
 try:
     import httpx
-except Exception:
+except ImportError:
     httpx = None  # type: ignore[assignment]
 
 from ..infra.cost_mixin import AudioCostMixin

--- a/prompture/drivers/google_driver.py
+++ b/prompture/drivers/google_driver.py
@@ -61,8 +61,7 @@ class GoogleDriver(CostMixin, Driver):
             from ..exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "google-genai package is not installed. "
-                'Install it with: pip install "prompture[google]"'
+                'google-genai package is not installed. Install it with: pip install "prompture[google]"'
             )
         self.api_key = api_key or os.getenv("GOOGLE_API_KEY")
         if not self.api_key:

--- a/prompture/drivers/google_driver.py
+++ b/prompture/drivers/google_driver.py
@@ -61,7 +61,13 @@ class GoogleDriver(CostMixin, Driver):
             raise RuntimeError("google-genai package is not installed. Install it with: pip install google-genai")
         self.api_key = api_key or os.getenv("GOOGLE_API_KEY")
         if not self.api_key:
-            raise ValueError("Google API key not found. Set GOOGLE_API_KEY env var or pass api_key to constructor")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "GOOGLE_API_KEY is not set. Provide api_key=... or set the "
+                "GOOGLE_API_KEY environment variable. "
+                "See https://github.com/jhd3197/prompture#configuration"
+            )
 
         self.model = model
 

--- a/prompture/drivers/google_driver.py
+++ b/prompture/drivers/google_driver.py
@@ -3,12 +3,12 @@ import logging
 import os
 import uuid
 from collections.abc import Iterator
-from typing import Any, Optional
+from typing import Any
 
 try:
     from google import genai
     from google.genai import types
-except Exception:
+except ImportError:
     genai = None  # type: ignore[assignment]
     types = None  # type: ignore[assignment]
 
@@ -58,7 +58,12 @@ class GoogleDriver(CostMixin, Driver):
             model: Model to use. Defaults to "gemini-1.5-pro"
         """
         if genai is None:
-            raise RuntimeError("google-genai package is not installed. Install it with: pip install google-genai")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "google-genai package is not installed. "
+                'Install it with: pip install "prompture[google]"'
+            )
         self.api_key = api_key or os.getenv("GOOGLE_API_KEY")
         if not self.api_key:
             from ..exceptions import ConfigurationError
@@ -162,7 +167,7 @@ class GoogleDriver(CostMixin, Driver):
         return _prepare_google_vision_messages(messages)
 
     def _build_generation_args(
-        self, messages: list[dict[str, Any]], options: Optional[dict[str, Any]] = None
+        self, messages: list[dict[str, Any]], options: dict[str, Any] | None = None
     ) -> tuple[Any, dict[str, Any]]:
         """Parse messages and options into (contents, config_dict) for generate_content.
 
@@ -294,14 +299,14 @@ class GoogleDriver(CostMixin, Driver):
 
         return gen_input, config_dict
 
-    def generate(self, prompt: str, options: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    def generate(self, prompt: str, options: dict[str, Any] | None = None) -> dict[str, Any]:
         messages = [{"role": "user", "content": prompt}]
         return self._do_generate(messages, options)
 
     def generate_messages(self, messages: list[dict[str, str]], options: dict[str, Any]) -> dict[str, Any]:
         return self._do_generate(self._prepare_messages(messages), options)
 
-    def _do_generate(self, messages: list[dict[str, str]], options: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    def _do_generate(self, messages: list[dict[str, str]], options: dict[str, Any] | None = None) -> dict[str, Any]:
         gen_input, config_dict = self._build_generation_args(messages, options)
 
         # Validate capabilities against models.dev metadata
@@ -335,7 +340,9 @@ class GoogleDriver(CostMixin, Driver):
 
         except Exception as e:
             logger.error(f"Google API request failed: {e}")
-            raise RuntimeError(f"Google API request failed: {e}") from e
+            from ..exceptions import DriverError
+
+            raise DriverError(f"Google API request failed: {e}") from e
 
     # ------------------------------------------------------------------
     # Tool use
@@ -441,7 +448,9 @@ class GoogleDriver(CostMixin, Driver):
 
         except Exception as e:
             logger.error(f"Google API tool call request failed: {e}")
-            raise RuntimeError(f"Google API tool call request failed: {e}") from e
+            from ..exceptions import DriverError
+
+            raise DriverError(f"Google API tool call request failed: {e}") from e
 
     # ------------------------------------------------------------------
     # Streaming
@@ -485,4 +494,6 @@ class GoogleDriver(CostMixin, Driver):
 
         except Exception as e:
             logger.error(f"Google API streaming request failed: {e}")
-            raise RuntimeError(f"Google API streaming request failed: {e}") from e
+            from ..exceptions import DriverError
+
+            raise DriverError(f"Google API streaming request failed: {e}") from e

--- a/prompture/drivers/google_vertexai_driver.py
+++ b/prompture/drivers/google_vertexai_driver.py
@@ -20,13 +20,13 @@ from typing import Any
 try:
     from google import genai
     from google.genai import types
-except Exception:
+except ImportError:
     genai = None  # type: ignore[assignment]
     types = None  # type: ignore[assignment]
 
 try:
     from anthropic import AnthropicVertex
-except Exception:
+except ImportError:
     AnthropicVertex = None  # type: ignore[assignment]
 
 from ..infra.cost_mixin import CostMixin

--- a/prompture/drivers/grok_driver.py
+++ b/prompture/drivers/grok_driver.py
@@ -17,7 +17,6 @@ logger = logging.getLogger(__name__)
 class GrokDriver(CostMixin, Driver):
     supports_json_mode = True
     supports_tool_use = True
-    supports_streaming = True
     supports_streaming_tool_use = True
 
     supports_vision = True
@@ -250,7 +249,4 @@ class GrokDriver(CostMixin, Driver):
         """Stream one turn as :class:`LiveEvent` via the shared raw-HTTP helper."""
         from ._openai_compat_stream import stream_raw_http_compat_tool_call
 
-        yield from stream_raw_http_compat_tool_call(
-            self, messages, tools, options, provider="grok"
-        )
-
+        yield from stream_raw_http_compat_tool_call(self, messages, tools, options, provider="grok")

--- a/prompture/drivers/grok_driver.py
+++ b/prompture/drivers/grok_driver.py
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 class GrokDriver(CostMixin, Driver):
     supports_json_mode = True
     supports_tool_use = True
+    supports_streaming = True
+    supports_streaming_tool_use = True
+
     supports_vision = True
 
     # All pricing and model config now resolved from JSON rate files (KB) and
@@ -233,3 +236,21 @@ class GrokDriver(CostMixin, Driver):
         if choice["message"].get("reasoning_content") is not None:
             result["reasoning_content"] = choice["message"]["reasoning_content"]
         return result
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ):
+        """Stream one turn as :class:`LiveEvent` via the shared raw-HTTP helper."""
+        from ._openai_compat_stream import stream_raw_http_compat_tool_call
+
+        yield from stream_raw_http_compat_tool_call(
+            self, messages, tools, options, provider="grok"
+        )
+

--- a/prompture/drivers/grok_img_gen_driver.py
+++ b/prompture/drivers/grok_img_gen_driver.py
@@ -8,7 +8,7 @@ from typing import Any
 
 try:
     from openai import OpenAI
-except Exception:
+except ImportError:
     OpenAI = None  # type: ignore[misc, assignment]
 
 from ..infra.cost_mixin import ImageCostMixin

--- a/prompture/drivers/groq_driver.py
+++ b/prompture/drivers/groq_driver.py
@@ -20,6 +20,8 @@ logger = logging.getLogger(__name__)
 class GroqDriver(CostMixin, Driver):
     supports_json_mode = True
     supports_tool_use = True
+    supports_streaming = True
+    supports_streaming_tool_use = True
     supports_vision = True
 
     # All pricing and model config now resolved from JSON rate files (KB) and
@@ -246,3 +248,29 @@ class GroqDriver(CostMixin, Driver):
         if reasoning_content is not None:
             result["reasoning_content"] = reasoning_content
         return result
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ):
+        """Stream one Groq turn as :class:`LiveEvent` via the shared
+        OpenAI-compat helper."""
+        if self.client is None:
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "groq package is not installed. "
+                'Install it with: pip install "prompture[groq]"'
+            )
+
+        from ._openai_compat_stream import stream_openai_compat_tool_call
+
+        yield from stream_openai_compat_tool_call(
+            self, messages, tools, options, provider="groq"
+        )

--- a/prompture/drivers/groq_driver.py
+++ b/prompture/drivers/groq_driver.py
@@ -35,10 +35,18 @@ class GroqDriver(CostMixin, Driver):
         """
         self.api_key = api_key or os.getenv("GROQ_API_KEY")
         self.model = model
-        if groq is not None:
-            self.client: Any = groq.Client(api_key=self.api_key)
-        else:
-            self.client = None
+        if groq is None:
+            self.client: Any = None
+            return
+        if not self.api_key:
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "GROQ_API_KEY is not set. Provide api_key=... or set the "
+                "GROQ_API_KEY environment variable. "
+                "See https://github.com/jhd3197/prompture#configuration"
+            )
+        self.client: Any = groq.Client(api_key=self.api_key)
 
     @classmethod
     def list_models(cls, *, api_key: str | None = None, timeout: int = 10, **kw: object) -> list[str] | None:

--- a/prompture/drivers/groq_driver.py
+++ b/prompture/drivers/groq_driver.py
@@ -20,7 +20,6 @@ logger = logging.getLogger(__name__)
 class GroqDriver(CostMixin, Driver):
     supports_json_mode = True
     supports_tool_use = True
-    supports_streaming = True
     supports_streaming_tool_use = True
     supports_vision = True
 
@@ -78,10 +77,7 @@ class GroqDriver(CostMixin, Driver):
         if self.client is None:
             from ..exceptions import ConfigurationError
 
-            raise ConfigurationError(
-                "groq package is not installed. "
-                'Install it with: pip install "prompture[groq]"'
-            )
+            raise ConfigurationError('groq package is not installed. Install it with: pip install "prompture[groq]"')
 
         model = options.get("model", self.model)
 
@@ -171,10 +167,7 @@ class GroqDriver(CostMixin, Driver):
         if self.client is None:
             from ..exceptions import ConfigurationError
 
-            raise ConfigurationError(
-                "groq package is not installed. "
-                'Install it with: pip install "prompture[groq]"'
-            )
+            raise ConfigurationError('groq package is not installed. Install it with: pip install "prompture[groq]"')
 
         model = options.get("model", self.model)
         model_config = self._get_model_config("groq", model)
@@ -264,13 +257,8 @@ class GroqDriver(CostMixin, Driver):
         if self.client is None:
             from ..exceptions import ConfigurationError
 
-            raise ConfigurationError(
-                "groq package is not installed. "
-                'Install it with: pip install "prompture[groq]"'
-            )
+            raise ConfigurationError('groq package is not installed. Install it with: pip install "prompture[groq]"')
 
         from ._openai_compat_stream import stream_openai_compat_tool_call
 
-        yield from stream_openai_compat_tool_call(
-            self, messages, tools, options, provider="groq"
-        )
+        yield from stream_openai_compat_tool_call(self, messages, tools, options, provider="groq")

--- a/prompture/drivers/groq_driver.py
+++ b/prompture/drivers/groq_driver.py
@@ -8,7 +8,7 @@ from typing import Any
 
 try:
     import groq
-except Exception:
+except ImportError:
     groq = None  # type: ignore[assignment]
 
 from ..infra.cost_mixin import CostMixin
@@ -74,7 +74,12 @@ class GroqDriver(CostMixin, Driver):
 
     def _do_generate(self, messages: list[dict[str, str]], options: dict[str, Any]) -> dict[str, Any]:
         if self.client is None:
-            raise RuntimeError("groq package is not installed")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "groq package is not installed. "
+                'Install it with: pip install "prompture[groq]"'
+            )
 
         model = options.get("model", self.model)
 
@@ -162,7 +167,12 @@ class GroqDriver(CostMixin, Driver):
     ) -> dict[str, Any]:
         """Generate a response that may include tool calls."""
         if self.client is None:
-            raise RuntimeError("groq package is not installed")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "groq package is not installed. "
+                'Install it with: pip install "prompture[groq]"'
+            )
 
         model = options.get("model", self.model)
         model_config = self._get_model_config("groq", model)

--- a/prompture/drivers/lmstudio_driver.py
+++ b/prompture/drivers/lmstudio_driver.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from typing import Any, Optional
+from typing import Any
 
 import requests
 
@@ -65,14 +65,14 @@ class LMStudioDriver(Driver):
 
         return _prepare_openai_vision_messages(messages)
 
-    def generate(self, prompt: str, options: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    def generate(self, prompt: str, options: dict[str, Any] | None = None) -> dict[str, Any]:
         messages = [{"role": "user", "content": prompt}]
         return self._do_generate(messages, options)
 
     def generate_messages(self, messages: list[dict[str, str]], options: dict[str, Any]) -> dict[str, Any]:
         return self._do_generate(self._prepare_messages(messages), options)
 
-    def _do_generate(self, messages: list[dict[str, str]], options: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    def _do_generate(self, messages: list[dict[str, str]], options: dict[str, Any] | None = None) -> dict[str, Any]:
         merged_options = self.options.copy()
         if options:
             merged_options.update(options)

--- a/prompture/drivers/lmstudio_driver.py
+++ b/prompture/drivers/lmstudio_driver.py
@@ -99,6 +99,18 @@ class LMStudioDriver(Driver):
                 # LM Studio rejects "json_object" type.
                 pass
 
+        # vLLM-style guided_json pass-through + generic extra_body escape hatch
+        # (8A-lite). Useful when LM Studio is fronting a vLLM backend or when
+        # the user wants to inject vendor-specific fields.
+        from ._openai_compat import apply_guided_decoding, merge_extra_body
+
+        apply_guided_decoding(
+            payload,
+            json_schema=merged_options.get("json_schema"),
+            guided_decoding=merged_options.get("guided_decoding"),
+        )
+        merge_extra_body(payload, merged_options)
+
         try:
             logger.debug(f"Sending request to LM Studio endpoint: {self.endpoint}")
             logger.debug(f"Request payload: {payload}")

--- a/prompture/drivers/mistral_driver.py
+++ b/prompture/drivers/mistral_driver.py
@@ -33,7 +33,12 @@ class MistralDriver(CostMixin, Driver):
     def __init__(self, api_key: str | None = None, model: str = "mistral-large-latest"):
         self.api_key = api_key or os.getenv("MISTRAL_API_KEY")
         if not self.api_key:
-            raise ValueError("Mistral API key not found. Set MISTRAL_API_KEY env var.")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "MISTRAL_API_KEY is not set. Provide api_key=... or set the "
+                "MISTRAL_API_KEY environment variable."
+            )
         self.model = model
         self.base_url = "https://api.mistral.ai/v1"
         self.headers = {
@@ -68,7 +73,9 @@ class MistralDriver(CostMixin, Driver):
 
     def _do_generate(self, messages: list[dict[str, str]], options: dict[str, Any]) -> dict[str, Any]:
         if not self.api_key:
-            raise RuntimeError("Mistral API key not found")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError("MISTRAL_API_KEY is not set.")
 
         model = options.get("model", self.model)
         model_config = self._get_model_config("mistral", model)
@@ -116,9 +123,15 @@ class MistralDriver(CostMixin, Driver):
             error_msg = f"Mistral API request failed: {e!s}"
             if body:
                 error_msg += f"\nResponse: {body}"
-            raise RuntimeError(error_msg) from e
+            from ..exceptions import DriverError
+
+            err = DriverError(error_msg)
+            err.status_code = e.response.status_code if e.response is not None else None
+            raise err from e
         except requests.exceptions.RequestException as e:
-            raise RuntimeError(f"Mistral API request failed: {e!s}") from e
+            from ..exceptions import DriverError
+
+            raise DriverError(f"Mistral API request failed: {e!s}") from e
 
         usage = resp.get("usage", {})
         prompt_tokens = usage.get("prompt_tokens", 0)
@@ -146,7 +159,9 @@ class MistralDriver(CostMixin, Driver):
         options: dict[str, Any],
     ) -> dict[str, Any]:
         if not self.api_key:
-            raise RuntimeError("Mistral API key not found")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError("MISTRAL_API_KEY is not set.")
 
         model = options.get("model", self.model)
         model_config = self._get_model_config("mistral", model)
@@ -183,9 +198,15 @@ class MistralDriver(CostMixin, Driver):
             error_msg = f"Mistral API request failed: {e!s}"
             if body:
                 error_msg += f"\nResponse: {body}"
-            raise RuntimeError(error_msg) from e
+            from ..exceptions import DriverError
+
+            err = DriverError(error_msg)
+            err.status_code = e.response.status_code if e.response is not None else None
+            raise err from e
         except requests.exceptions.RequestException as e:
-            raise RuntimeError(f"Mistral API request failed: {e!s}") from e
+            from ..exceptions import DriverError
+
+            raise DriverError(f"Mistral API request failed: {e!s}") from e
 
         usage = resp.get("usage", {})
         prompt_tokens = usage.get("prompt_tokens", 0)

--- a/prompture/drivers/mistral_driver.py
+++ b/prompture/drivers/mistral_driver.py
@@ -38,8 +38,7 @@ class MistralDriver(CostMixin, Driver):
             from ..exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "MISTRAL_API_KEY is not set. Provide api_key=... or set the "
-                "MISTRAL_API_KEY environment variable."
+                "MISTRAL_API_KEY is not set. Provide api_key=... or set the MISTRAL_API_KEY environment variable."
             )
         self.model = model
         self.base_url = "https://api.mistral.ai/v1"
@@ -260,7 +259,4 @@ class MistralDriver(CostMixin, Driver):
         """Stream one turn as :class:`LiveEvent` via the shared raw-HTTP helper."""
         from ._openai_compat_stream import stream_raw_http_compat_tool_call
 
-        yield from stream_raw_http_compat_tool_call(
-            self, messages, tools, options, provider="mistral"
-        )
-
+        yield from stream_raw_http_compat_tool_call(self, messages, tools, options, provider="mistral")

--- a/prompture/drivers/mistral_driver.py
+++ b/prompture/drivers/mistral_driver.py
@@ -24,6 +24,8 @@ class MistralDriver(CostMixin, Driver):
     supports_json_mode = True
     supports_json_schema = True
     supports_tool_use = True
+    supports_streaming = True
+    supports_streaming_tool_use = True
     supports_streaming = False
     supports_vision = True
     supports_messages = True
@@ -244,3 +246,21 @@ class MistralDriver(CostMixin, Driver):
             "tool_calls": tool_calls_out,
             "stop_reason": stop_reason,
         }
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ):
+        """Stream one turn as :class:`LiveEvent` via the shared raw-HTTP helper."""
+        from ._openai_compat_stream import stream_raw_http_compat_tool_call
+
+        yield from stream_raw_http_compat_tool_call(
+            self, messages, tools, options, provider="mistral"
+        )
+

--- a/prompture/drivers/modelscope_driver.py
+++ b/prompture/drivers/modelscope_driver.py
@@ -25,6 +25,7 @@ class ModelScopeDriver(CostMixin, Driver):
     supports_json_mode = True
     supports_json_schema = False
     supports_tool_use = True
+    supports_streaming_tool_use = True
     supports_streaming = True
     supports_vision = False
 
@@ -235,6 +236,24 @@ class ModelScopeDriver(CostMixin, Driver):
             "tool_calls": tool_calls_out,
             "stop_reason": stop_reason,
         }
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ):
+        """Stream one turn as :class:`LiveEvent` via the shared raw-HTTP helper."""
+        from ._openai_compat_stream import stream_raw_http_compat_tool_call
+
+        yield from stream_raw_http_compat_tool_call(
+            self, messages, tools, options, provider="modelscope"
+        )
+
 
     # ------------------------------------------------------------------
     # Streaming

--- a/prompture/drivers/modelscope_driver.py
+++ b/prompture/drivers/modelscope_driver.py
@@ -250,10 +250,7 @@ class ModelScopeDriver(CostMixin, Driver):
         """Stream one turn as :class:`LiveEvent` via the shared raw-HTTP helper."""
         from ._openai_compat_stream import stream_raw_http_compat_tool_call
 
-        yield from stream_raw_http_compat_tool_call(
-            self, messages, tools, options, provider="modelscope"
-        )
-
+        yield from stream_raw_http_compat_tool_call(self, messages, tools, options, provider="modelscope")
 
     # ------------------------------------------------------------------
     # Streaming

--- a/prompture/drivers/moonshot_driver.py
+++ b/prompture/drivers/moonshot_driver.py
@@ -477,7 +477,6 @@ class MoonshotDriver(CostMixin, Driver):
 
         return result
 
-
     # ------------------------------------------------------------------
     # Live streaming with interleaved tool calls
     # ------------------------------------------------------------------
@@ -491,9 +490,7 @@ class MoonshotDriver(CostMixin, Driver):
         """Stream one turn as :class:`LiveEvent` via the shared raw-HTTP helper."""
         from ._openai_compat_stream import stream_raw_http_compat_tool_call
 
-        yield from stream_raw_http_compat_tool_call(
-            self, messages, tools, options, provider="moonshot"
-        )
+        yield from stream_raw_http_compat_tool_call(self, messages, tools, options, provider="moonshot")
 
     # ------------------------------------------------------------------
     # Streaming

--- a/prompture/drivers/moonshot_driver.py
+++ b/prompture/drivers/moonshot_driver.py
@@ -52,6 +52,8 @@ class MoonshotDriver(CostMixin, Driver):
     supports_json_mode = True
     supports_json_schema = True
     supports_tool_use = True
+    supports_streaming_tool_use = True
+
     supports_streaming = True
     supports_vision = True
 
@@ -474,6 +476,24 @@ class MoonshotDriver(CostMixin, Driver):
             result["reasoning_content"] = message["reasoning_content"]
 
         return result
+
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ):
+        """Stream one turn as :class:`LiveEvent` via the shared raw-HTTP helper."""
+        from ._openai_compat_stream import stream_raw_http_compat_tool_call
+
+        yield from stream_raw_http_compat_tool_call(
+            self, messages, tools, options, provider="moonshot"
+        )
 
     # ------------------------------------------------------------------
     # Streaming

--- a/prompture/drivers/ollama_driver.py
+++ b/prompture/drivers/ollama_driver.py
@@ -226,9 +226,13 @@ class OllamaDriver(Driver):
             "stream": True,
         }
 
-        if merged_options.get("json_mode"):
-            json_schema = merged_options.get("json_schema")
-            payload["format"] = json_schema if json_schema else "json"
+        # Native JSON mode / structured output — see generate_messages() for
+        # the matching logic. A schema implies JSON mode.
+        json_schema = merged_options.get("json_schema")
+        if json_schema is not None:
+            payload["format"] = json_schema
+        elif merged_options.get("json_mode"):
+            payload["format"] = "json"
         if "temperature" in merged_options:
             payload["temperature"] = merged_options["temperature"]
         if "top_p" in merged_options:
@@ -294,10 +298,15 @@ class OllamaDriver(Driver):
             "stream": False,
         }
 
-        # Native JSON mode / structured output support
-        if merged_options.get("json_mode"):
-            json_schema = merged_options.get("json_schema")
-            payload["format"] = json_schema if json_schema else "json"
+        # Native JSON mode / structured output (Ollama >=0.5 accepts a JSON
+        # schema dict directly in `format`; older versions accept "json" for
+        # loose grammar). Having a schema implies JSON mode, so we don't
+        # require an explicit json_mode=True flag in that case.
+        json_schema = merged_options.get("json_schema")
+        if json_schema is not None:
+            payload["format"] = json_schema
+        elif merged_options.get("json_mode"):
+            payload["format"] = "json"
 
         if "temperature" in merged_options:
             payload["temperature"] = merged_options["temperature"]

--- a/prompture/drivers/ollama_driver.py
+++ b/prompture/drivers/ollama_driver.py
@@ -3,7 +3,7 @@ import logging
 import os
 import uuid
 from collections.abc import Iterator
-from typing import Any, Optional
+from typing import Any
 
 import requests
 
@@ -85,7 +85,7 @@ class OllamaDriver(Driver):
 
         return _prepare_ollama_vision_messages(messages)
 
-    def generate(self, prompt: str, options: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    def generate(self, prompt: str, options: dict[str, Any] | None = None) -> dict[str, Any]:
         # Delegate to /api/chat — the /api/generate endpoint produces
         # poor results with instruction-tuned models and does not support
         # JSON schema objects in the ``format`` field.

--- a/prompture/drivers/openai_compatible_driver.py
+++ b/prompture/drivers/openai_compatible_driver.py
@@ -185,6 +185,8 @@ class OpenAICompatibleDriver(CostMixin, Driver):
         if supports_temperature and "temperature" in opts:
             data["temperature"] = opts["temperature"]
 
+        from ._openai_compat import apply_guided_decoding, merge_extra_body
+
         if options.get("json_mode"):
             json_schema = options.get("json_schema")
             if json_schema:
@@ -199,6 +201,16 @@ class OpenAICompatibleDriver(CostMixin, Driver):
                 }
             else:
                 data["response_format"] = {"type": "json_object"}
+
+        # vLLM-style FSM-constrained decoding pass-through (8A-lite).
+        # Safe on every OpenAI-compatible server — unrecognised keys are ignored.
+        apply_guided_decoding(
+            data,
+            json_schema=options.get("json_schema"),
+            guided_decoding=options.get("guided_decoding"),
+        )
+        # Generic vendor escape hatch (mirrors openai SDK's extra_body).
+        merge_extra_body(data, options)
 
         try:
             response = requests.post(

--- a/prompture/drivers/openai_driver.py
+++ b/prompture/drivers/openai_driver.py
@@ -129,6 +129,7 @@ class OpenAIDriver(CostMixin, Driver):
     supports_json_schema = True
     supports_tool_use = True
     supports_streaming = True
+    supports_streaming_tool_use = True
     supports_vision = True
 
     # All pricing and model config now resolved from JSON rate files (KB) and
@@ -341,3 +342,156 @@ class OpenAIDriver(CostMixin, Driver):
         yield _build_openai_stream_done(
             model, full_text, prompt_tokens, completion_tokens, total_cost, cached_prompt_tokens
         )
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> Iterator[Any]:
+        """Stream one OpenAI turn as :class:`LiveEvent`.
+
+        Maps ``delta.content`` to ``TextDelta`` and assembles
+        ``delta.tool_calls[index].function.{name,arguments}`` fragments
+        into ``ToolUseStart`` (on first appearance, when id/name arrive)
+        plus ``ToolInputDelta`` (per argument fragment). At the end of the
+        stream, yields ``ToolUseStop`` for each tool (OpenAI has no
+        per-block stop event), then ``MessageStop`` with usage.
+        """
+        if self.client is None:
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "openai package (>=1.0.0) is not installed. "
+                'Install it with: pip install "prompture[openai]"'
+            )
+
+        from ..agents.live_events import (
+            MessageStop,
+            TextDelta,
+            ToolInputDelta,
+            ToolUseStart,
+            ToolUseStop,
+        )
+
+        model = options.get("model", self.model)
+        model_config = self._get_model_config("openai", model)
+        tokens_param = model_config["tokens_param"]
+        supports_temperature = model_config["supports_temperature"]
+
+        opts = {"temperature": 1.0, "max_tokens": 4096, **options}
+        kwargs = _build_openai_base_kwargs(
+            model,
+            messages,
+            opts,
+            tokens_param,
+            supports_temperature,
+            4096,
+            extra={
+                "tools": tools,
+                "stream": True,
+                "stream_options": {"include_usage": True},
+            },
+        )
+
+        stream = self.client.chat.completions.create(**kwargs)
+
+        prompt_tokens = 0
+        completion_tokens = 0
+        cached_prompt_tokens = 0
+        finish_reason = "stop"
+
+        tool_calls_by_index: dict[int, dict[str, Any]] = {}
+
+        import json as _json
+
+        for chunk in stream:
+            if getattr(chunk, "usage", None):
+                prompt_tokens = chunk.usage.prompt_tokens or 0
+                completion_tokens = chunk.usage.completion_tokens or 0
+                cached_prompt_tokens = _extract_openai_cached_tokens(chunk.usage)
+
+            if not chunk.choices:
+                continue
+
+            choice = chunk.choices[0]
+            delta = getattr(choice, "delta", None)
+            if delta is None:
+                fr = getattr(choice, "finish_reason", None)
+                if fr:
+                    finish_reason = fr
+                continue
+
+            content = getattr(delta, "content", None) or ""
+            if content:
+                yield TextDelta(text=content)
+
+            delta_tool_calls = getattr(delta, "tool_calls", None) or []
+            for tc in delta_tool_calls:
+                idx = getattr(tc, "index", 0) or 0
+                bucket = tool_calls_by_index.setdefault(
+                    idx,
+                    {"id": "", "name": "", "args_fragments": [], "start_emitted": False},
+                )
+                tc_id = getattr(tc, "id", None)
+                if tc_id and not bucket["id"]:
+                    bucket["id"] = tc_id
+                fn = getattr(tc, "function", None)
+                if fn is not None:
+                    fn_name = getattr(fn, "name", None)
+                    if fn_name and not bucket["name"]:
+                        bucket["name"] = fn_name
+                    fn_args = getattr(fn, "arguments", None)
+                    if fn_args:
+                        bucket["args_fragments"].append(fn_args)
+                if (
+                    not bucket["start_emitted"]
+                    and bucket["id"]
+                    and bucket["name"]
+                ):
+                    bucket["start_emitted"] = True
+                    yield ToolUseStart(id=bucket["id"], name=bucket["name"])
+                if bucket["start_emitted"]:
+                    fn_args_now = getattr(fn, "arguments", None) if fn is not None else None
+                    if fn_args_now:
+                        yield ToolInputDelta(id=bucket["id"], fragment=fn_args_now)
+
+            fr = getattr(choice, "finish_reason", None)
+            if fr:
+                finish_reason = fr
+
+        for idx in sorted(tool_calls_by_index.keys()):
+            bucket = tool_calls_by_index[idx]
+            if not bucket["start_emitted"] and bucket["id"] and bucket["name"]:
+                yield ToolUseStart(id=bucket["id"], name=bucket["name"])
+                bucket["start_emitted"] = True
+            args_str = "".join(bucket["args_fragments"])
+            try:
+                parsed = _json.loads(args_str) if args_str else {}
+                if not isinstance(parsed, dict):
+                    parsed = {}
+            except _json.JSONDecodeError:
+                logger.warning(
+                    "Failed to parse streamed tool input for %s: %r",
+                    bucket["name"],
+                    args_str[:200],
+                )
+                parsed = {}
+            yield ToolUseStop(id=bucket["id"], name=bucket["name"], input=parsed)
+
+        total_cost = self._calculate_cost(
+            "openai", model, prompt_tokens, completion_tokens, cached_tokens=cached_prompt_tokens
+        )
+        meta = {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+            "cached_prompt_tokens": cached_prompt_tokens,
+            "cost": round(total_cost, 6),
+            "model_name": model,
+        }
+        yield MessageStop(stop_reason=finish_reason, usage=meta)

--- a/prompture/drivers/openai_driver.py
+++ b/prompture/drivers/openai_driver.py
@@ -181,8 +181,7 @@ class OpenAIDriver(CostMixin, Driver):
             from ..exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "openai package (>=1.0.0) is not installed. "
-                'Install it with: pip install "prompture[openai]"'
+                'openai package (>=1.0.0) is not installed. Install it with: pip install "prompture[openai]"'
             )
 
         model = options.get("model", self.model)
@@ -242,8 +241,7 @@ class OpenAIDriver(CostMixin, Driver):
             from ..exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "openai package (>=1.0.0) is not installed. "
-                'Install it with: pip install "prompture[openai]"'
+                'openai package (>=1.0.0) is not installed. Install it with: pip install "prompture[openai]"'
             )
 
         model = options.get("model", self.model)
@@ -295,8 +293,7 @@ class OpenAIDriver(CostMixin, Driver):
             from ..exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "openai package (>=1.0.0) is not installed. "
-                'Install it with: pip install "prompture[openai]"'
+                'openai package (>=1.0.0) is not installed. Install it with: pip install "prompture[openai]"'
             )
 
         model = options.get("model", self.model)
@@ -360,12 +357,9 @@ class OpenAIDriver(CostMixin, Driver):
             from ..exceptions import ConfigurationError
 
             raise ConfigurationError(
-                "openai package (>=1.0.0) is not installed. "
-                'Install it with: pip install "prompture[openai]"'
+                'openai package (>=1.0.0) is not installed. Install it with: pip install "prompture[openai]"'
             )
 
         from ._openai_compat_stream import stream_openai_compat_tool_call
 
-        yield from stream_openai_compat_tool_call(
-            self, messages, tools, options, provider="openai"
-        )
+        yield from stream_openai_compat_tool_call(self, messages, tools, options, provider="openai")

--- a/prompture/drivers/openai_driver.py
+++ b/prompture/drivers/openai_driver.py
@@ -138,10 +138,18 @@ class OpenAIDriver(CostMixin, Driver):
     def __init__(self, api_key: str | None = None, model: str = "gpt-4o-mini"):
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
         self.model = model
-        if OpenAI is not None:
-            self.client = OpenAI(api_key=self.api_key)
-        else:
+        if OpenAI is None:
             self.client = None
+            return
+        if not self.api_key:
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "OPENAI_API_KEY is not set. Provide api_key=... or set the "
+                "OPENAI_API_KEY environment variable. "
+                "See https://github.com/jhd3197/prompture#configuration"
+            )
+        self.client = OpenAI(api_key=self.api_key)
 
     @classmethod
     def list_models(cls, *, api_key: str | None = None, timeout: int = 10, **kw: object) -> list[str] | None:

--- a/prompture/drivers/openai_driver.py
+++ b/prompture/drivers/openai_driver.py
@@ -9,7 +9,7 @@ from typing import Any
 
 try:
     from openai import OpenAI
-except Exception:
+except ImportError:
     OpenAI = None  # type: ignore[misc, assignment]
 
 from ..infra.cost_mixin import CostMixin, prepare_strict_schema
@@ -177,7 +177,12 @@ class OpenAIDriver(CostMixin, Driver):
 
     def _do_generate(self, messages: list[dict[str, Any]], options: dict[str, Any]) -> dict[str, Any]:
         if self.client is None:
-            raise RuntimeError("openai package (>=1.0.0) is not installed")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "openai package (>=1.0.0) is not installed. "
+                'Install it with: pip install "prompture[openai]"'
+            )
 
         model = options.get("model", self.model)
 
@@ -233,7 +238,12 @@ class OpenAIDriver(CostMixin, Driver):
     ) -> dict[str, Any]:
         """Generate a response that may include tool calls."""
         if self.client is None:
-            raise RuntimeError("openai package (>=1.0.0) is not installed")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "openai package (>=1.0.0) is not installed. "
+                'Install it with: pip install "prompture[openai]"'
+            )
 
         model = options.get("model", self.model)
         model_config = self._get_model_config("openai", model)
@@ -281,7 +291,12 @@ class OpenAIDriver(CostMixin, Driver):
     ) -> Iterator[dict[str, Any]]:
         """Yield response chunks via OpenAI streaming API."""
         if self.client is None:
-            raise RuntimeError("openai package (>=1.0.0) is not installed")
+            from ..exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                "openai package (>=1.0.0) is not installed. "
+                'Install it with: pip install "prompture[openai]"'
+            )
 
         model = options.get("model", self.model)
         model_config = self._get_model_config("openai", model)

--- a/prompture/drivers/openai_driver.py
+++ b/prompture/drivers/openai_driver.py
@@ -353,15 +353,9 @@ class OpenAIDriver(CostMixin, Driver):
         tools: list[dict[str, Any]],
         options: dict[str, Any],
     ) -> Iterator[Any]:
-        """Stream one OpenAI turn as :class:`LiveEvent`.
-
-        Maps ``delta.content`` to ``TextDelta`` and assembles
-        ``delta.tool_calls[index].function.{name,arguments}`` fragments
-        into ``ToolUseStart`` (on first appearance, when id/name arrive)
-        plus ``ToolInputDelta`` (per argument fragment). At the end of the
-        stream, yields ``ToolUseStop`` for each tool (OpenAI has no
-        per-block stop event), then ``MessageStop`` with usage.
-        """
+        """Stream one OpenAI turn as :class:`LiveEvent` via the shared
+        OpenAI-compat helper. See
+        :mod:`prompture.drivers._openai_compat_stream` for the protocol."""
         if self.client is None:
             from ..exceptions import ConfigurationError
 
@@ -370,128 +364,8 @@ class OpenAIDriver(CostMixin, Driver):
                 'Install it with: pip install "prompture[openai]"'
             )
 
-        from ..agents.live_events import (
-            MessageStop,
-            TextDelta,
-            ToolInputDelta,
-            ToolUseStart,
-            ToolUseStop,
+        from ._openai_compat_stream import stream_openai_compat_tool_call
+
+        yield from stream_openai_compat_tool_call(
+            self, messages, tools, options, provider="openai"
         )
-
-        model = options.get("model", self.model)
-        model_config = self._get_model_config("openai", model)
-        tokens_param = model_config["tokens_param"]
-        supports_temperature = model_config["supports_temperature"]
-
-        opts = {"temperature": 1.0, "max_tokens": 4096, **options}
-        kwargs = _build_openai_base_kwargs(
-            model,
-            messages,
-            opts,
-            tokens_param,
-            supports_temperature,
-            4096,
-            extra={
-                "tools": tools,
-                "stream": True,
-                "stream_options": {"include_usage": True},
-            },
-        )
-
-        stream = self.client.chat.completions.create(**kwargs)
-
-        prompt_tokens = 0
-        completion_tokens = 0
-        cached_prompt_tokens = 0
-        finish_reason = "stop"
-
-        tool_calls_by_index: dict[int, dict[str, Any]] = {}
-
-        import json as _json
-
-        for chunk in stream:
-            if getattr(chunk, "usage", None):
-                prompt_tokens = chunk.usage.prompt_tokens or 0
-                completion_tokens = chunk.usage.completion_tokens or 0
-                cached_prompt_tokens = _extract_openai_cached_tokens(chunk.usage)
-
-            if not chunk.choices:
-                continue
-
-            choice = chunk.choices[0]
-            delta = getattr(choice, "delta", None)
-            if delta is None:
-                fr = getattr(choice, "finish_reason", None)
-                if fr:
-                    finish_reason = fr
-                continue
-
-            content = getattr(delta, "content", None) or ""
-            if content:
-                yield TextDelta(text=content)
-
-            delta_tool_calls = getattr(delta, "tool_calls", None) or []
-            for tc in delta_tool_calls:
-                idx = getattr(tc, "index", 0) or 0
-                bucket = tool_calls_by_index.setdefault(
-                    idx,
-                    {"id": "", "name": "", "args_fragments": [], "start_emitted": False},
-                )
-                tc_id = getattr(tc, "id", None)
-                if tc_id and not bucket["id"]:
-                    bucket["id"] = tc_id
-                fn = getattr(tc, "function", None)
-                if fn is not None:
-                    fn_name = getattr(fn, "name", None)
-                    if fn_name and not bucket["name"]:
-                        bucket["name"] = fn_name
-                    fn_args = getattr(fn, "arguments", None)
-                    if fn_args:
-                        bucket["args_fragments"].append(fn_args)
-                if (
-                    not bucket["start_emitted"]
-                    and bucket["id"]
-                    and bucket["name"]
-                ):
-                    bucket["start_emitted"] = True
-                    yield ToolUseStart(id=bucket["id"], name=bucket["name"])
-                if bucket["start_emitted"]:
-                    fn_args_now = getattr(fn, "arguments", None) if fn is not None else None
-                    if fn_args_now:
-                        yield ToolInputDelta(id=bucket["id"], fragment=fn_args_now)
-
-            fr = getattr(choice, "finish_reason", None)
-            if fr:
-                finish_reason = fr
-
-        for idx in sorted(tool_calls_by_index.keys()):
-            bucket = tool_calls_by_index[idx]
-            if not bucket["start_emitted"] and bucket["id"] and bucket["name"]:
-                yield ToolUseStart(id=bucket["id"], name=bucket["name"])
-                bucket["start_emitted"] = True
-            args_str = "".join(bucket["args_fragments"])
-            try:
-                parsed = _json.loads(args_str) if args_str else {}
-                if not isinstance(parsed, dict):
-                    parsed = {}
-            except _json.JSONDecodeError:
-                logger.warning(
-                    "Failed to parse streamed tool input for %s: %r",
-                    bucket["name"],
-                    args_str[:200],
-                )
-                parsed = {}
-            yield ToolUseStop(id=bucket["id"], name=bucket["name"], input=parsed)
-
-        total_cost = self._calculate_cost(
-            "openai", model, prompt_tokens, completion_tokens, cached_tokens=cached_prompt_tokens
-        )
-        meta = {
-            "prompt_tokens": prompt_tokens,
-            "completion_tokens": completion_tokens,
-            "total_tokens": prompt_tokens + completion_tokens,
-            "cached_prompt_tokens": cached_prompt_tokens,
-            "cost": round(total_cost, 6),
-            "model_name": model,
-        }
-        yield MessageStop(stop_reason=finish_reason, usage=meta)

--- a/prompture/drivers/openai_embedding_driver.py
+++ b/prompture/drivers/openai_embedding_driver.py
@@ -8,7 +8,7 @@ from typing import Any
 
 try:
     from openai import OpenAI
-except Exception:
+except ImportError:
     OpenAI = None  # type: ignore[misc, assignment]
 
 from ..infra.cost_mixin import EmbeddingCostMixin

--- a/prompture/drivers/openai_img_gen_driver.py
+++ b/prompture/drivers/openai_img_gen_driver.py
@@ -8,7 +8,7 @@ from typing import Any
 
 try:
     from openai import OpenAI
-except Exception:
+except ImportError:
     OpenAI = None  # type: ignore[misc, assignment]
 
 from ..infra.cost_mixin import ImageCostMixin

--- a/prompture/drivers/openai_stt_driver.py
+++ b/prompture/drivers/openai_stt_driver.py
@@ -9,7 +9,7 @@ from typing import Any
 
 try:
     from openai import OpenAI
-except Exception:
+except ImportError:
     OpenAI = None  # type: ignore[misc, assignment]
 
 from ..infra.cost_mixin import AudioCostMixin

--- a/prompture/drivers/openai_tts_driver.py
+++ b/prompture/drivers/openai_tts_driver.py
@@ -9,7 +9,7 @@ from typing import Any
 
 try:
     from openai import OpenAI
-except Exception:
+except ImportError:
     OpenAI = None  # type: ignore[misc, assignment]
 
 from ..infra.cost_mixin import AudioCostMixin

--- a/prompture/drivers/openrouter_driver.py
+++ b/prompture/drivers/openrouter_driver.py
@@ -128,6 +128,19 @@ class OpenRouterDriver(CostMixin, Driver):
             else:
                 data["response_format"] = {"type": "json_object"}
 
+        # vLLM-style guided_json pass-through + generic extra_body escape
+        # hatch (8A-lite). OpenRouter passes unrecognised fields to upstream
+        # providers, so vLLM-backed models on OpenRouter get FSM-constrained
+        # decoding when guided_decoding=True is set.
+        from ._openai_compat import apply_guided_decoding, merge_extra_body
+
+        apply_guided_decoding(
+            data,
+            json_schema=options.get("json_schema"),
+            guided_decoding=options.get("guided_decoding"),
+        )
+        merge_extra_body(data, options)
+
         try:
             response = requests.post(
                 f"{self.base_url}/chat/completions",

--- a/prompture/drivers/openrouter_driver.py
+++ b/prompture/drivers/openrouter_driver.py
@@ -21,6 +21,8 @@ class OpenRouterDriver(CostMixin, Driver):
     supports_json_mode = True
     supports_json_schema = True
     supports_tool_use = True
+    supports_streaming_tool_use = True
+
     supports_streaming = True
     supports_vision = True
 
@@ -281,6 +283,24 @@ class OpenRouterDriver(CostMixin, Driver):
         if choice["message"].get("reasoning_content") is not None:
             result["reasoning_content"] = choice["message"]["reasoning_content"]
         return result
+
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ):
+        """Stream one turn as :class:`LiveEvent` via the shared raw-HTTP helper."""
+        from ._openai_compat_stream import stream_raw_http_compat_tool_call
+
+        yield from stream_raw_http_compat_tool_call(
+            self, messages, tools, options, provider="openrouter"
+        )
 
     # ------------------------------------------------------------------
     # Streaming

--- a/prompture/drivers/openrouter_driver.py
+++ b/prompture/drivers/openrouter_driver.py
@@ -284,7 +284,6 @@ class OpenRouterDriver(CostMixin, Driver):
             result["reasoning_content"] = choice["message"]["reasoning_content"]
         return result
 
-
     # ------------------------------------------------------------------
     # Live streaming with interleaved tool calls
     # ------------------------------------------------------------------
@@ -298,9 +297,7 @@ class OpenRouterDriver(CostMixin, Driver):
         """Stream one turn as :class:`LiveEvent` via the shared raw-HTTP helper."""
         from ._openai_compat_stream import stream_raw_http_compat_tool_call
 
-        yield from stream_raw_http_compat_tool_call(
-            self, messages, tools, options, provider="openrouter"
-        )
+        yield from stream_raw_http_compat_tool_call(self, messages, tools, options, provider="openrouter")
 
     # ------------------------------------------------------------------
     # Streaming

--- a/prompture/drivers/provider_descriptors.py
+++ b/prompture/drivers/provider_descriptors.py
@@ -21,8 +21,9 @@ remain accessible (via PEP 562 ``__getattr__``) for backwards compatibility.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any
 
 
 @dataclass(frozen=True)

--- a/prompture/drivers/zai_driver.py
+++ b/prompture/drivers/zai_driver.py
@@ -265,10 +265,7 @@ class ZaiDriver(CostMixin, Driver):
         """Stream one turn as :class:`LiveEvent` via the shared raw-HTTP helper."""
         from ._openai_compat_stream import stream_raw_http_compat_tool_call
 
-        yield from stream_raw_http_compat_tool_call(
-            self, messages, tools, options, provider="zai"
-        )
-
+        yield from stream_raw_http_compat_tool_call(self, messages, tools, options, provider="zai")
 
     # ------------------------------------------------------------------
     # Streaming

--- a/prompture/drivers/zai_driver.py
+++ b/prompture/drivers/zai_driver.py
@@ -23,6 +23,7 @@ class ZaiDriver(CostMixin, Driver):
     supports_json_mode = True
     supports_json_schema = True
     supports_tool_use = True
+    supports_streaming_tool_use = True
     supports_streaming = True
     supports_vision = True
 
@@ -250,6 +251,24 @@ class ZaiDriver(CostMixin, Driver):
             "tool_calls": tool_calls_out,
             "stop_reason": stop_reason,
         }
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ):
+        """Stream one turn as :class:`LiveEvent` via the shared raw-HTTP helper."""
+        from ._openai_compat_stream import stream_raw_http_compat_tool_call
+
+        yield from stream_raw_http_compat_tool_call(
+            self, messages, tools, options, provider="zai"
+        )
+
 
     # ------------------------------------------------------------------
     # Streaming

--- a/prompture/eval/__init__.py
+++ b/prompture/eval/__init__.py
@@ -1,0 +1,47 @@
+"""LLM-as-judge evaluation primitives.
+
+Four orthogonal evaluators that all share the LLM driver protocol used
+throughout Prompture::
+
+    driver.generate(prompt, options) -> {"text": str, "meta": {...}}
+
+* :class:`LLMJudge` — score one output against a rubric of criteria.
+* :class:`PairwiseJudge` — pick the better of two outputs with
+  position-bias correction.
+* :class:`SelfConsistencyEvaluator` — sample N independent answers and
+  return the majority vote plus an agreement ratio.
+* :class:`FaithfulnessEvaluator` — decompose a RAG answer into atomic
+  claims and check each one against the retrieved evidence.
+
+All evaluators return ``Result`` dataclasses with a small, stable
+shape so downstream tooling can render reports without parsing free
+text.
+"""
+
+from __future__ import annotations
+
+from .base import (
+    EvalDriver,
+    EvalError,
+    FaithfulnessResult,
+    JudgeResult,
+    PairwiseResult,
+    SelfConsistencyResult,
+)
+from .faithfulness import FaithfulnessEvaluator
+from .judge import LLMJudge
+from .pairwise import PairwiseJudge
+from .self_consistency import SelfConsistencyEvaluator
+
+__all__ = [
+    "EvalDriver",
+    "EvalError",
+    "FaithfulnessEvaluator",
+    "FaithfulnessResult",
+    "JudgeResult",
+    "LLMJudge",
+    "PairwiseJudge",
+    "PairwiseResult",
+    "SelfConsistencyEvaluator",
+    "SelfConsistencyResult",
+]

--- a/prompture/eval/base.py
+++ b/prompture/eval/base.py
@@ -1,0 +1,170 @@
+"""Shared types and helpers for :mod:`prompture.eval`.
+
+* :class:`EvalDriver` — the minimal LLM-driver protocol every evaluator
+  in this package accepts. Any object exposing
+  ``generate(prompt, options) -> {"text": str, ...}`` qualifies, which
+  matches every sync :class:`prompture.drivers.base.Driver` plus any
+  user-supplied stub.
+* Result dataclasses (one per evaluator) — frozen, hashable-friendly,
+  with a ``to_dict()`` for report serialisation.
+* :class:`EvalError` — single error type the package raises for any
+  irrecoverable evaluation failure (so callers can ``except`` it
+  without catching every underlying SDK error).
+
+Evaluators that score things use Pydantic models to coerce the LLM
+output into a structured shape via
+:func:`prompture.extract_with_model` — the same mechanism the rest of
+Prompture uses. That gives us free retry, validation, schema
+tightening (Phase 5), and cache support.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Protocol
+
+
+class EvalError(RuntimeError):
+    """Raised when an evaluator can't produce a usable result.
+
+    Examples: the rubric is empty, the LLM consistently returns
+    unparseable text after retries, a pairwise judge call fails
+    twice in a row.
+    """
+
+
+class EvalDriver(Protocol):
+    """Minimal LLM-driver contract used by every evaluator."""
+
+    def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:  # pragma: no cover - protocol
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class JudgeResult:
+    """Structured outcome from :meth:`LLMJudge.evaluate`.
+
+    Attributes:
+        score: Overall score on the rubric's 1..``scale`` integer range.
+        reasoning: One-paragraph justification the LLM produced.
+        per_criterion: ``{criterion_name: integer_score}`` — one entry
+            per :class:`LLMJudge` criterion. Absent when the rubric had
+            no named criteria.
+        passed: ``True`` when ``score >= pass_threshold`` (or ``None``
+            when no threshold was supplied).
+        meta: Token + cost metadata from the underlying LLM call.
+    """
+
+    score: int
+    reasoning: str
+    per_criterion: dict[str, int] = field(default_factory=dict)
+    passed: bool | None = None
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class PairwiseResult:
+    """Outcome of comparing two candidates.
+
+    Attributes:
+        winner: ``"A"``, ``"B"``, or ``"tie"``. ``"tie"`` is emitted
+            when the two judge passes disagree on the winner with no
+            confidence margin.
+        confidence: Fraction of judge passes that picked ``winner``
+            (0.0 – 1.0). With ``swap_positions=True`` the denominator
+            is 2; otherwise 1.
+        votes: Per-position votes, e.g. ``{"A_first": "A", "B_first": "B"}``.
+        reasoning: Aggregated free-text reasoning from each pass.
+        meta: Combined token + cost metadata across all judge calls.
+    """
+
+    winner: str
+    confidence: float
+    votes: dict[str, str] = field(default_factory=dict)
+    reasoning: dict[str, str] = field(default_factory=dict)
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class SelfConsistencyResult:
+    """Outcome of N independent samples + majority vote.
+
+    Attributes:
+        consensus: Most-common normalised answer (string). ``None``
+            when no samples produced a usable answer.
+        agreement: Fraction of samples that matched ``consensus``
+            (0.0 – 1.0). High values (>= 0.8) suggest low hallucination
+            risk; low values flag uncertainty.
+        samples: The N normalised answers in collection order so
+            callers can compute their own statistics.
+        counts: ``{answer: count}`` distribution.
+        meta: Combined token + cost metadata across all sample calls.
+    """
+
+    consensus: str | None
+    agreement: float
+    samples: list[str] = field(default_factory=list)
+    counts: dict[str, int] = field(default_factory=dict)
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class FaithfulnessResult:
+    """Outcome of RAG faithfulness checking.
+
+    Attributes:
+        score: Fraction of claims supported by the evidence
+            (0.0 – 1.0). 1.0 means every claim was grounded; 0.0
+            means none were.
+        supported: List of supported claim strings.
+        unsupported: List of unsupported claim strings — the
+            primary thing to inspect when the score is low.
+        contradicted: List of claims the evidence actively contradicts
+            (a subset of unsupported, surfaced separately so callers
+            can distinguish "no evidence" from "evidence says no").
+        meta: Combined token + cost metadata.
+    """
+
+    score: float
+    supported: list[str] = field(default_factory=list)
+    unsupported: list[str] = field(default_factory=list)
+    contradicted: list[str] = field(default_factory=list)
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _accumulate_meta(target: dict[str, Any], chunk: dict[str, Any] | None) -> None:
+    """In-place sum of token / cost / count fields from a per-call ``meta``.
+
+    Used by every evaluator to roll up costs across multiple LLM
+    calls into the result's ``meta`` field.
+    """
+    if not chunk:
+        return
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        if isinstance(chunk.get(key), (int, float)):
+            target[key] = target.get(key, 0) + int(chunk[key])
+    if isinstance(chunk.get("cost"), (int, float)):
+        target["cost"] = float(target.get("cost", 0.0)) + float(chunk["cost"])
+    target["calls"] = target.get("calls", 0) + 1

--- a/prompture/eval/faithfulness.py
+++ b/prompture/eval/faithfulness.py
@@ -183,10 +183,14 @@ class FaithfulnessEvaluator:
         self.driver = driver
         self.decomposition_prompt = decomposition_prompt
         self.verification_prompt = verification_prompt
-        self.llm_options = llm_options if llm_options is not None else {
-            "temperature": 0.0,
-            "max_tokens": 512,
-        }
+        self.llm_options = (
+            llm_options
+            if llm_options is not None
+            else {
+                "temperature": 0.0,
+                "max_tokens": 512,
+            }
+        )
         self.treat_silent_as = treat_silent_as
 
     # ------------------------------------------------------------------

--- a/prompture/eval/faithfulness.py
+++ b/prompture/eval/faithfulness.py
@@ -1,0 +1,277 @@
+"""RAG-answer faithfulness evaluator.
+
+Given a generated RAG answer plus the retrieved evidence chunks,
+this evaluator measures how well the answer is grounded in the
+evidence. The pipeline is two LLM calls per evaluation:
+
+1. **Decomposition** — break the answer into atomic claims (one
+   verifiable fact per claim).
+2. **Verification** — for each claim, ask the judge whether the
+   evidence ``supports``, ``contradicts``, or is ``silent`` on it.
+
+Score = ``supported / total_claims``. A score of 1.0 means every
+claim was directly supported; a low score plus a non-empty
+``contradicted`` list flags the most dangerous failure mode
+(hallucinated facts that the evidence explicitly refutes).
+
+Both prompts are short and use a forced-choice JSON shape so the
+parsing is robust to weaker judges.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from .base import EvalDriver, EvalError, FaithfulnessResult, _accumulate_meta
+
+#: Default decomposition prompt. ``{answer}`` is substituted.
+DEFAULT_DECOMPOSITION_PROMPT = """Break the ANSWER below into a list of atomic claims. Each claim must:
+- contain exactly one verifiable fact
+- stand on its own (no pronouns referring outside the claim)
+- be written in the same tense and voice as the answer
+
+ANSWER:
+{answer}
+
+Output a JSON array of strings, one claim per element, with no other text:
+["claim 1", "claim 2", ...]
+"""
+
+
+#: Default verification prompt. ``{claim}`` and ``{evidence}`` are
+#: substituted per claim.
+DEFAULT_VERIFICATION_PROMPT = """You are checking whether a claim is grounded in retrieved evidence.
+
+EVIDENCE:
+{evidence}
+
+CLAIM:
+{claim}
+
+Respond with exactly one of these three labels — nothing else, no punctuation:
+SUPPORTED   (the evidence directly states or strongly implies the claim)
+CONTRADICTED   (the evidence states the opposite)
+SILENT   (the evidence neither supports nor contradicts the claim)
+"""
+
+
+_VERDICT_RE = re.compile(r"\b(SUPPORTED|CONTRADICTED|SILENT)\b", re.IGNORECASE)
+
+
+def _parse_claims(text: str) -> list[str]:
+    """Pull a list of claim strings out of the decomposition response.
+
+    Accepts:
+    - a JSON array (the documented happy path)
+    - bullet/numbered lists when the model ignored the JSON instruction
+    """
+    text = (text or "").strip()
+    if not text:
+        return []
+
+    # JSON happy path.
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+
+    if isinstance(parsed, list):
+        return [str(c).strip() for c in parsed if isinstance(c, (str, int, float)) and str(c).strip()]
+
+    # Fenced JSON.
+    fence = re.search(r"```(?:json)?\s*(\[.*?\])\s*```", text, flags=re.DOTALL)
+    if fence:
+        try:
+            parsed = json.loads(fence.group(1))
+            if isinstance(parsed, list):
+                return [str(c).strip() for c in parsed if isinstance(c, (str, int, float)) and str(c).strip()]
+        except json.JSONDecodeError:
+            pass
+
+    # Embedded JSON array.
+    start = text.find("[")
+    end = text.rfind("]")
+    if 0 <= start < end:
+        try:
+            parsed = json.loads(text[start : end + 1])
+            if isinstance(parsed, list):
+                return [str(c).strip() for c in parsed if isinstance(c, (str, int, float)) and str(c).strip()]
+        except json.JSONDecodeError:
+            pass
+
+    # Bullet / numbered list fallback.
+    lines = []
+    for line in text.splitlines():
+        stripped = re.sub(r"^\s*(?:\d+[.)]|[-*])\s+", "", line.strip())
+        stripped = stripped.strip(" \"'")
+        if stripped:
+            lines.append(stripped)
+    return lines
+
+
+def _parse_verdict(text: str) -> str | None:
+    """Extract the verdict label from the verification response."""
+    m = _VERDICT_RE.search(text or "")
+    if not m:
+        return None
+    return m.group(1).upper()
+
+
+def _format_evidence(evidence: list[str]) -> str:
+    """Format the evidence list as numbered passages for the judge."""
+    if not evidence:
+        return "(no evidence provided)"
+    return "\n\n".join(f"[{i + 1}] {chunk.strip()}" for i, chunk in enumerate(evidence) if chunk.strip())
+
+
+class FaithfulnessEvaluator:
+    """Measure how well a RAG answer is grounded in retrieved evidence.
+
+    Args:
+        driver: LLM driver used for both decomposition and per-claim
+            verification.
+        decomposition_prompt: Template overriding
+            :data:`DEFAULT_DECOMPOSITION_PROMPT`. Must include
+            ``{answer}``.
+        verification_prompt: Template overriding
+            :data:`DEFAULT_VERIFICATION_PROMPT`. Must include ``{claim}``
+            and ``{evidence}``.
+        llm_options: Forwarded to ``driver.generate``. Defaults to
+            ``{"temperature": 0.0, "max_tokens": 512}``.
+        treat_silent_as: How to score ``SILENT`` verdicts. ``"unsupported"``
+            (default) — silent claims count against the score; this is
+            the conservative choice and matches RAGAS faithfulness.
+            ``"neutral"`` — silent claims are excluded from the
+            denominator entirely.
+
+    Example::
+
+        evaluator = FaithfulnessEvaluator(driver=my_driver)
+        result = evaluator.evaluate(
+            answer="Paris is the capital of France and home to the Eiffel Tower.",
+            evidence=[
+                "Paris is the capital city of France.",
+                "Lyon is France's third-largest city.",
+            ],
+        )
+        # FaithfulnessResult(
+        #   score=0.5,
+        #   supported=["Paris is the capital of France."],
+        #   unsupported=["Paris is home to the Eiffel Tower."],
+        #   contradicted=[],
+        # )
+    """
+
+    def __init__(
+        self,
+        driver: EvalDriver,
+        *,
+        decomposition_prompt: str = DEFAULT_DECOMPOSITION_PROMPT,
+        verification_prompt: str = DEFAULT_VERIFICATION_PROMPT,
+        llm_options: dict[str, Any] | None = None,
+        treat_silent_as: str = "unsupported",
+    ) -> None:
+        if "{answer}" not in decomposition_prompt:
+            raise EvalError("decomposition_prompt must include {answer}.")
+        for ph in ("{claim}", "{evidence}"):
+            if ph not in verification_prompt:
+                raise EvalError(f"verification_prompt must include {ph}.")
+        if treat_silent_as not in {"unsupported", "neutral"}:
+            raise EvalError(f"treat_silent_as must be 'unsupported' or 'neutral'; got {treat_silent_as!r}.")
+        self.driver = driver
+        self.decomposition_prompt = decomposition_prompt
+        self.verification_prompt = verification_prompt
+        self.llm_options = llm_options if llm_options is not None else {
+            "temperature": 0.0,
+            "max_tokens": 512,
+        }
+        self.treat_silent_as = treat_silent_as
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def evaluate(self, answer: str, evidence: list[str]) -> FaithfulnessResult:
+        """Score ``answer`` against ``evidence``.
+
+        Decomposes the answer into atomic claims, verifies each
+        against the evidence, and returns a :class:`FaithfulnessResult`
+        with the supported / unsupported / contradicted partitions
+        and the rolled-up score.
+
+        Raises:
+            EvalError: When the decomposition step produces zero
+                usable claims (e.g. the LLM returned junk).
+        """
+        meta: dict[str, Any] = {}
+        claims = self._decompose(answer, meta=meta)
+        if not claims:
+            raise EvalError("Decomposition produced no claims; cannot score faithfulness.")
+
+        evidence_text = _format_evidence(evidence)
+
+        supported: list[str] = []
+        unsupported: list[str] = []
+        contradicted: list[str] = []
+        silent: list[str] = []
+
+        for claim in claims:
+            verdict = self._verify(claim, evidence_text, meta=meta)
+            if verdict == "SUPPORTED":
+                supported.append(claim)
+            elif verdict == "CONTRADICTED":
+                contradicted.append(claim)
+                unsupported.append(claim)
+            else:
+                # SILENT or unparseable
+                silent.append(claim)
+                if self.treat_silent_as == "unsupported":
+                    unsupported.append(claim)
+
+        # Score denominator depends on treat_silent_as.
+        if self.treat_silent_as == "neutral":
+            denominator = len(supported) + len(unsupported)
+        else:
+            denominator = len(claims)
+        score = (len(supported) / denominator) if denominator else 0.0
+
+        return FaithfulnessResult(
+            score=score,
+            supported=supported,
+            unsupported=unsupported,
+            contradicted=contradicted,
+            meta=meta,
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _decompose(self, answer: str, *, meta: dict[str, Any]) -> list[str]:
+        rendered = self.decomposition_prompt.format(answer=answer)
+        try:
+            response = self.driver.generate(rendered, dict(self.llm_options))
+        except Exception as exc:
+            raise EvalError(f"Decomposition driver call failed: {exc}") from exc
+        if isinstance(response, dict):
+            _accumulate_meta(meta, response.get("meta"))
+            text = response.get("text") or ""
+        else:
+            text = str(response or "")
+        return _parse_claims(text)
+
+    def _verify(self, claim: str, evidence_text: str, *, meta: dict[str, Any]) -> str:
+        rendered = self.verification_prompt.format(claim=claim, evidence=evidence_text)
+        try:
+            response = self.driver.generate(rendered, dict(self.llm_options))
+        except Exception as exc:
+            raise EvalError(f"Verification driver call failed: {exc}") from exc
+        if isinstance(response, dict):
+            _accumulate_meta(meta, response.get("meta"))
+            text = response.get("text") or ""
+        else:
+            text = str(response or "")
+        verdict = _parse_verdict(text)
+        return verdict or "SILENT"

--- a/prompture/eval/judge.py
+++ b/prompture/eval/judge.py
@@ -156,7 +156,14 @@ class LLMJudge:
             raise EvalError("LLMJudge requires at least one criterion.")
         if scale < 2:
             raise EvalError(f"scale must be >= 2; got {scale}.")
-        required_placeholders = ("{input}", "{output}", "{reference}", "{criteria_block}", "{scale}", "{response_shape}")
+        required_placeholders = (
+            "{input}",
+            "{output}",
+            "{reference}",
+            "{criteria_block}",
+            "{scale}",
+            "{response_shape}",
+        )
         for placeholder in required_placeholders:
             if placeholder not in prompt:
                 raise EvalError(f"Prompt template is missing required placeholder {placeholder}.")
@@ -166,10 +173,14 @@ class LLMJudge:
         self.scale = scale
         self.pass_threshold = pass_threshold
         self.prompt = prompt
-        self.llm_options = llm_options if llm_options is not None else {
-            "temperature": 0.0,
-            "max_tokens": 400,
-        }
+        self.llm_options = (
+            llm_options
+            if llm_options is not None
+            else {
+                "temperature": 0.0,
+                "max_tokens": 400,
+            }
+        )
         self._criterion_keys = _criterion_keys(self.criteria)
         self._criteria_block = _criteria_block(self.criteria)
         self._response_shape = _response_shape(self.criteria, self.scale)
@@ -231,10 +242,7 @@ class LLMJudge:
             _accumulate_meta(meta, response.get("meta"))
 
         if score is None:
-            raise EvalError(
-                f"Judge response did not include a usable 'score' field. "
-                f"Got: {text[:160]!r}"
-            )
+            raise EvalError(f"Judge response did not include a usable 'score' field. Got: {text[:160]!r}")
 
         return JudgeResult(
             score=score,

--- a/prompture/eval/judge.py
+++ b/prompture/eval/judge.py
@@ -1,0 +1,351 @@
+"""Single-output rubric-based LLM judge.
+
+``LLMJudge`` asks a strong LLM to score one candidate output against
+a rubric of criteria, on a 1..N integer scale, with a free-text
+justification. The prompt is short, deterministic (``temperature=0``
+by default), and parses cleanly into a Pydantic model so callers
+never have to massage free text.
+
+This is the workhorse of the eval package — it underpins prompt-A/B
+testing, regression detection, and any "did the output get worse?"
+loop. Use :class:`PairwiseJudge` instead when the question is "which
+of these two is better" rather than "how good is this one".
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from .._internal.json_encoder import PromptureJSONEncoder
+from .base import EvalDriver, EvalError, JudgeResult, _accumulate_meta
+
+#: Default rubric prompt. ``{input}``, ``{output}``, ``{reference}``,
+#: ``{criteria_block}``, and ``{scale}`` are substituted. ``{reference}``
+#: is replaced with an empty string when no reference was supplied —
+#: that's why the template wraps it in a labelled section that gracefully
+#: degenerates when empty.
+DEFAULT_RUBRIC_PROMPT = """You are an impartial evaluator scoring an LLM output.
+
+Score the OUTPUT on every criterion below using an integer from 1 to {scale}, where 1 is the worst and {scale} is the best. Then assign an overall integer score on the same 1..{scale} range. Finally, write a one-paragraph justification (2-4 sentences).
+
+CRITERIA:
+{criteria_block}
+
+INPUT:
+{input}
+
+OUTPUT TO EVALUATE:
+{output}
+{reference}
+
+Respond with a single JSON object that matches this exact shape (no markdown, no preamble):
+{response_shape}
+
+Use double quotes for every string. Per-criterion scores must use the criterion name verbatim as the key.
+"""
+
+
+#: Substituted into the prompt only when a reference is supplied.
+_REFERENCE_BLOCK_TEMPLATE = "\nREFERENCE ANSWER (for comparison, not strict equality):\n{reference}\n"
+
+
+def _criteria_block(criteria: list[str]) -> str:
+    """Render a list of criteria as a bulleted block.
+
+    Single-line criteria become ``- name``. A criterion that contains
+    a colon is split into ``name: description`` so authors can attach
+    rubric details inline (e.g. ``"factuality: claims must match the
+    reference"``).
+    """
+    lines: list[str] = []
+    for c in criteria:
+        c = c.strip()
+        if not c:
+            continue
+        if ":" in c:
+            name, desc = c.split(":", 1)
+            lines.append(f"- {name.strip()}: {desc.strip()}")
+        else:
+            lines.append(f"- {c}")
+    return "\n".join(lines) if lines else "- overall quality"
+
+
+def _criterion_keys(criteria: list[str]) -> list[str]:
+    """Pull out just the canonical criterion names (text before ``:``)."""
+    keys: list[str] = []
+    for c in criteria:
+        c = c.strip()
+        if not c:
+            continue
+        keys.append(c.split(":", 1)[0].strip())
+    return keys
+
+
+def _response_shape(criteria: list[str], scale: int) -> str:
+    """Build the JSON shape hint we embed in the prompt itself.
+
+    Inlining the expected shape (rather than relying solely on
+    ``json_mode``) helps weaker models produce parseable output even
+    when the driver doesn't support strict JSON mode.
+    """
+    keys = _criterion_keys(criteria) or ["overall_quality"]
+    per_criterion: dict[str, str] = {k: f"<1..{scale} integer>" for k in keys}
+    shape = {
+        "score": f"<1..{scale} integer>",
+        "per_criterion": per_criterion,
+        "reasoning": "<one paragraph string>",
+    }
+    return json.dumps(shape, indent=2, cls=PromptureJSONEncoder)
+
+
+class LLMJudge:
+    """Rubric-based single-output judge.
+
+    Args:
+        driver: Any sync LLM driver matching :class:`EvalDriver`. The
+            best results come from a capable model (``gpt-4o``,
+            ``claude-sonnet-4-6``, etc.) — judge calls are a small
+            fraction of total cost in most evaluation runs.
+        criteria: List of named criteria the judge scores. Each entry
+            may be ``"name"`` or ``"name: description"``. Defaults to
+            ``["overall_quality"]``.
+        scale: Maximum integer score (inclusive). The minimum is
+            always 1. Defaults to 5.
+        pass_threshold: When set, every :class:`JudgeResult` carries a
+            boolean ``passed`` field == ``score >= pass_threshold``.
+        prompt: Template overriding :data:`DEFAULT_RUBRIC_PROMPT`. Must
+            include ``{input}``, ``{output}``, ``{reference}``,
+            ``{criteria_block}``, ``{scale}``, and ``{response_shape}``.
+        llm_options: Options forwarded to ``driver.generate``. Defaults
+            to ``{"temperature": 0.0, "max_tokens": 400}``.
+
+    Example::
+
+        from prompture.eval import LLMJudge
+
+        judge = LLMJudge(
+            driver=my_driver,
+            criteria=["factuality: claims must match the reference",
+                      "clarity",
+                      "brevity"],
+            scale=10,
+            pass_threshold=7,
+        )
+        result = judge.evaluate(
+            input_text="What is the capital of France?",
+            output="Paris is the capital of France.",
+            reference="Paris",
+        )
+        print(result.score, result.per_criterion, result.passed)
+    """
+
+    def __init__(
+        self,
+        driver: EvalDriver,
+        *,
+        criteria: list[str] | None = None,
+        scale: int = 5,
+        pass_threshold: int | None = None,
+        prompt: str = DEFAULT_RUBRIC_PROMPT,
+        llm_options: dict[str, Any] | None = None,
+    ) -> None:
+        criteria_list = list(criteria) if criteria is not None else ["overall_quality"]
+        if not criteria_list:
+            raise EvalError("LLMJudge requires at least one criterion.")
+        if scale < 2:
+            raise EvalError(f"scale must be >= 2; got {scale}.")
+        required_placeholders = ("{input}", "{output}", "{reference}", "{criteria_block}", "{scale}", "{response_shape}")
+        for placeholder in required_placeholders:
+            if placeholder not in prompt:
+                raise EvalError(f"Prompt template is missing required placeholder {placeholder}.")
+
+        self.driver = driver
+        self.criteria = criteria_list
+        self.scale = scale
+        self.pass_threshold = pass_threshold
+        self.prompt = prompt
+        self.llm_options = llm_options if llm_options is not None else {
+            "temperature": 0.0,
+            "max_tokens": 400,
+        }
+        self._criterion_keys = _criterion_keys(self.criteria)
+        self._criteria_block = _criteria_block(self.criteria)
+        self._response_shape = _response_shape(self.criteria, self.scale)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def evaluate(
+        self,
+        input_text: str,
+        output: str,
+        reference: str | None = None,
+    ) -> JudgeResult:
+        """Score one ``output`` against the rubric.
+
+        ``reference`` is optional — when supplied it's shown to the
+        judge with a "for comparison, not strict equality" hint so
+        the judge can detect factuality issues without penalising
+        cosmetic differences.
+
+        Raises:
+            EvalError: When the LLM call fails or the response can't
+                be parsed into the expected shape even after the
+                downstream extraction's own retry.
+        """
+        rendered = self._render_prompt(input_text, output, reference)
+        try:
+            response = self.driver.generate(rendered, dict(self.llm_options))
+        except Exception as exc:
+            raise EvalError(f"Judge driver call failed: {exc}") from exc
+
+        text = (response.get("text") if isinstance(response, dict) else "") or ""
+        parsed = self._parse_judge_response(text)
+
+        score = self._clamp_score(parsed.get("score"))
+        reasoning = str(parsed.get("reasoning") or "").strip()
+        raw_per = parsed.get("per_criterion") or {}
+        per_criterion: dict[str, int] = {}
+        if isinstance(raw_per, dict):
+            for key in self._criterion_keys:
+                val = raw_per.get(key)
+                if val is None:
+                    # Some models lowercase / normalise keys — try case-insensitive.
+                    val = next(
+                        (raw_per[k] for k in raw_per if isinstance(k, str) and k.lower() == key.lower()),
+                        None,
+                    )
+                clamped = self._clamp_score(val)
+                if clamped is not None:
+                    per_criterion[key] = clamped
+
+        passed: bool | None = None
+        if self.pass_threshold is not None and score is not None:
+            passed = score >= self.pass_threshold
+
+        meta: dict[str, Any] = {}
+        if isinstance(response, dict):
+            _accumulate_meta(meta, response.get("meta"))
+
+        if score is None:
+            raise EvalError(
+                f"Judge response did not include a usable 'score' field. "
+                f"Got: {text[:160]!r}"
+            )
+
+        return JudgeResult(
+            score=score,
+            reasoning=reasoning,
+            per_criterion=per_criterion,
+            passed=passed,
+            meta=meta,
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _render_prompt(self, input_text: str, output: str, reference: str | None) -> str:
+        reference_block = _REFERENCE_BLOCK_TEMPLATE.format(reference=reference) if reference else ""
+        return self.prompt.format(
+            input=input_text,
+            output=output,
+            reference=reference_block,
+            criteria_block=self._criteria_block,
+            scale=self.scale,
+            response_shape=self._response_shape,
+        )
+
+    def _clamp_score(self, value: Any) -> int | None:
+        """Coerce ``value`` to an int in ``[1, self.scale]``.
+
+        Accepts ints, floats, strings like ``"4"`` or ``"4/5"``.
+        Returns ``None`` when ``value`` can't be coerced.
+        """
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return None  # avoid the int(True)=1 trap
+        if isinstance(value, (int, float)):
+            ival = int(value)
+            return max(1, min(self.scale, ival))
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return None
+            # Handle "4/5" style — take the numerator.
+            num_match = re.match(r"^-?\d+", stripped)
+            if num_match:
+                try:
+                    return max(1, min(self.scale, int(num_match.group())))
+                except ValueError:
+                    return None
+        return None
+
+    def _parse_judge_response(self, text: str) -> dict[str, Any]:
+        """Pull a JSON object out of the judge's response text.
+
+        Handles three common shapes:
+
+        * raw JSON: ``{"score": 4, ...}``
+        * fenced JSON: ``\\`\\`\\`json\\n{...}\\n\\`\\`\\```
+        * JSON embedded in prose: we extract the first ``{...}`` span.
+        """
+        text = text.strip()
+        if not text:
+            return {}
+
+        # Fast path: whole response is JSON.
+        try:
+            parsed = json.loads(text)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+
+        # Strip ```json fences if present.
+        fence_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, flags=re.DOTALL)
+        if fence_match:
+            try:
+                parsed = json.loads(fence_match.group(1))
+                if isinstance(parsed, dict):
+                    return parsed
+            except json.JSONDecodeError:
+                pass
+
+        # Last resort: extract the first balanced ``{...}`` substring.
+        start = text.find("{")
+        if start == -1:
+            return {}
+        depth = 0
+        in_string = False
+        escape = False
+        for i in range(start, len(text)):
+            ch = text[i]
+            if escape:
+                escape = False
+                continue
+            if ch == "\\":
+                escape = True
+                continue
+            if ch == '"':
+                in_string = not in_string
+                continue
+            if in_string:
+                continue
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    candidate = text[start : i + 1]
+                    try:
+                        parsed = json.loads(candidate)
+                        if isinstance(parsed, dict):
+                            return parsed
+                    except json.JSONDecodeError:
+                        return {}
+        return {}

--- a/prompture/eval/pairwise.py
+++ b/prompture/eval/pairwise.py
@@ -1,0 +1,241 @@
+"""Pairwise A/B preference judge with position-bias correction.
+
+LLM judges have a well-documented positional bias — given two candidates,
+they're more likely to pick the first one regardless of quality. The
+fix is to ask twice with the candidates swapped and combine the votes:
+
+* both passes agree → that's the winner with confidence 1.0
+* passes disagree → the LLM is genuinely uncertain → ``"tie"``,
+  confidence 0.5
+* with ``swap_positions=False`` (cheaper, less accurate) we trust a
+  single pass and report confidence 1.0
+
+Use this when the question is "which of these two is better"; use
+:class:`LLMJudge` for "how good is this one".
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from .base import EvalDriver, EvalError, PairwiseResult, _accumulate_meta
+
+#: Default pairwise prompt. ``{input}``, ``{a}``, ``{b}`` are
+#: substituted. The instruction explicitly forbids "tie" because at
+#: the per-pass level we want a forced choice; the wrapper aggregates
+#: disagreement into "tie" itself.
+DEFAULT_PAIRWISE_PROMPT = """You are choosing the better of two LLM responses to the same input.
+
+INPUT:
+{input}
+
+RESPONSE A:
+{a}
+
+RESPONSE B:
+{b}
+
+Pick exactly one — A or B — that better answers the input. You must choose; saying both are equal is not allowed. Briefly justify your choice in 1-2 sentences.
+
+Respond on two lines, no markdown:
+CHOICE: A
+REASON: <one or two sentences>
+"""
+
+_CHOICE_RE = re.compile(r"\bCHOICE\s*[:=]\s*([AB])\b", re.IGNORECASE)
+
+
+def _parse_choice(text: str) -> tuple[str | None, str]:
+    """Extract ``("A" | "B" | None, reason)`` from a judge response.
+
+    Tolerant about formatting — accepts ``CHOICE: A``, ``Choice = B``,
+    ``a`` / ``b`` standalone, or the word ``Response A`` / ``Response B``
+    if no ``CHOICE`` line is present.
+    """
+    text = (text or "").strip()
+    if not text:
+        return None, ""
+
+    m = _CHOICE_RE.search(text)
+    if m:
+        choice = m.group(1).upper()
+        reason_match = re.search(r"\bREASON\s*[:=]\s*(.+)", text, flags=re.IGNORECASE | re.DOTALL)
+        reason = reason_match.group(1).strip() if reason_match else ""
+        return choice, reason
+
+    # Fall back: look for "Response A" / "Response B" first occurrence.
+    fallback = re.search(r"\bRESPONSE\s+([AB])\b", text, flags=re.IGNORECASE)
+    if fallback:
+        return fallback.group(1).upper(), text
+
+    # Last resort: a single isolated A / B character on the first line.
+    first_line = text.splitlines()[0].strip()
+    if first_line.upper() in {"A", "B"}:
+        return first_line.upper(), "\n".join(text.splitlines()[1:]).strip()
+
+    return None, text
+
+
+class PairwiseJudge:
+    """A/B preference judge with optional position-bias correction.
+
+    Args:
+        driver: LLM driver matching :class:`EvalDriver`.
+        swap_positions: When True (default), runs two judge passes per
+            ``compare`` call — once with (A, B) and once with (B, A) —
+            and combines votes to neutralise position bias. When False,
+            only one pass is run (half the cost, less accurate).
+        prompt: Template overriding :data:`DEFAULT_PAIRWISE_PROMPT`.
+            Must contain ``{input}``, ``{a}``, ``{b}``.
+        llm_options: Forwarded to ``driver.generate``. Defaults to
+            ``{"temperature": 0.0, "max_tokens": 200}``.
+
+    Example::
+
+        judge = PairwiseJudge(driver=my_driver)
+        result = judge.compare(
+            input_text="Summarise quantum entanglement in one sentence.",
+            output_a="Two particles share a state.",
+            output_b="When two particles become entangled, ...",
+        )
+        # PairwiseResult(winner='B', confidence=1.0, votes={...})
+    """
+
+    def __init__(
+        self,
+        driver: EvalDriver,
+        *,
+        swap_positions: bool = True,
+        prompt: str = DEFAULT_PAIRWISE_PROMPT,
+        llm_options: dict[str, Any] | None = None,
+    ) -> None:
+        for placeholder in ("{input}", "{a}", "{b}"):
+            if placeholder not in prompt:
+                raise EvalError(f"Pairwise prompt is missing required placeholder {placeholder}.")
+        self.driver = driver
+        self.swap_positions = swap_positions
+        self.prompt = prompt
+        self.llm_options = llm_options if llm_options is not None else {
+            "temperature": 0.0,
+            "max_tokens": 200,
+        }
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def compare(
+        self,
+        input_text: str,
+        output_a: str,
+        output_b: str,
+    ) -> PairwiseResult:
+        """Decide which of ``output_a`` / ``output_b`` is better.
+
+        When ``swap_positions=True`` (default), runs the judge twice
+        with the candidates in opposite orders so positional bias
+        cancels. The aggregated result is ``"A"`` or ``"B"`` when both
+        passes agree, ``"tie"`` otherwise.
+        """
+        votes: dict[str, str] = {}
+        reasoning: dict[str, str] = {}
+        meta: dict[str, Any] = {}
+
+        # First pass: A presented first.
+        choice_ab, reason_ab = self._judge_once(input_text, output_a, output_b, meta=meta)
+        if choice_ab is not None:
+            votes["A_first"] = choice_ab
+            reasoning["A_first"] = reason_ab
+
+        if not self.swap_positions:
+            return self._build_result_single(votes, reasoning, meta)
+
+        # Second pass: B presented first; remap "A"->B, "B"->A so the
+        # ``winner`` field always refers to the originals.
+        choice_ba_raw, reason_ba = self._judge_once(input_text, output_b, output_a, meta=meta)
+        if choice_ba_raw is not None:
+            remapped = {"A": "B", "B": "A"}.get(choice_ba_raw, choice_ba_raw)
+            votes["B_first"] = remapped
+            reasoning["B_first"] = reason_ba
+
+        return self._build_result_swapped(votes, reasoning, meta)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _judge_once(
+        self,
+        input_text: str,
+        a_content: str,
+        b_content: str,
+        *,
+        meta: dict[str, Any],
+    ) -> tuple[str | None, str]:
+        rendered = self.prompt.format(input=input_text, a=a_content, b=b_content)
+        try:
+            response = self.driver.generate(rendered, dict(self.llm_options))
+        except Exception as exc:
+            raise EvalError(f"Pairwise driver call failed: {exc}") from exc
+        if isinstance(response, dict):
+            _accumulate_meta(meta, response.get("meta"))
+            text = response.get("text") or ""
+        else:
+            text = str(response or "")
+        return _parse_choice(text)
+
+    def _build_result_single(
+        self,
+        votes: dict[str, str],
+        reasoning: dict[str, str],
+        meta: dict[str, Any],
+    ) -> PairwiseResult:
+        if not votes:
+            raise EvalError("Pairwise judge produced no parseable choice.")
+        winner = next(iter(votes.values()))
+        return PairwiseResult(
+            winner=winner,
+            confidence=1.0,
+            votes=votes,
+            reasoning=reasoning,
+            meta=meta,
+        )
+
+    def _build_result_swapped(
+        self,
+        votes: dict[str, str],
+        reasoning: dict[str, str],
+        meta: dict[str, Any],
+    ) -> PairwiseResult:
+        # Tally the two votes (each one already remapped to the original-position frame).
+        if not votes:
+            raise EvalError("Pairwise judge produced no parseable choices on either pass.")
+
+        counts: dict[str, int] = {"A": 0, "B": 0}
+        for choice in votes.values():
+            if choice in counts:
+                counts[choice] += 1
+
+        a, b = counts["A"], counts["B"]
+        total = a + b
+        if total == 0:
+            raise EvalError("Pairwise judge returned only invalid choices.")
+
+        if a > b:
+            winner = "A"
+            confidence = a / total
+        elif b > a:
+            winner = "B"
+            confidence = b / total
+        else:
+            winner = "tie"
+            confidence = 0.5
+
+        return PairwiseResult(
+            winner=winner,
+            confidence=confidence,
+            votes=votes,
+            reasoning=reasoning,
+            meta=meta,
+        )

--- a/prompture/eval/pairwise.py
+++ b/prompture/eval/pairwise.py
@@ -116,10 +116,14 @@ class PairwiseJudge:
         self.driver = driver
         self.swap_positions = swap_positions
         self.prompt = prompt
-        self.llm_options = llm_options if llm_options is not None else {
-            "temperature": 0.0,
-            "max_tokens": 200,
-        }
+        self.llm_options = (
+            llm_options
+            if llm_options is not None
+            else {
+                "temperature": 0.0,
+                "max_tokens": 200,
+            }
+        )
 
     # ------------------------------------------------------------------
     # Public API

--- a/prompture/eval/self_consistency.py
+++ b/prompture/eval/self_consistency.py
@@ -1,0 +1,181 @@
+"""N-sample self-consistency evaluator.
+
+Sample the same prompt ``n`` times at non-zero temperature and report:
+
+* the **consensus** — the most-common normalised answer
+* an **agreement ratio** — fraction of samples that match the consensus
+* the full sample list + count distribution
+
+Low agreement is a strong hallucination signal: the model is rolling
+the dice rather than reading off a stable belief. Useful for any
+extraction or short-form-answer task where you'd like a confidence
+score alongside the answer.
+
+Two modes:
+
+* **Free-form** (default): pass an LLM driver. Each sample is one
+  ``driver.generate`` call. Useful for short-answer questions.
+* **Wrapped**: supply a callable ``sampler() -> str`` and the
+  evaluator just runs your callable N times. Useful when each sample
+  involves multiple LLM calls (e.g. a chain) and you want the
+  outer-most answer compared.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from collections.abc import Callable
+from typing import Any
+
+from .base import EvalDriver, EvalError, SelfConsistencyResult, _accumulate_meta
+
+
+def _default_normalize(text: str) -> str:
+    """Cheap default normaliser: lowercased, whitespace-collapsed, trimmed.
+
+    Removes trailing punctuation so ``"42."`` and ``"42"`` collapse
+    to the same bucket. Keeps internal numeric tokens intact.
+    """
+    s = (text or "").strip().lower()
+    s = re.sub(r"\s+", " ", s)
+    s = s.rstrip(" .!?,;:'\"")
+    return s
+
+
+class SelfConsistencyEvaluator:
+    """Sample N times, return majority vote + agreement.
+
+    Args:
+        driver: LLM driver to sample from. Ignored when ``sampler`` is
+            supplied. One of ``driver`` or ``sampler`` must be set.
+        n_samples: How many times to sample. Defaults to 5. Higher
+            gives a tighter agreement estimate but scales linearly in
+            cost. Use a temperature > 0 in ``llm_options`` so samples
+            actually differ.
+        temperature: Override ``llm_options['temperature']`` when set.
+            Defaults to 0.7, which is high enough to surface real
+            uncertainty without going off the rails. Ignored when a
+            custom ``sampler`` is given.
+        normalize: Function ``str -> str`` that collapses sample text
+            into the bucket key used for the vote. Defaults to
+            :func:`_default_normalize`. Pass ``lambda s: s.strip()`` to
+            keep exact-match comparison.
+        llm_options: Forwarded to ``driver.generate`` per sample.
+        sampler: Callable producing one sample. When supplied, the
+            evaluator just runs it N times and ``driver`` is unused.
+
+    Example::
+
+        evaluator = SelfConsistencyEvaluator(driver=my_driver, n_samples=5)
+        result = evaluator.evaluate("What is 17 * 23?")
+        if result.agreement >= 0.8:
+            print(f"Confident answer: {result.consensus}")
+        else:
+            print(f"Low agreement ({result.agreement:.0%}) — counts: {result.counts}")
+    """
+
+    def __init__(
+        self,
+        driver: EvalDriver | None = None,
+        *,
+        n_samples: int = 5,
+        temperature: float = 0.7,
+        normalize: Callable[[str], str] = _default_normalize,
+        llm_options: dict[str, Any] | None = None,
+        sampler: Callable[[], str] | None = None,
+    ) -> None:
+        if n_samples < 1:
+            raise EvalError(f"n_samples must be >= 1; got {n_samples}.")
+        if driver is None and sampler is None:
+            raise EvalError("SelfConsistencyEvaluator requires either driver= or sampler=.")
+        self.driver = driver
+        self.n_samples = n_samples
+        self.temperature = temperature
+        self.normalize = normalize
+        self.sampler = sampler
+        base_opts = dict(llm_options or {})
+        # Default temperature only when caller didn't pin one.
+        base_opts.setdefault("temperature", temperature)
+        base_opts.setdefault("max_tokens", 256)
+        self.llm_options = base_opts
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def evaluate(self, prompt: str | None = None) -> SelfConsistencyResult:
+        """Run the sampler N times and return the majority vote.
+
+        ``prompt`` is required when using the driver path; ignored
+        (but accepted for API symmetry) when ``sampler`` is set.
+
+        Raises:
+            EvalError: When zero samples produced usable text.
+        """
+        if self.sampler is None:
+            if not prompt or not prompt.strip():
+                raise EvalError("prompt is required when using driver-based sampling.")
+            sampler = self._driver_sampler(prompt)
+        else:
+            sampler = self.sampler
+
+        meta: dict[str, Any] = {}
+        normalised: list[str] = []
+
+        for _ in range(self.n_samples):
+            text, per_call_meta = self._invoke_sampler(sampler)
+            if per_call_meta:
+                _accumulate_meta(meta, per_call_meta)
+            normalised_text = self.normalize(text)
+            if normalised_text:
+                normalised.append(normalised_text)
+
+        if not normalised:
+            raise EvalError("All self-consistency samples returned empty text.")
+
+        counter = Counter(normalised)
+        consensus, top_count = counter.most_common(1)[0]
+        agreement = top_count / len(normalised)
+
+        return SelfConsistencyResult(
+            consensus=consensus,
+            agreement=agreement,
+            samples=normalised,
+            counts=dict(counter),
+            meta=meta,
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _driver_sampler(self, prompt: str) -> Callable[[], tuple[str, dict[str, Any] | None]]:
+        """Build a sampler closure that calls ``driver.generate(prompt, ...)``.
+
+        Returns a callable that, on each invocation, runs one driver
+        call and returns ``(text, meta_or_none)``.
+        """
+        if self.driver is None:  # narrowing for type checkers
+            raise EvalError("driver is required for the driver-based sampler.")
+
+        driver = self.driver
+        options = self.llm_options
+
+        def _sample() -> tuple[str, dict[str, Any] | None]:
+            response = driver.generate(prompt, dict(options))
+            if isinstance(response, dict):
+                return str(response.get("text") or ""), response.get("meta")
+            return str(response or ""), None
+
+        return _sample
+
+    def _invoke_sampler(self, sampler: Callable[..., Any]) -> tuple[str, dict[str, Any] | None]:
+        """Run a sampler and normalise its return shape to ``(text, meta_or_none)``."""
+        result = sampler()
+        if isinstance(result, tuple) and len(result) == 2:
+            text, meta = result
+            return str(text or ""), meta if isinstance(meta, dict) else None
+        if isinstance(result, dict):
+            return str(result.get("text") or ""), result.get("meta")
+        return str(result or ""), None

--- a/prompture/extraction/async_core.py
+++ b/prompture/extraction/async_core.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import sys
-from datetime import date, datetime
-from decimal import Decimal
 from typing import Any, Literal, Union
+
+from .._internal.json_encoder import PromptureJSONEncoder
 
 try:
     import toon
@@ -408,27 +407,20 @@ async def extract_and_jsonify(
         reasoning_strategy = auto_select_reasoning_strategy(text, json_schema)
     content_prompt = apply_reasoning_strategy(content_prompt, reasoning_strategy)
 
-    try:
-        result = await ask_for_json(
-            driver,
-            content_prompt,
-            json_schema,
-            ai_cleanup,
-            model_id,
-            opts,
-            output_format=output_format,
-            json_mode=json_mode,
-            system_prompt=system_prompt,
-            strategy=strategy,
-        )
-        result["usage"]["reasoning_strategy"] = _strategy_name(reasoning_strategy)
-        return result
-    except Exception as e:
-        if "pytest" in sys.modules:
-            import pytest
-
-            pytest.skip(f"Connection error occurred: {e}")
-        raise
+    result = await ask_for_json(
+        driver,
+        content_prompt,
+        json_schema,
+        ai_cleanup,
+        model_id,
+        opts,
+        output_format=output_format,
+        json_mode=json_mode,
+        system_prompt=system_prompt,
+        strategy=strategy,
+    )
+    result["usage"]["reasoning_strategy"] = _strategy_name(reasoning_strategy)
+    return result
 
 
 async def manual_extract_and_jsonify(
@@ -557,7 +549,7 @@ async def _async_chunked_extract(
                 merged_json[field_name] = None
 
     model_instance = model_cls(**merged_json)
-    merged_json_str = json.dumps(merged_json, default=str, ensure_ascii=False)
+    merged_json_str = json.dumps(merged_json, cls=PromptureJSONEncoder, ensure_ascii=False)
 
     result_dict: dict[str, Any] = {
         "json_string": merged_json_str,
@@ -862,15 +854,7 @@ async def stepwise_extract_with_model(
         model_instance = model_cls(**data)
         model_dict = model_instance.model_dump()
 
-        class ExtendedJSONEncoder(json.JSONEncoder):
-            def default(self, obj: Any) -> Any:
-                if isinstance(obj, (datetime, date)):
-                    return obj.isoformat()
-                if isinstance(obj, Decimal):
-                    return str(obj)
-                return super().default(obj)
-
-        json_string = json.dumps(model_dict, cls=ExtendedJSONEncoder)
+        json_string = json.dumps(model_dict, cls=PromptureJSONEncoder)
 
         result = {
             "json_string": json_string,

--- a/prompture/extraction/async_core.py
+++ b/prompture/extraction/async_core.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from typing import Any, Literal, Union
+from typing import Any, Literal
 
 from .._internal.json_encoder import PromptureJSONEncoder
 
@@ -719,7 +719,7 @@ async def stepwise_extract_with_model(
     system_prompt: str | None = None,
     share_context: bool = False,
     reasoning_strategy: str | ReasoningStrategyProtocol | None = None,
-) -> dict[str, Union[str, dict[str, Any]]]:
+) -> dict[str, str | dict[str, Any]]:
     """Extract information field-by-field using sequential async LLM calls."""
     if not text or not text.strip():
         raise ValueError("Text input cannot be empty")
@@ -1071,7 +1071,7 @@ async def extract_with_models(
 
 
 async def extract_from_data(
-    data: Union[list[dict[str, Any]], dict[str, Any]],
+    data: list[dict[str, Any]] | dict[str, Any],
     question: str,
     json_schema: dict[str, Any],
     *,

--- a/prompture/extraction/core.py
+++ b/prompture/extraction/core.py
@@ -86,6 +86,108 @@ def _merge_usage(
     }
 
 
+def _walk_schema_to_field(
+    schema: dict[str, Any], loc: tuple[Any, ...]
+) -> dict[str, Any] | None:
+    """Navigate a JSON-Schema dict to the entry referenced by ``loc``.
+
+    ``loc`` follows Pydantic's ValidationError convention:
+
+    * string entries index into ``properties``
+    * integer entries index into ``items``
+
+    Returns the schema entry for the addressed field, or ``None`` when
+    the path doesn't resolve (e.g. the schema uses ``$ref`` we don't
+    follow here, or the field is wrapped in an ``anyOf`` / ``oneOf``
+    that we don't traverse). Returning ``None`` is a quiet skip — the
+    caller leaves the schema untouched for that error.
+    """
+    if not loc:
+        return None
+    node: Any = schema
+    for part in loc[:-1]:
+        if not isinstance(node, dict):
+            return None
+        if isinstance(part, str):
+            node = node.get("properties", {}).get(part)
+        elif isinstance(part, int):
+            node = node.get("items")
+        else:
+            return None
+        if node is None:
+            return None
+    last = loc[-1]
+    if not isinstance(node, dict):
+        return None
+    if isinstance(last, str):
+        return node.get("properties", {}).get(last)  # type: ignore[no-any-return]
+    if isinstance(last, int):
+        return node.get("items")  # type: ignore[no-any-return]
+    return None
+
+
+def _format_validation_hint(error: dict[str, Any]) -> str:
+    """Render one Pydantic validation error as a short corrective hint.
+
+    Designed to be appended to a field's ``description`` so the model
+    sees it on the next attempt. Kept concise — long retry hints
+    confuse small models more than they help.
+    """
+    msg = str(error.get("msg") or "value did not validate").strip().rstrip(".")
+    input_val = error.get("input")
+    expected_type = error.get("type", "")
+
+    if input_val is None or (isinstance(input_val, str) and not input_val):
+        return f"VALIDATION: {msg}."
+    # Truncate gigantic inputs (e.g. long strings the model dumped).
+    rendered_input = repr(input_val)
+    if len(rendered_input) > 80:
+        rendered_input = rendered_input[:77] + "..."
+    suffix = f" Previous attempt returned {rendered_input}."
+    type_hint = f" (constraint: {expected_type})" if expected_type else ""
+    return f"VALIDATION: {msg}{type_hint}.{suffix}"
+
+
+def tighten_schema_from_validation_errors(
+    schema: dict[str, Any], errors: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Return a copy of ``schema`` with retry hints appended to failing fields.
+
+    For every Pydantic validation error in ``errors`` we look up the
+    addressed field in ``schema`` and append a short hint to that
+    field's ``description`` (creating one if missing). Errors whose
+    ``loc`` we can't resolve are silently skipped — those still get
+    handled by the existing prompt-level ``validation_feedback`` path.
+
+    The returned schema is a deep copy; the input is never mutated. If
+    no errors resolve to a field, the input schema is returned
+    unchanged (cheap, no copy).
+    """
+    if not errors:
+        return schema
+
+    import copy
+
+    resolved_any = False
+    new_schema = copy.deepcopy(schema)
+    for err in errors:
+        loc = err.get("loc") or ()
+        if not isinstance(loc, (tuple, list)):
+            continue
+        field_schema = _walk_schema_to_field(new_schema, tuple(loc))
+        if field_schema is None:
+            continue
+        hint = _format_validation_hint(err)
+        existing = field_schema.get("description", "")
+        if hint in str(existing):
+            # Don't append the same hint twice across multiple retries.
+            continue
+        field_schema["description"] = f"{existing} {hint}".strip() if existing else hint
+        resolved_any = True
+
+    return new_schema if resolved_any else schema
+
+
 def _build_content_with_images(text: str, images: list[ImageInput] | None = None) -> str | list[dict[str, Any]]:
     """Return plain string when no images, or a list of content blocks."""
     if not images:
@@ -1051,6 +1153,12 @@ def extract_with_model(
 
     last_error: Exception | None = None
     validation_feedback: str | None = None
+    # Phase 5: schema-level retry feedback. When a Pydantic ValidationError
+    # is captured, we tighten the relevant fields' `description` entries
+    # and pass the patched schema on the next attempt. Combined with the
+    # prompt-level `validation_feedback`, this gives the model both
+    # structural and conversational hints to correct itself.
+    tightened_schema: dict[str, Any] | None = None
 
     for attempt in range(max(1, max_retries)):
         try:
@@ -1063,9 +1171,11 @@ def extract_with_model(
                     "Please fix these issues."
                 )
 
+            effective_schema = tightened_schema if tightened_schema is not None else schema
+
             result = extract_and_jsonify(
                 text=actual_text,
-                json_schema=schema,
+                json_schema=effective_schema,
                 model_name=actual_model,
                 instruction_template=effective_instruction,
                 ai_cleanup=ai_cleanup,
@@ -1146,6 +1256,21 @@ def extract_with_model(
             # Capture Pydantic validation errors to feed back on next attempt
             if hasattr(exc, "errors") and callable(getattr(exc, "errors", None)):
                 validation_feedback = str(exc)
+                # Phase 5: tighten the schema for the next retry so the
+                # model gets a structural hint, not just a prompt-level one.
+                try:
+                    error_details = exc.errors()  # type: ignore[attr-defined]
+                except Exception:
+                    error_details = []
+                if error_details:
+                    base = tightened_schema if tightened_schema is not None else schema
+                    candidate = tighten_schema_from_validation_errors(base, error_details)
+                    if candidate is not base:
+                        tightened_schema = candidate
+                        logger.debug(
+                            "[extract] Tightened schema descriptions for %d failing field(s).",
+                            len(error_details),
+                        )
             if attempt < max(1, max_retries) - 1:
                 logger.debug("[extract] Attempt %d failed: %s, retrying...", attempt + 1, exc)
                 continue

--- a/prompture/extraction/core.py
+++ b/prompture/extraction/core.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import warnings
-from typing import TYPE_CHECKING, Any, Literal, Union
+from typing import TYPE_CHECKING, Any, Literal
 
 from .._internal.json_encoder import PromptureJSONEncoder
 
@@ -658,10 +658,10 @@ def ask_for_json(
 
 
 def extract_and_jsonify(
-    text: Union[str, Driver],  # Can be either text or driver for backward compatibility
+    text: str | Driver,  # Can be either text or driver for backward compatibility
     json_schema: dict[str, Any],
     *,  # Force keyword arguments for remaining params
-    model_name: Union[str, dict[str, Any]] = "",  # Can be schema (old) or model name (new)
+    model_name: str | dict[str, Any] = "",  # Can be schema (old) or model name (new)
     driver: Driver | None = None,
     instruction_template: str = "Extract information from the following text:",
     ai_cleanup: bool = True,
@@ -926,9 +926,9 @@ def _chunked_extract(
 
 
 def extract_with_model(
-    model_cls: Union[type[BaseModel], str],  # Can be model class or model name string for legacy support
-    text: Union[str, dict[str, Any], None] = None,  # Can be text or schema for legacy support
-    model_name: Union[str, dict[str, Any], None] = None,  # Can be model name, text, or None for routing
+    model_cls: type[BaseModel] | str,  # Can be model class or model name string for legacy support
+    text: str | dict[str, Any] | None = None,  # Can be text or schema for legacy support
+    model_name: str | dict[str, Any] | None = None,  # Can be model name, text, or None for routing
     instruction_template: str = "Extract information from the following text:",
     ai_cleanup: bool = True,
     output_format: Literal["json", "toon"] = "json",
@@ -937,7 +937,7 @@ def extract_with_model(
     json_mode: Literal["auto", "on", "off"] = "auto",
     system_prompt: str | None = None,
     images: list[ImageInput] | None = None,
-    routing: Union[str, RoutingConfig, None] = None,
+    routing: str | RoutingConfig | None = None,
     max_retries: int = 1,
     fallback: BaseModel | None = None,
     reasoning_strategy: str | ReasoningStrategyProtocol | None = None,
@@ -1314,7 +1314,7 @@ def stepwise_extract_with_model(
     system_prompt: str | None = None,
     share_context: bool = False,
     reasoning_strategy: str | ReasoningStrategyProtocol | None = None,
-) -> dict[str, Union[str, dict[str, Any]]]:
+) -> dict[str, str | dict[str, Any]]:
     """Extracts structured information into a Pydantic model by processing each field individually.
 
     For each field in the model, makes a separate LLM call to extract that specific field,
@@ -1858,7 +1858,7 @@ def extract_with_models(
     raise err
 
 
-def _json_to_toon(data: Union[list[dict[str, Any]], dict[str, Any]], data_key: str | None = None) -> str:
+def _json_to_toon(data: list[dict[str, Any]] | dict[str, Any], data_key: str | None = None) -> str:
     """Convert JSON array or dict containing array to TOON format.
 
     Args:
@@ -1996,7 +1996,7 @@ def _calculate_token_savings(json_text: str, toon_text: str) -> dict[str, Any]:
 
 
 def extract_from_data(
-    data: Union[list[dict[str, Any]], dict[str, Any]],
+    data: list[dict[str, Any]] | dict[str, Any],
     question: str,
     json_schema: dict[str, Any],
     *,

--- a/prompture/extraction/core.py
+++ b/prompture/extraction/core.py
@@ -86,9 +86,7 @@ def _merge_usage(
     }
 
 
-def _walk_schema_to_field(
-    schema: dict[str, Any], loc: tuple[Any, ...]
-) -> dict[str, Any] | None:
+def _walk_schema_to_field(schema: dict[str, Any], loc: tuple[Any, ...]) -> dict[str, Any] | None:
     """Navigate a JSON-Schema dict to the entry referenced by ``loc``.
 
     ``loc`` follows Pydantic's ValidationError convention:
@@ -148,9 +146,7 @@ def _format_validation_hint(error: dict[str, Any]) -> str:
     return f"VALIDATION: {msg}{type_hint}.{suffix}"
 
 
-def tighten_schema_from_validation_errors(
-    schema: dict[str, Any], errors: list[dict[str, Any]]
-) -> dict[str, Any]:
+def tighten_schema_from_validation_errors(schema: dict[str, Any], errors: list[dict[str, Any]]) -> dict[str, Any]:
     """Return a copy of ``schema`` with retry hints appended to failing fields.
 
     For every Pydantic validation error in ``errors`` we look up the
@@ -1136,10 +1132,7 @@ def extract_with_model(
             if picked:
                 examples_block = format_examples_for_prompt(picked)
                 augmented_instruction = f"{examples_block}\n{instruction_template}"
-                selected_examples_meta = [
-                    {"input": ex.input_text, "metadata": dict(ex.metadata)}
-                    for ex in picked
-                ]
+                selected_examples_meta = [{"input": ex.input_text, "metadata": dict(ex.metadata)} for ex in picked]
                 logger.debug(
                     "[extract] Few-shot: selected %d/%d examples for query.",
                     len(picked),

--- a/prompture/extraction/core.py
+++ b/prompture/extraction/core.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 import json
 import logging
-import sys
 import warnings
-from datetime import date, datetime
-from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Literal, Union
+
+from .._internal.json_encoder import PromptureJSONEncoder
 
 if TYPE_CHECKING:
     from ..pipeline.routing import RoutingConfig
@@ -598,7 +597,7 @@ def extract_and_jsonify(
     Raises:
         ValueError: If text is empty or None, or if model_name format is invalid.
         json.JSONDecodeError: If the response cannot be parsed as JSON and ai_cleanup is False.
-        pytest.skip: If a ConnectionError occurs during testing (when pytest is running).
+        ConnectionError: If the underlying HTTP call fails.
     """
     if options is None:
         options = {}
@@ -693,10 +692,6 @@ def extract_and_jsonify(
         result["usage"]["reasoning_strategy"] = _strategy_name(reasoning_strategy)
         return result
     except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError) as e:
-        if "pytest" in sys.modules:
-            import pytest
-
-            pytest.skip(f"Connection error occurred: {e}")
         raise ConnectionError(f"Connection error occurred: {e}") from e
 
 
@@ -816,7 +811,7 @@ def _chunked_extract(
 
     # Validate merged result
     model_instance = actual_cls(**merged_json)
-    merged_json_str = json.dumps(merged_json, default=str, ensure_ascii=False)
+    merged_json_str = json.dumps(merged_json, cls=PromptureJSONEncoder, ensure_ascii=False)
 
     result_dict: dict[str, Any] = {
         "json_string": merged_json_str,
@@ -1400,17 +1395,8 @@ def stepwise_extract_with_model(
         model_instance = model_cls(**data)
         model_dict = model_instance.model_dump()
 
-        # Enhanced DateTimeEncoder to handle both datetime and date objects
-        class ExtendedJSONEncoder(json.JSONEncoder):
-            def default(self, obj: Any) -> Any:
-                if isinstance(obj, (datetime, date)):
-                    return obj.isoformat()
-                if isinstance(obj, Decimal):
-                    return str(obj)
-                return super().default(obj)
-
-        # Create json string with custom encoder
-        json_string = json.dumps(model_dict, cls=ExtendedJSONEncoder)
+        # Use the shared PromptureJSONEncoder (handles datetime/Decimal/UUID/BaseModel/etc.)
+        json_string = json.dumps(model_dict, cls=PromptureJSONEncoder)
 
         # Create result matching extract_with_model format
         result = {

--- a/prompture/extraction/core.py
+++ b/prompture/extraction/core.py
@@ -842,6 +842,8 @@ def extract_with_model(
     source: Any = None,
     chunking: Any = None,
     strategy: str | StructuredOutputStrategy | None = None,
+    examples_store: Any = None,
+    examples_k: int = 3,
 ) -> dict[str, Any]:
     """Extracts structured information into a Pydantic model instance.
 
@@ -876,6 +878,15 @@ def extract_with_model(
         chunking: Chunking configuration for large documents.  Pass ``True``
             for auto-chunking with defaults, a ``ChunkingConfig`` instance
             for full control, or ``None``/``False`` to disable.
+        examples_store: Optional :class:`~prompture.extraction.few_shot.FewShotExampleStore`.
+            When provided, the top ``examples_k`` most-similar examples are
+            retrieved by embedding similarity and injected into the prompt
+            ahead of the actual input. Published few-shot literature shows
+            5–20 percentage-point accuracy lifts on structured extraction.
+            The result's usage metadata includes a ``few_shot`` entry with
+            the selected input strings for transparency.
+        examples_k: Number of examples to retrieve from ``examples_store``.
+            Ignored when ``examples_store`` is ``None``. Defaults to 3.
 
     Returns:
         A validated instance of the Pydantic model. When routing is used,
@@ -1009,16 +1020,45 @@ def extract_with_model(
     schema = actual_cls.model_json_schema()
     logger.debug("[extract] Generated JSON schema")
 
+    # --- Few-shot example selection (Phase 4) ---
+    # Compute once per call (not per retry — examples don't change between
+    # validation retries). When examples_store is provided, the top-K most
+    # similar examples are formatted and prepended to the instruction.
+    selected_examples_meta: list[dict[str, Any]] | None = None
+    augmented_instruction = instruction_template
+    if examples_store is not None and examples_k > 0:
+        try:
+            from .few_shot import format_examples_for_prompt
+
+            picked = examples_store.select(actual_text, k=examples_k)
+            if picked:
+                examples_block = format_examples_for_prompt(picked)
+                augmented_instruction = f"{examples_block}\n{instruction_template}"
+                selected_examples_meta = [
+                    {"input": ex.input_text, "metadata": dict(ex.metadata)}
+                    for ex in picked
+                ]
+                logger.debug(
+                    "[extract] Few-shot: selected %d/%d examples for query.",
+                    len(picked),
+                    examples_k,
+                )
+        except Exception:
+            logger.warning(
+                "[extract] examples_store.select() failed; continuing without few-shot.",
+                exc_info=True,
+            )
+
     last_error: Exception | None = None
     validation_feedback: str | None = None
 
     for attempt in range(max(1, max_retries)):
         try:
             # Build instruction template with validation feedback from prior attempt
-            effective_instruction = instruction_template
+            effective_instruction = augmented_instruction
             if validation_feedback is not None and max_retries >= 2:
                 effective_instruction = (
-                    f"{instruction_template}\n\n"
+                    f"{augmented_instruction}\n\n"
                     f"Previous attempt failed validation: {validation_feedback}. "
                     "Please fix these issues."
                 )
@@ -1077,6 +1117,14 @@ def extract_with_model(
             # --- Add routing metadata if routing was used ---
             if routing_result is not None:
                 result_dict["routing"] = routing_result.to_dict()
+
+            # --- Add few-shot transparency metadata when examples were used ---
+            if selected_examples_meta is not None:
+                result_dict["usage"]["few_shot"] = {
+                    "count": len(selected_examples_meta),
+                    "k_requested": examples_k,
+                    "examples": selected_examples_meta,
+                }
 
             # --- cache store ---
             if use_cache and cache_key is not None:

--- a/prompture/extraction/few_shot.py
+++ b/prompture/extraction/few_shot.py
@@ -1,0 +1,311 @@
+"""Semantic few-shot example selection for structured extraction.
+
+Stores (input, expected_output) example pairs and serves the most
+similar examples to a new query by cosine similarity in embedding space.
+Lifts extraction accuracy by injecting K nearest exemplars into the
+prompt automatically — published numbers from few-shot literature show
+5–20 percentage-point gains on structured-output benchmarks.
+
+Architecture
+~~~~~~~~~~~~
+
+* :class:`FewShotExampleStore` — in-memory store. ``add()`` /
+  ``add_many()`` to populate, ``select()`` to retrieve top-K.
+* :class:`Example` — the dataclass carried inside the store.
+* :func:`format_examples_for_prompt` — turns selected examples into
+  the prompt fragment :func:`prompture.extraction.core.extract_with_model`
+  injects.
+
+The store accepts any embedder with the standard
+``embed(texts, options) -> {"embeddings": list[list[float]]}`` contract
+used across :class:`prompture.drivers.embedding_base.EmbeddingDriver`.
+When ``embedder=None`` a deterministic char-trigram fallback embedder
+is used so the store is usable for prototyping / tests with zero
+external dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from .._internal.json_encoder import PromptureJSONEncoder
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Embedder protocol + tiny fallback
+# ---------------------------------------------------------------------------
+
+
+class _Embedder(Protocol):
+    """Minimal embedder contract — matches :class:`EmbeddingDriver`."""
+
+    def embed(self, texts: list[str], options: dict[str, Any]) -> dict[str, Any]:  # pragma: no cover
+        ...
+
+
+class _NgramEmbedder:
+    """Char-trigram hashed embedder. Zero-dependency fallback for testing.
+
+    Produces a fixed-size vector by hashing every char-trigram of the
+    input into a bucket and counting occurrences. Cosine similarity on
+    these vectors approximates Jaccard-like content overlap. Good
+    enough to demonstrate top-K selection in tests; replace with a
+    real embedding model in production.
+    """
+
+    def __init__(self, dimensions: int = 256) -> None:
+        self.dimensions = dimensions
+
+    def embed(self, texts: list[str], options: dict[str, Any]) -> dict[str, Any]:
+        vectors: list[list[float]] = []
+        for t in texts:
+            padded = f"  {t.lower()}  "
+            vec = [0.0] * self.dimensions
+            for i in range(len(padded) - 2):
+                tri = padded[i : i + 3]
+                vec[hash(tri) % self.dimensions] += 1.0
+            vectors.append(vec)
+        return {"embeddings": vectors, "meta": {"model_name": "ngram-fallback", "dimensions": self.dimensions}}
+
+
+# ---------------------------------------------------------------------------
+# Data class
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Example:
+    """A single ``(input, expected_output)`` example with its cached embedding."""
+
+    input_text: str
+    expected_output: Any
+    metadata: dict[str, Any] = field(default_factory=dict)
+    embedding: list[float] | None = field(default=None, repr=False)
+
+
+# ---------------------------------------------------------------------------
+# Math
+# ---------------------------------------------------------------------------
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = 0.0
+    na = 0.0
+    nb = 0.0
+    for x, y in zip(a, b):
+        dot += x * y
+        na += x * x
+        nb += y * y
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (math.sqrt(na) * math.sqrt(nb))
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+class FewShotExampleStore:
+    """In-memory semantic example bank for structured extraction.
+
+    Args:
+        embedder: Any embedding driver exposing the standard
+            ``embed(texts, options) -> {"embeddings": ...}`` contract.
+            When ``None`` (the default), a deterministic char-trigram
+            fallback is used — fine for prototyping and tests but you
+            want a real embedding model for production accuracy.
+        embed_options: Forwarded verbatim on every embed call. Useful
+            for picking a specific ``dimensions`` on OpenAI embeddings,
+            or routing to a specific model.
+
+    Example::
+
+        from prompture.extraction.few_shot import FewShotExampleStore
+
+        store = FewShotExampleStore()  # uses fallback embedder
+        store.add("Maria is 32, a developer.", {"name": "Maria", "age": 32})
+        store.add("Bob, 47, accountant.", {"name": "Bob", "age": 47})
+
+        hits = store.select("Alice is 25, designer.", k=2)
+        for ex in hits:
+            print(ex.input_text, ex.expected_output)
+    """
+
+    def __init__(
+        self,
+        embedder: _Embedder | None = None,
+        *,
+        embed_options: dict[str, Any] | None = None,
+    ) -> None:
+        self.embedder = embedder if embedder is not None else _NgramEmbedder()
+        self.embed_options = embed_options or {}
+        self._examples: list[Example] = []
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def add(
+        self,
+        input_text: str,
+        expected_output: Any,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> Example:
+        """Embed and store a single example. Returns the stored :class:`Example`."""
+        ex = Example(input_text=input_text, expected_output=expected_output, metadata=metadata or {})
+        ex.embedding = self._embed_single(input_text)
+        self._examples.append(ex)
+        return ex
+
+    def add_many(self, examples: list[tuple[str, Any]]) -> list[Example]:
+        """Batch-embed and store multiple examples. Saves embedding calls."""
+        if not examples:
+            return []
+        inputs = [t for t, _ in examples]
+        vectors = self._embed_batch(inputs)
+        out: list[Example] = []
+        for (input_text, expected_output), vec in zip(examples, vectors):
+            ex = Example(input_text=input_text, expected_output=expected_output)
+            ex.embedding = vec
+            self._examples.append(ex)
+            out.append(ex)
+        return out
+
+    def clear(self) -> None:
+        self._examples.clear()
+
+    def __len__(self) -> int:
+        return len(self._examples)
+
+    @property
+    def examples(self) -> list[Example]:
+        """Read-only view over the stored examples (returned as a copy)."""
+        return list(self._examples)
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def select(self, query: str, k: int = 3) -> list[Example]:
+        """Return the top-``k`` examples most similar to ``query``.
+
+        Ties are broken by insertion order (stable sort). When ``k``
+        exceeds the store size, all stored examples are returned.
+        """
+        if k <= 0 or not self._examples:
+            return []
+        q_vec = self._embed_single(query)
+        scored: list[tuple[float, int, Example]] = []
+        for idx, ex in enumerate(self._examples):
+            if ex.embedding is None:
+                continue
+            scored.append((_cosine(q_vec, ex.embedding), idx, ex))
+        # Sort by descending similarity, breaking ties on insertion order.
+        scored.sort(key=lambda t: (-t[0], t[1]))
+        return [ex for _, _, ex in scored[:k]]
+
+    # ------------------------------------------------------------------
+    # Embedder plumbing
+    # ------------------------------------------------------------------
+
+    def _embed_single(self, text: str) -> list[float]:
+        return self._embed_batch([text])[0]
+
+    def _embed_batch(self, texts: list[str]) -> list[list[float]]:
+        response = self.embedder.embed(texts, self.embed_options)
+        if not isinstance(response, dict) or "embeddings" not in response:
+            raise ValueError(
+                "Embedder returned an unexpected shape; expected a dict with an "
+                f"'embeddings' key, got: {type(response).__name__}"
+            )
+        vectors = response["embeddings"]
+        if len(vectors) != len(texts):
+            raise ValueError(
+                f"Embedder returned {len(vectors)} vectors for {len(texts)} inputs."
+            )
+        return [list(v) for v in vectors]
+
+
+# ---------------------------------------------------------------------------
+# Prompt formatting
+# ---------------------------------------------------------------------------
+
+
+def format_examples_for_prompt(
+    examples: list[Example],
+    *,
+    header: str = "Here are similar examples you should use as a guide:",
+    footer: str = "Now extract from the input below using the same conventions:",
+    output_indent: int = 2,
+) -> str:
+    """Render a list of :class:`Example` objects as a single prompt fragment.
+
+    Output format::
+
+        {header}
+
+        Input: <example 1 input>
+        Output:
+        {<example 1 output as JSON>}
+
+        Input: <example 2 input>
+        Output:
+        {<example 2 output as JSON>}
+
+        {footer}
+
+    The output of each example is serialised via
+    :class:`prompture._internal.json_encoder.PromptureJSONEncoder` so
+    Pydantic models, datetimes, Decimals, UUIDs, etc. all serialise
+    deterministically.
+
+    Returns an empty string when ``examples`` is empty so callers can
+    safely splice the result into any prompt without adding stray
+    whitespace.
+    """
+    if not examples:
+        return ""
+    parts: list[str] = [header.strip(), ""]
+    for ex in examples:
+        rendered_output = _render_output(ex.expected_output, indent=output_indent)
+        parts.append(f"Input: {ex.input_text}")
+        parts.append(f"Output:\n{rendered_output}")
+        parts.append("")  # blank line between examples
+    parts.append(footer.strip())
+    return "\n".join(parts).strip() + "\n"
+
+
+def _render_output(value: Any, *, indent: int) -> str:
+    """Serialise an example's expected output to a stable text representation."""
+    # Pydantic BaseModel? Use model_dump.
+    try:
+        from pydantic import BaseModel
+
+        if isinstance(value, BaseModel):
+            value = value.model_dump(mode="json")
+    except ImportError:  # pragma: no cover - pydantic is a hard dep
+        pass
+
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, indent=indent, cls=PromptureJSONEncoder)
+    if isinstance(value, str):
+        return value
+    # Fallback: best-effort stringify via the shared encoder.
+    return json.dumps(value, indent=indent, cls=PromptureJSONEncoder)
+
+
+__all__ = [
+    "Example",
+    "FewShotExampleStore",
+    "format_examples_for_prompt",
+]

--- a/prompture/extraction/few_shot.py
+++ b/prompture/extraction/few_shot.py
@@ -230,9 +230,7 @@ class FewShotExampleStore:
             )
         vectors = response["embeddings"]
         if len(vectors) != len(texts):
-            raise ValueError(
-                f"Embedder returned {len(vectors)} vectors for {len(texts)} inputs."
-            )
+            raise ValueError(f"Embedder returned {len(vectors)} vectors for {len(texts)} inputs.")
         return [list(v) for v in vectors]
 
 

--- a/prompture/extraction/few_shot.py
+++ b/prompture/extraction/few_shot.py
@@ -100,7 +100,7 @@ def _cosine(a: list[float], b: list[float]) -> float:
     dot = 0.0
     na = 0.0
     nb = 0.0
-    for x, y in zip(a, b):
+    for x, y in zip(a, b, strict=False):
         dot += x * y
         na += x * x
         nb += y * y
@@ -174,7 +174,7 @@ class FewShotExampleStore:
         inputs = [t for t, _ in examples]
         vectors = self._embed_batch(inputs)
         out: list[Example] = []
-        for (input_text, expected_output), vec in zip(examples, vectors):
+        for (input_text, expected_output), vec in zip(examples, vectors, strict=False):
             ex = Example(input_text=input_text, expected_output=expected_output)
             ex.embedding = vec
             self._examples.append(ex)

--- a/prompture/extraction/fields.py
+++ b/prompture/extraction/fields.py
@@ -14,7 +14,7 @@ Features:
 import collections.abc
 import threading
 from datetime import date, datetime
-from typing import Any, Optional, Union
+from typing import Any, Union
 
 from pydantic import Field
 from pydantic.fields import FieldInfo
@@ -38,7 +38,7 @@ def _get_template_variables() -> dict[str, Any]:
     }
 
 
-def _apply_templates(text: str, custom_vars: Optional[dict[str, Any]] = None) -> str:
+def _apply_templates(text: str, custom_vars: dict[str, Any] | None = None) -> str:
     """Apply template variable substitution to a text string."""
     if not isinstance(text, str):
         return text
@@ -345,8 +345,8 @@ FIELD_DEFINITIONS = _global_registry
 
 
 def get_field_definition(
-    field_name: str, apply_templates: bool = True, custom_template_vars: Optional[dict[str, Any]] = None
-) -> Optional[FieldDefinition]:
+    field_name: str, apply_templates: bool = True, custom_template_vars: dict[str, Any] | None = None
+) -> FieldDefinition | None:
     """
     Retrieve the definition for a specific field from the global registry.
 
@@ -443,7 +443,7 @@ def add_field_definitions(field_definitions: dict[str, FieldDefinition]) -> None
 
 
 def field_from_registry(
-    field_name: str, apply_templates: bool = True, custom_template_vars: Optional[dict[str, Any]] = None
+    field_name: str, apply_templates: bool = True, custom_template_vars: dict[str, Any] | None = None
 ) -> FieldInfo:
     """
     Create a Pydantic Field from a field definition in the global registry.

--- a/prompture/extraction/reasoning.py
+++ b/prompture/extraction/reasoning.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import logging
 import threading
 from dataclasses import dataclass
-from typing import Any, Protocol, Union, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 logger = logging.getLogger("prompture.extraction.reasoning")
 
@@ -257,7 +257,7 @@ def auto_select_reasoning_strategy(
     return None
 
 
-def _strategy_name(strategy: Union[str, ReasoningStrategyProtocol, None]) -> str | None:
+def _strategy_name(strategy: str | ReasoningStrategyProtocol | None) -> str | None:
     """Return a serialisable name for *strategy*, or ``None``."""
     if strategy is None:
         return None
@@ -268,7 +268,7 @@ def _strategy_name(strategy: Union[str, ReasoningStrategyProtocol, None]) -> str
 
 def apply_reasoning_strategy(
     content_prompt: str,
-    strategy: Union[str, ReasoningStrategyProtocol, None],
+    strategy: str | ReasoningStrategyProtocol | None,
 ) -> str:
     """Resolve and apply a reasoning strategy to *content_prompt*.
 

--- a/prompture/extraction/streaming.py
+++ b/prompture/extraction/streaming.py
@@ -1,0 +1,373 @@
+"""Partial-JSON streaming for structured extraction.
+
+When an LLM streams a JSON response, this module makes the in-flight
+JSON readable as a partial Pydantic model so downstream consumers can
+render fields progressively instead of blocking on the full response.
+
+The parser is stdlib-only by default. For complex / edge-case partial
+JSON (unicode escapes mid-stream, exotic literals) you can install the
+``partial-json-parser`` package and pass ``parser="partial_json_parser"``
+to :func:`stream_extract` — the module imports it lazily and falls back
+to stdlib when it's not installed.
+
+Two public entry points:
+
+* :func:`parse_partial_json` — best-effort parse of an incomplete JSON
+  string into a Python value. Returns ``None`` when no recoverable
+  parse exists.
+* :func:`stream_extract` / :func:`astream_extract` — drive an LLM
+  driver's streaming method and yield progressively-filled Pydantic
+  model instances as text arrives.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import AsyncIterator, Iterator
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+# ---------------------------------------------------------------------------
+# Partial JSON parsing
+# ---------------------------------------------------------------------------
+
+
+def _scan_state(text: str) -> tuple[list[str], bool, bool] | None:
+    """Scan ``text`` once and report the open-bracket stack + string state.
+
+    Returns ``(stack, in_string, trailing_escape)``. ``stack`` is a list
+    of *closing* characters (``'}'`` / ``']'``) in reverse open order
+    so it can be reversed and appended to recover a parseable suffix.
+    ``trailing_escape`` is True when the buffer ended right after a
+    backslash — we can't reliably parse that case.
+
+    Returns ``None`` if the bracket structure is unrecoverable
+    (more closers than openers, etc.).
+    """
+    stack: list[str] = []
+    in_string = False
+    escape = False
+    for ch in text:
+        if escape:
+            escape = False
+            continue
+        if ch == "\\":
+            escape = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch == "{":
+            stack.append("}")
+        elif ch == "[":
+            stack.append("]")
+        elif ch in ("}", "]"):
+            if not stack:
+                return None
+            stack.pop()
+    return stack, in_string, escape
+
+
+def parse_partial_json(text: str) -> Any:
+    """Best-effort parse of a possibly-incomplete JSON string.
+
+    Strategy:
+
+    1. Try ``json.loads(text)`` — fast path when the stream happens to
+       be balanced.
+    2. Walk the string to compute the open-bracket stack and whether
+       we're inside a string literal. Append the necessary closing
+       tokens (closing quote, then ``}``/``]`` in reverse open order)
+       and re-attempt parsing.
+    3. If that fails, progressively trim the trailing fragment back to
+       a comma / open-bracket / colon boundary and retry. This handles
+       partial numbers (``42``), partial keywords (``tru``), or partial
+       keys (``"na``).
+
+    Returns the parsed Python value, or ``None`` when no usable parse
+    exists yet. Stripping whitespace at both ends; treats input as
+    UTF-8 text. Designed for object/array roots — bare-literal streams
+    work too but are not the common case.
+    """
+    if not text:
+        return None
+    text = text.strip()
+    if not text:
+        return None
+
+    # Fast path
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    # Compute structural state once
+    state = _scan_state(text)
+    if state is None:
+        return None
+    _stack, _in_string, _trailing_escape = state
+    if _trailing_escape:
+        # Drop the trailing backslash and retry — it's an incomplete escape.
+        text = text[:-1]
+
+    suffix = ""
+    if _in_string:
+        suffix += '"'
+    suffix += "".join(reversed(_stack))
+
+    try:
+        return json.loads(text + suffix)
+    except json.JSONDecodeError:
+        pass
+
+    # Fallback: walk backwards from the end, attempting parse after each cut.
+    # We only cut at "safe" boundaries that won't sit inside a string literal.
+    cut_points: list[int] = []
+    s_in_string = False
+    s_escape = False
+    for i, ch in enumerate(text):
+        if s_escape:
+            s_escape = False
+            continue
+        if ch == "\\":
+            s_escape = True
+            continue
+        if ch == '"':
+            s_in_string = not s_in_string
+            continue
+        if s_in_string:
+            continue
+        if ch in (",", "{", "[", ":", "}", "]"):
+            cut_points.append(i + 1)
+
+    # Try the cut points from the rightmost backwards.
+    for cut in reversed(cut_points):
+        candidate = text[:cut].rstrip(" \t\n\r,:")
+        if not candidate:
+            continue
+        sub_state = _scan_state(candidate)
+        if sub_state is None:
+            continue
+        sub_stack, sub_in_string, sub_escape = sub_state
+        if sub_escape:
+            continue
+        sub_suffix = ""
+        if sub_in_string:
+            sub_suffix += '"'
+        sub_suffix += "".join(reversed(sub_stack))
+        try:
+            return json.loads(candidate + sub_suffix)
+        except json.JSONDecodeError:
+            continue
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Building partial Pydantic models
+# ---------------------------------------------------------------------------
+
+
+def _build_partial_model(model_cls: type[T], data: Any) -> T | None:
+    """Build a non-validated instance of ``model_cls`` from partial data.
+
+    Uses :meth:`BaseModel.model_construct` (Pydantic v2) so missing /
+    not-yet-typed fields don't raise. Returns ``None`` when ``data``
+    isn't a mapping (a partial top-level array, say) — the caller can
+    decide to skip emitting in that case.
+
+    Only keys present in ``model_cls.model_fields`` are forwarded so
+    stray keys the LLM hallucinates don't pollute the partial.
+    """
+    if not isinstance(data, dict):
+        return None
+    field_names = set(model_cls.model_fields.keys())
+    filtered = {k: v for k, v in data.items() if k in field_names}
+    try:
+        return model_cls.model_construct(**filtered)
+    except Exception:
+        logger.debug("Partial model construction failed for %s", model_cls.__name__, exc_info=True)
+        return None
+
+
+def _dump(model: BaseModel) -> dict[str, Any]:
+    """Compare two partial models by their dumped JSON-compatible representation."""
+    try:
+        return model.model_dump(mode="json")
+    except Exception:
+        return model.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Streaming drivers
+# ---------------------------------------------------------------------------
+
+
+def stream_extract(
+    driver: Any,
+    content_prompt: str,
+    model_cls: type[T],
+    *,
+    system_prompt: str | None = None,
+    options: dict[str, Any] | None = None,
+    emit_unchanged: bool = False,
+) -> Iterator[T]:
+    """Yield progressively-filled ``model_cls`` instances from a streaming driver.
+
+    Drives :meth:`Driver.generate_messages_stream` (or equivalent),
+    accumulating delta text, calling :func:`parse_partial_json` after
+    every chunk and yielding a new partial Pydantic instance whenever
+    the parsed-and-filtered snapshot changes.
+
+    Args:
+        driver: Any LLM driver exposing ``generate_messages_stream``.
+        content_prompt: The user prompt the model should respond to.
+            A schema-enforcing instruction is up to the caller — this
+            function does NOT modify the prompt beyond optionally
+            wrapping it as a user-role message.
+        model_cls: Pydantic v2 model to construct partials of.
+        system_prompt: Optional system prompt. When given, sent as the
+            first message in the role=system slot.
+        options: Driver options forwarded to ``generate_messages_stream``.
+        emit_unchanged: When True, yield an instance even when the
+            partial snapshot is identical to the previous one (useful
+            for testing). Defaults to False — only changed snapshots
+            are yielded.
+
+    Yields:
+        A new ``model_cls`` instance after each material change. The
+        final instance may still be a partial if the driver finished
+        before producing a complete object; consumers wanting strict
+        validation should pass the final into ``model_cls(...)``
+        themselves.
+
+    Raises:
+        AttributeError: when ``driver`` has no ``generate_messages_stream``
+            method. Use :func:`prompture.extraction.core.extract_with_model`
+            instead for non-streaming drivers.
+    """
+    if not hasattr(driver, "generate_messages_stream"):
+        raise AttributeError(
+            f"{type(driver).__name__} does not expose generate_messages_stream(); "
+            "use extract_with_model() for non-streaming drivers."
+        )
+
+    messages: list[dict[str, Any]] = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append({"role": "user", "content": content_prompt})
+
+    merged_options = dict(options or {})
+
+    accumulated = ""
+    last_snapshot: dict[str, Any] | None = None
+
+    for chunk in driver.generate_messages_stream(messages, merged_options):
+        if not isinstance(chunk, dict):
+            continue
+        if chunk.get("type") == "delta":
+            piece = chunk.get("text") or ""
+            if not piece:
+                continue
+            accumulated += piece
+            parsed = parse_partial_json(accumulated)
+            partial = _build_partial_model(model_cls, parsed)
+            if partial is None:
+                continue
+            snapshot = _dump(partial)
+            if not emit_unchanged and snapshot == last_snapshot:
+                continue
+            last_snapshot = snapshot
+            yield partial
+        elif chunk.get("type") == "done":
+            # Last shot: if the accumulated text now parses fully, emit one
+            # final, *validated* model so consumers get the strict object.
+            final_text = chunk.get("text") or accumulated
+            try:
+                final_data = json.loads(final_text)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(final_data, dict):
+                continue
+            try:
+                yield model_cls.model_validate(final_data)
+            except Exception:
+                # Final didn't validate — keep the last partial as our best output.
+                logger.debug("Final stream payload didn't validate; consumer keeps last partial.")
+
+
+async def astream_extract(
+    driver: Any,
+    content_prompt: str,
+    model_cls: type[T],
+    *,
+    system_prompt: str | None = None,
+    options: dict[str, Any] | None = None,
+    emit_unchanged: bool = False,
+) -> AsyncIterator[T]:
+    """Async counterpart of :func:`stream_extract`.
+
+    Drives ``async generate_messages_stream`` on the driver. Same
+    semantics, same emission rules — see :func:`stream_extract`.
+    """
+    if not hasattr(driver, "generate_messages_stream"):
+        raise AttributeError(
+            f"{type(driver).__name__} does not expose generate_messages_stream(); "
+            "use extract_with_model() for non-streaming drivers."
+        )
+
+    messages: list[dict[str, Any]] = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append({"role": "user", "content": content_prompt})
+
+    merged_options = dict(options or {})
+
+    accumulated = ""
+    last_snapshot: dict[str, Any] | None = None
+
+    async for chunk in driver.generate_messages_stream(messages, merged_options):
+        if not isinstance(chunk, dict):
+            continue
+        if chunk.get("type") == "delta":
+            piece = chunk.get("text") or ""
+            if not piece:
+                continue
+            accumulated += piece
+            parsed = parse_partial_json(accumulated)
+            partial = _build_partial_model(model_cls, parsed)
+            if partial is None:
+                continue
+            snapshot = _dump(partial)
+            if not emit_unchanged and snapshot == last_snapshot:
+                continue
+            last_snapshot = snapshot
+            yield partial
+        elif chunk.get("type") == "done":
+            final_text = chunk.get("text") or accumulated
+            try:
+                final_data = json.loads(final_text)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(final_data, dict):
+                continue
+            try:
+                yield model_cls.model_validate(final_data)
+            except Exception:
+                logger.debug("Final stream payload didn't validate; consumer keeps last partial.")
+
+
+__all__ = [
+    "astream_extract",
+    "parse_partial_json",
+    "stream_extract",
+]

--- a/prompture/extraction/tools.py
+++ b/prompture/extraction/tools.py
@@ -35,6 +35,22 @@ from pydantic import BaseModel
 
 logger = logging.getLogger("prompture.tools")
 
+# Exception tuple for value-conversion catches. Covers the standard library's
+# numeric / type-coercion paths plus a couple of attribute-access fallbacks
+# the recursive converter relies on. Conversions ultimately bottom out in
+# pydantic / dateutil / tukuy, all of which raise from this set; using this
+# tuple instead of a bare ``except Exception:`` avoids swallowing programmer
+# errors (NameError, ImportError) that should propagate.
+_CONVERSION_ERRORS: tuple[type[BaseException], ...] = (
+    ValueError,
+    TypeError,
+    InvalidOperation,
+    ArithmeticError,
+    AttributeError,
+    OverflowError,
+    LookupError,  # KeyError / IndexError from dict/list coercion
+)
+
 # Lazy Tukuy transformer — tukuy is an optional dependency ([toon] extra).
 _TUKUY = None
 
@@ -183,7 +199,7 @@ def parse_shorthand_number(
     allow_percent: bool = True,
     percent_base: float = 1.0,
     as_decimal: bool | None = None,
-) -> Union[int, float, Decimal]:
+) -> int | float | Decimal:
     """
     Parse a number possibly containing:
     - currency prefix: $1,200
@@ -480,7 +496,7 @@ def convert_value(
                 result = _safe_convert_recursive(value, t)
                 logger.debug("Union conversion succeeded with type %s for value '%s'", t, value)
                 return result
-            except Exception as e:
+            except _CONVERSION_ERRORS as e:
                 conversion_errors.append((t, str(e)))
                 logger.debug("Union conversion failed for type %s: %s", t, e)
 
@@ -500,19 +516,19 @@ def convert_value(
                 try:
                     converted_item = _safe_convert_recursive(item, item_t)
                     result_items.append(converted_item)
-                except Exception as e:
+                except _CONVERSION_ERRORS as e:
                     logger.warning("Failed to convert list item %d '%s' to %s: %s", i, item, item_t, e)
                     # Try to get default for item type
                     try:
                         default_item = get_type_default(item_t)
                         result_items.append(default_item)
-                    except Exception:
+                    except _CONVERSION_ERRORS:
                         # Skip item if we can't get a default
                         continue
 
             return result_items
 
-        except Exception as e:
+        except _CONVERSION_ERRORS as e:
             error_msg = f"Cannot convert '{value}' to list: {e}"
             logger.warning("%s", error_msg)
             return _get_fallback_value(error_msg)
@@ -527,7 +543,7 @@ def convert_value(
                 for item in value:
                     try:
                         converted_items.append(_safe_convert_recursive(item, item_t))
-                    except Exception as e:
+                    except _CONVERSION_ERRORS as e:
                         logger.warning("Failed to convert tuple item '%s': %s", item, e)
                         converted_items.append(get_type_default(item_t))
                 return tuple(converted_items)
@@ -535,15 +551,15 @@ def convert_value(
                 if len(value) != len(args):
                     raise ValueError(f"Expected tuple of len {len(args)}, got {len(value)}")
                 converted_items = []
-                for v, t in zip(value, args):
+                for v, t in zip(value, args, strict=False):
                     try:
                         converted_items.append(_safe_convert_recursive(v, t))
-                    except Exception as e:
+                    except _CONVERSION_ERRORS as e:
                         logger.warning("Failed to convert tuple item '%s' to %s: %s", v, t, e)
                         converted_items.append(get_type_default(t))
                 return tuple(converted_items)
             return tuple(value)
-        except Exception as e:
+        except _CONVERSION_ERRORS as e:
             error_msg = f"Cannot convert '{value}' to tuple: {e}"
             logger.warning("%s", error_msg)
             return _get_fallback_value(error_msg)
@@ -563,14 +579,14 @@ def convert_value(
                     converted_key = _safe_convert_recursive(k, key_t)
                     converted_val = _safe_convert_recursive(v, val_t)
                     result_dict[converted_key] = converted_val
-                except Exception as e:
+                except _CONVERSION_ERRORS as e:
                     logger.warning("Failed to convert dict item %s:%s: %s", k, v, e)
                     # Skip problematic items
                     continue
 
             return result_dict
 
-        except Exception as e:
+        except _CONVERSION_ERRORS as e:
             error_msg = f"Cannot convert '{value}' to dict: {e}"
             logger.warning("%s", error_msg)
             return _get_fallback_value(error_msg)

--- a/prompture/extraction/tools.py
+++ b/prompture/extraction/tools.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import types
 import uuid
 from collections.abc import Mapping
 from datetime import date, datetime, time, timezone
@@ -34,6 +35,16 @@ import dateutil.parser
 from pydantic import BaseModel
 
 logger = logging.getLogger("prompture.tools")
+
+# PEP-604 unions like ``str | None`` have ``get_origin(...)`` returning
+# ``types.UnionType`` instead of ``typing.Union``. Treat both shapes as the
+# same Union so optional fields validate / convert correctly under both
+# annotation styles.
+_UNION_ORIGINS: tuple[Any, ...] = (Union, types.UnionType)
+
+
+def _is_union_origin(origin: Any) -> bool:
+    return origin in _UNION_ORIGINS
 
 # Exception tuple for value-conversion catches. Covers the standard library's
 # numeric / type-coercion paths plus a couple of attribute-access fallbacks
@@ -263,8 +274,8 @@ def _base_schema_for_type(field_name: str, field_type: type[Any]) -> dict[str, A
     origin = get_origin(field_type)
     args = get_args(field_type)
 
-    # Optional / Union
-    if origin is Union:
+    # Optional / Union (handles both typing.Union[X, None] and PEP-604 X | None)
+    if _is_union_origin(origin):
         non_none = [a for a in args if a is not type(None)]
         nullable = len(non_none) < len(args)
         # Prefer single non-none; otherwise treat as "anyOf"
@@ -470,8 +481,9 @@ def convert_value(
         origin = get_origin(target_type)
         args = get_args(target_type)
 
-        # Check if target type is Optional (Union with None)
-        if origin is Union and type(None) in args:
+        # Check if target type is Optional (typing.Union with None OR PEP-604
+        # ``T | None``). Both report different origins; treat them the same.
+        if _is_union_origin(origin) and type(None) in args:
             return None
 
         # For non-optional types, use fallback
@@ -480,8 +492,8 @@ def convert_value(
     origin = get_origin(target_type)
     args = get_args(target_type)
 
-    # Optional / Union - Enhanced with better error recovery
-    if origin is Union:
+    # Optional / Union - handles both typing.Union[X, None] and PEP-604 X | None
+    if _is_union_origin(origin):
         non_none = [a for a in args if a is not type(None)]
         is_optional = type(None) in args
 
@@ -925,8 +937,8 @@ def get_type_default(field_type: type[Any]) -> Any:
     origin = get_origin(field_type)
     args = get_args(field_type)
 
-    # Handle Optional/Union types
-    if origin is Union:
+    # Handle Optional/Union types (typing.Union or PEP-604 X | None)
+    if _is_union_origin(origin):
         non_none = [a for a in args if a is not type(None)]
         if len(non_none) == 1:
             # Optional[T] -> get default for T

--- a/prompture/extraction/tukuy_bridge.py
+++ b/prompture/extraction/tukuy_bridge.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 import contextvars
 import inspect
 import logging
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from ..agents.tools_schema import ToolDefinition, ToolRegistry
 

--- a/prompture/groups/consensus.py
+++ b/prompture/groups/consensus.py
@@ -134,7 +134,7 @@ def _values_equal(a: Any, b: Any, tolerance: float = 0.01) -> bool:
     if isinstance(a, list):
         if len(a) != len(b):
             return False
-        return all(_values_equal(ai, bi, tolerance) for ai, bi in zip(a, b))
+        return all(_values_equal(ai, bi, tolerance) for ai, bi in zip(a, b, strict=False))
 
     return bool(a == b)
 
@@ -165,7 +165,7 @@ def _find_majority_value(values: list[Any]) -> tuple[Any, int]:
     most_common_hashable, count = counter.most_common(1)[0]
 
     # Map back to original value
-    for v, h in zip(values, hashable_values):
+    for v, h in zip(values, hashable_values, strict=False):
         if h == most_common_hashable:
             return v, count
 
@@ -339,7 +339,7 @@ def _compute_weighted_average_consensus(
             # Weighted average for numeric fields
             total_weight = sum(field_weights)
             if total_weight > 0:
-                weighted_sum = sum(v * w for v, w in zip(field_values, field_weights))
+                weighted_sum = sum(v * w for v, w in zip(field_values, field_weights, strict=False))
                 avg_value = weighted_sum / total_weight
                 # Preserve int type if all inputs were ints
                 if all(isinstance(v, int) for v in field_values):

--- a/prompture/groups/types.py
+++ b/prompture/groups/types.py
@@ -14,6 +14,8 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
+from .._internal.json_encoder import PromptureJSONEncoder
+
 
 class ErrorPolicy(enum.Enum):
     """How a group handles agent failures."""
@@ -110,7 +112,7 @@ class GroupResult:
     def save(self, path: str) -> None:
         """Write the exported dict to a JSON file."""
         with open(path, "w", encoding="utf-8") as f:
-            json.dump(self.export(), f, indent=2, default=str)
+            json.dump(self.export(), f, indent=2, cls=PromptureJSONEncoder)
 
 
 @dataclass

--- a/prompture/infra/budget.py
+++ b/prompture/infra/budget.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import enum
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Callable, Union
+from typing import Any
 
 from ..exceptions import BudgetExceededError
 
@@ -161,7 +162,7 @@ class CostEstimate:
     token_counter: str = "heuristic"
 
 
-def _tokens_for(text_or_count: Union[str, int]) -> tuple[int, str]:
+def _tokens_for(text_or_count: str | int) -> tuple[int, str]:
     """Resolve a ``str | int`` to ``(token_count, counter_name)``."""
     if isinstance(text_or_count, int):
         return max(0, text_or_count), "exact"
@@ -179,8 +180,8 @@ def _tokens_for(text_or_count: Union[str, int]) -> tuple[int, str]:
 
 def estimate_call_cost(
     model: str,
-    prompt: Union[str, int],
-    completion: Union[str, int, None] = None,
+    prompt: str | int,
+    completion: str | int | None = None,
     *,
     expected_completion_tokens: int = 500,
 ) -> CostEstimate:

--- a/prompture/infra/cache.py
+++ b/prompture/infra/cache.py
@@ -16,6 +16,8 @@ from collections import OrderedDict
 from pathlib import Path
 from typing import Any
 
+from .._internal.json_encoder import PromptureJSONEncoder
+
 # ---------------------------------------------------------------------------
 # Cache key generation
 # ---------------------------------------------------------------------------
@@ -66,7 +68,7 @@ def make_cache_key(
     if system_prompt is not None:
         parts["system_prompt"] = system_prompt
 
-    blob = json.dumps(parts, sort_keys=True, default=str)
+    blob = json.dumps(parts, sort_keys=True, cls=PromptureJSONEncoder)
     return hashlib.sha256(blob.encode()).hexdigest()
 
 
@@ -236,7 +238,7 @@ class SQLiteCacheBackend(CacheBackend):
                 conn.close()
 
     def set(self, key: str, value: Any, ttl: int | None = None) -> None:
-        value_json = json.dumps(value, default=str)
+        value_json = json.dumps(value, cls=PromptureJSONEncoder)
         now = time.time()
         with self._lock:
             conn = self._connect()
@@ -320,7 +322,7 @@ class RedisCacheBackend(CacheBackend):
         return json.loads(raw)
 
     def set(self, key: str, value: Any, ttl: int | None = None) -> None:
-        value_json = json.dumps(value, default=str)
+        value_json = json.dumps(value, cls=PromptureJSONEncoder)
         if ttl:
             self._client.setex(self._prefixed(key), ttl, value_json)
         else:

--- a/prompture/infra/callbacks.py
+++ b/prompture/infra/callbacks.py
@@ -19,8 +19,9 @@ Usage::
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any
 
 # Type aliases for callback signatures.
 # Each callback receives a single ``dict[str, Any]`` payload and returns nothing.

--- a/prompture/infra/logging.py
+++ b/prompture/infra/logging.py
@@ -26,6 +26,8 @@ import logging
 from datetime import datetime, timezone
 from typing import Any
 
+from .._internal.json_encoder import PromptureJSONEncoder
+
 
 class JSONFormatter(logging.Formatter):
     """Emit each log record as a single JSON line.
@@ -45,7 +47,7 @@ class JSONFormatter(logging.Formatter):
         data = getattr(record, "prompture_data", None)
         if data is not None:
             payload["data"] = data
-        return json.dumps(payload, default=str, ensure_ascii=False)
+        return json.dumps(payload, cls=PromptureJSONEncoder, ensure_ascii=False)
 
 
 def configure_logging(

--- a/prompture/infra/model_rates.py
+++ b/prompture/infra/model_rates.py
@@ -12,7 +12,7 @@ import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ _CACHE_FILE = _CACHE_DIR / "models_dev.json"
 _META_FILE = _CACHE_DIR / "models_dev_meta.json"
 
 _lock = threading.Lock()
-_data: Optional[dict[str, Any]] = None
+_data: dict[str, Any] | None = None
 _loaded = False
 
 # Lifecycle cache: maps models.dev provider name → {model_id: lifecycle_dict}
@@ -88,7 +88,7 @@ def _write_cache(data: dict[str, Any]) -> None:
         logger.debug("Failed to write model rates cache: %s", exc)
 
 
-def _read_cache() -> Optional[dict[str, Any]]:
+def _read_cache() -> dict[str, Any] | None:
     """Read cached API data from disk."""
     try:
         return json.loads(_CACHE_FILE.read_text(encoding="utf-8"))  # type: ignore[no-any-return]
@@ -96,7 +96,7 @@ def _read_cache() -> Optional[dict[str, Any]]:
         return None
 
 
-def _fetch_from_api() -> Optional[dict[str, Any]]:
+def _fetch_from_api() -> dict[str, Any] | None:
     """Fetch fresh data from models.dev API."""
     try:
         import requests
@@ -109,7 +109,7 @@ def _fetch_from_api() -> Optional[dict[str, Any]]:
         return None
 
 
-def _ensure_loaded() -> Optional[dict[str, Any]]:
+def _ensure_loaded() -> dict[str, Any] | None:
     """Lazy-load data: use cache if valid, otherwise fetch from API."""
     global _data, _loaded
     if _loaded:
@@ -139,7 +139,7 @@ def _ensure_loaded() -> Optional[dict[str, Any]]:
         return _data
 
 
-def _strip_to_base_model(model_id: str) -> Optional[str]:
+def _strip_to_base_model(model_id: str) -> str | None:
     """Try to derive the base model name from a versioned or fine-tuned model ID.
 
     Handles common patterns:
@@ -152,7 +152,7 @@ def _strip_to_base_model(model_id: str) -> Optional[str]:
     """
     import re
 
-    candidate: Optional[str] = None
+    candidate: str | None = None
 
     # Fine-tuned models: ft:base-model:rest
     if model_id.startswith("ft:"):
@@ -173,7 +173,7 @@ def _lookup_in_provider(
     data: dict[str, Any],
     api_provider: str,
     model_id: str,
-) -> Optional[dict[str, Any]]:
+) -> dict[str, Any] | None:
     """Lookup a model in a specific provider's data, with base-model fallback."""
     provider_data = data.get(api_provider)
     if not isinstance(provider_data, dict):
@@ -197,7 +197,7 @@ def _lookup_in_provider(
     return None
 
 
-def _lookup_model(provider: str, model_id: str) -> Optional[dict[str, Any]]:
+def _lookup_model(provider: str, model_id: str) -> dict[str, Any] | None:
     """Find a model entry in the cached data.
 
     The API structure is ``{provider: {model_id: {...}, ...}, ...}``.
@@ -254,7 +254,7 @@ def _lookup_model(provider: str, model_id: str) -> Optional[dict[str, Any]]:
 # ── Public API ──────────────────────────────────────────────────────────────
 
 
-def get_model_rates(provider: str, model_id: str) -> Optional[dict[str, float]]:
+def get_model_rates(provider: str, model_id: str) -> dict[str, float] | None:
     """Return pricing dict for a model, or ``None`` if unavailable.
 
     Resolution is delegated to the pluggable :mod:`pricing` registry —
@@ -272,7 +272,7 @@ def get_model_rates(provider: str, model_id: str) -> Optional[dict[str, float]]:
     return resolve_rates(provider, model_id)
 
 
-def get_model_info(provider: str, model_id: str) -> Optional[dict[str, Any]]:
+def get_model_info(provider: str, model_id: str) -> dict[str, Any] | None:
     """Return full model metadata (cost, limits, capabilities), or ``None``."""
     return _lookup_model(provider, model_id)
 
@@ -335,17 +335,17 @@ class ModelCapabilities:
     "the model doesn't support X" from "we have no data about X".
     """
 
-    supports_temperature: Optional[bool] = None
-    supports_tool_use: Optional[bool] = None
-    supports_structured_output: Optional[bool] = None
-    supports_vision: Optional[bool] = None
-    is_reasoning: Optional[bool] = None
-    context_window: Optional[int] = None
-    max_output_tokens: Optional[int] = None
+    supports_temperature: bool | None = None
+    supports_tool_use: bool | None = None
+    supports_structured_output: bool | None = None
+    supports_vision: bool | None = None
+    is_reasoning: bool | None = None
+    context_window: int | None = None
+    max_output_tokens: int | None = None
     modalities_input: tuple[str, ...] = ()
     modalities_output: tuple[str, ...] = ()
-    api_type: Optional[str] = None  # "openai", "anthropic", "google", "openai-compatible"
-    tokens_param: Optional[str] = None  # "max_tokens" or "max_completion_tokens"
+    api_type: str | None = None  # "openai", "anthropic", "google", "openai-compatible"
+    tokens_param: str | None = None  # "max_tokens" or "max_completion_tokens"
 
 
 # Capabilities KB loaded from per-provider JSON files in rates/
@@ -378,7 +378,7 @@ def _load_capabilities() -> dict[tuple[str, str], "ModelCapabilities"]:
 _CAPABILITIES_KB = _load_capabilities()
 
 
-def _lookup_kb(provider: str, model_id: str) -> Optional[ModelCapabilities]:
+def _lookup_kb(provider: str, model_id: str) -> ModelCapabilities | None:
     """Look up model in hardcoded capabilities knowledge base.
 
     Tries exact match first, then falls back to stripping date suffixes
@@ -397,19 +397,19 @@ def _lookup_kb(provider: str, model_id: str) -> Optional[ModelCapabilities]:
 def _parse_capabilities_from_entry(entry: dict[str, Any]) -> ModelCapabilities:
     """Parse a models.dev entry dict into a :class:`ModelCapabilities` instance."""
     # Boolean capabilities (True/False/None)
-    supports_temperature: Optional[bool] = None
+    supports_temperature: bool | None = None
     if "temperature" in entry:
         supports_temperature = bool(entry["temperature"])
 
-    supports_tool_use: Optional[bool] = None
+    supports_tool_use: bool | None = None
     if "tool_call" in entry:
         supports_tool_use = bool(entry["tool_call"])
 
-    supports_structured_output: Optional[bool] = None
+    supports_structured_output: bool | None = None
     if "structured_output" in entry:
         supports_structured_output = bool(entry["structured_output"])
 
-    is_reasoning: Optional[bool] = None
+    is_reasoning: bool | None = None
     if "reasoning" in entry:
         is_reasoning = bool(entry["reasoning"])
 
@@ -425,13 +425,13 @@ def _parse_capabilities_from_entry(entry: dict[str, Any]) -> ModelCapabilities:
         if isinstance(raw_out, (list, tuple)):
             modalities_output = tuple(str(m) for m in raw_out)
 
-    supports_vision: Optional[bool] = None
+    supports_vision: bool | None = None
     if modalities_input:
         supports_vision = "image" in modalities_input
 
     # Limits
-    context_window: Optional[int] = None
-    max_output_tokens: Optional[int] = None
+    context_window: int | None = None
+    max_output_tokens: int | None = None
     limits = entry.get("limit", {})
     if isinstance(limits, dict):
         ctx = limits.get("context")
@@ -456,7 +456,7 @@ def _parse_capabilities_from_entry(entry: dict[str, Any]) -> ModelCapabilities:
     )
 
 
-def get_model_capabilities(provider: str, model_id: str) -> Optional[ModelCapabilities]:
+def get_model_capabilities(provider: str, model_id: str) -> ModelCapabilities | None:
     """Return capability metadata for a model, or ``None`` if unavailable.
 
     Resolution order:
@@ -535,7 +535,7 @@ def _compute_family_status(provider_api_name: str) -> dict[str, dict[str, Any]]:
     now = datetime.now(timezone.utc)
 
     # Build per-family lists: {family: [(model_id, entry, release_date, is_latest_marker), ...]}
-    families: dict[str, list[tuple[str, dict[str, Any], Optional[datetime], bool]]] = {}
+    families: dict[str, list[tuple[str, dict[str, Any], datetime | None, bool]]] = {}
     for model_id, entry in models.items():
         if not isinstance(entry, dict):
             continue
@@ -544,7 +544,7 @@ def _compute_family_status(provider_api_name: str) -> dict[str, dict[str, Any]]:
         name = entry.get("name", "")
         is_latest_marker = "(latest)" in name.lower() if name else False
 
-        release_date: Optional[datetime] = None
+        release_date: datetime | None = None
         raw_date = entry.get("release_date")
         if raw_date:
             with contextlib.suppress(Exception):
@@ -588,12 +588,12 @@ def _compute_family_status(provider_api_name: str) -> dict[str, dict[str, Any]]:
                 status = "current" if i == current_idx else "unknown"
 
             # Compute superseded_by: next newer model in the family
-            superseded_by: Optional[str] = None
+            superseded_by: str | None = None
             if i > current_idx and i > 0:
                 superseded_by = members[i - 1][0]
 
             # Estimate end_of_support for legacy/deprecated: release_date + 24 months
-            end_of_support: Optional[str] = None
+            end_of_support: str | None = None
             if status in ("legacy", "deprecated") and release_date is not None:
                 eos = release_date + timedelta(days=730)  # ~24 months
                 end_of_support = eos.strftime("%Y-%m-%d")
@@ -624,7 +624,7 @@ def _infer_family(model_id: str) -> str:
     return stripped
 
 
-def get_model_lifecycle(provider: str, model_id: str) -> Optional[dict[str, Any]]:
+def get_model_lifecycle(provider: str, model_id: str) -> dict[str, Any] | None:
     """Return lifecycle/deprecation metadata for a model.
 
     Returns a dict with keys: ``status``, ``family``, ``release_date``,

--- a/prompture/infra/settings.py
+++ b/prompture/infra/settings.py
@@ -1,4 +1,3 @@
-
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 

--- a/prompture/infra/settings.py
+++ b/prompture/infra/settings.py
@@ -1,4 +1,3 @@
-from typing import Optional
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -10,157 +9,157 @@ class Settings(BaseSettings):
     ai_provider: str = "ollama"
 
     # OpenAI
-    openai_api_key: Optional[str] = None
+    openai_api_key: str | None = None
     openai_model: str = "gpt-3.5-turbo"
 
     # Claude
-    claude_api_key: Optional[str] = None
+    claude_api_key: str | None = None
     claude_model: str = "claude-3-haiku-20240307"
 
     # HuggingFace
-    hf_endpoint: Optional[str] = None
-    hf_token: Optional[str] = None
+    hf_endpoint: str | None = None
+    hf_token: str | None = None
 
     # Ollama
     ollama_endpoint: str = "http://localhost:11434/api/generate"
     ollama_model: str = "llama2"
 
     # Azure (default / OpenAI backend)
-    azure_api_key: Optional[str] = None
-    azure_api_endpoint: Optional[str] = None
-    azure_deployment_id: Optional[str] = None
+    azure_api_key: str | None = None
+    azure_api_endpoint: str | None = None
+    azure_deployment_id: str | None = None
 
     # Azure - Claude backend (optional)
-    azure_claude_api_key: Optional[str] = None
-    azure_claude_endpoint: Optional[str] = None
-    azure_claude_api_version: Optional[str] = None
+    azure_claude_api_key: str | None = None
+    azure_claude_endpoint: str | None = None
+    azure_claude_api_version: str | None = None
 
     # Azure - Mistral backend (optional)
-    azure_mistral_api_key: Optional[str] = None
-    azure_mistral_endpoint: Optional[str] = None
-    azure_mistral_api_version: Optional[str] = None
+    azure_mistral_api_key: str | None = None
+    azure_mistral_endpoint: str | None = None
+    azure_mistral_api_version: str | None = None
 
     # LM Studio
     lmstudio_endpoint: str = "http://127.0.0.1:1234/v1/chat/completions"
     lmstudio_model: str = "deepseek/deepseek-r1-0528-qwen3-8b"
-    lmstudio_api_key: Optional[str] = None
+    lmstudio_api_key: str | None = None
 
     # Google
-    google_api_key: Optional[str] = None
+    google_api_key: str | None = None
     google_model: str = "gemini-1.5-pro"
 
     # Google Vertex AI (Gemini + Claude via Model Garden)
-    google_vertex_api_key: Optional[str] = None
-    google_vertex_project_id: Optional[str] = None
+    google_vertex_api_key: str | None = None
+    google_vertex_project_id: str | None = None
     google_vertex_location: str = "us-central1"
     google_vertex_model: str = "gemini-2.5-flash"
-    google_vertex_access_token: Optional[str] = None
+    google_vertex_access_token: str | None = None
 
     # Groq
-    groq_api_key: Optional[str] = None
+    groq_api_key: str | None = None
     groq_model: str = "llama2-70b-4096"
 
     # OpenRouter
-    openrouter_api_key: Optional[str] = None
+    openrouter_api_key: str | None = None
     openrouter_model: str = "openai/gpt-4o-mini"
 
     # Grok
-    grok_api_key: Optional[str] = None
-    xai_api_key: Optional[str] = None
+    grok_api_key: str | None = None
+    xai_api_key: str | None = None
     grok_model: str = "grok-4-fast-reasoning"
     grok_video_model: str = "grok-imagine-video"
 
     # Moonshot AI (Kimi)
-    moonshot_api_key: Optional[str] = None
+    moonshot_api_key: str | None = None
     moonshot_model: str = "kimi-k2-0905-preview"
     moonshot_endpoint: str = "https://api.moonshot.ai/v1"
 
     # Z.ai (Zhipu AI)
-    zhipu_api_key: Optional[str] = None
+    zhipu_api_key: str | None = None
     zhipu_model: str = "glm-4.7"
     zhipu_endpoint: str = "https://api.z.ai/api/paas/v4"
 
     # ModelScope (Alibaba Cloud)
-    modelscope_api_key: Optional[str] = None
+    modelscope_api_key: str | None = None
     modelscope_model: str = "Qwen/Qwen3-235B-A22B-Instruct-2507"
     modelscope_endpoint: str = "https://api-inference.modelscope.cn/v1"
 
     # AirLLM
     airllm_model: str = "meta-llama/Llama-2-7b-hf"
-    airllm_compression: Optional[str] = None  # "4bit" or "8bit"
+    airllm_compression: str | None = None  # "4bit" or "8bit"
 
     # CachiBot.ai (proxy)
-    cachibot_api_key: Optional[str] = None
+    cachibot_api_key: str | None = None
     cachibot_endpoint: str = "https://cachibot.ai/api/v1"
 
     # Stability AI (image generation)
-    stability_api_key: Optional[str] = None
-    stability_endpoint: Optional[str] = None
+    stability_api_key: str | None = None
+    stability_endpoint: str | None = None
 
     # Runway (image generation via /v1/text_to_image)
-    runway_api_key: Optional[str] = None
-    runway_endpoint: Optional[str] = None
+    runway_api_key: str | None = None
+    runway_endpoint: str | None = None
 
     # Kling AI (image + video generation)
-    kling_access_key: Optional[str] = None
-    kling_secret_key: Optional[str] = None
-    kling_endpoint: Optional[str] = None
+    kling_access_key: str | None = None
+    kling_secret_key: str | None = None
+    kling_endpoint: str | None = None
     kling_image_model: str = "kling-v2-1"
     kling_video_model: str = "kling-v2-1"
 
     # MiniMax / Hailuo (LLM + video generation)
-    minimax_api_key: Optional[str] = None
-    hailuo_api_key: Optional[str] = None
+    minimax_api_key: str | None = None
+    hailuo_api_key: str | None = None
     minimax_endpoint: str = "https://api.minimax.io/v1"
     minimax_model: str = "MiniMax-Text-01"
     minimax_video_model: str = "MiniMax-Hailuo-2.3"
 
     # Fal.ai (image + video generation aggregator)
-    fal_api_key: Optional[str] = None
-    fal_endpoint: Optional[str] = None
+    fal_api_key: str | None = None
+    fal_endpoint: str | None = None
     fal_image_model: str = "fal-ai/flux/dev"
     fal_video_model: str = "fal-ai/kling-video/v2.6/pro/image-to-video"
 
     # Luma AI (Dream Machine — video generation)
-    luma_api_key: Optional[str] = None  # nosec B105
+    luma_api_key: str | None = None  # nosec B105
     luma_video_model: str = "ray-2"
 
     # Pika Labs (video generation)
-    pika_api_key: Optional[str] = None  # nosec B105
+    pika_api_key: str | None = None  # nosec B105
     pika_video_model: str = "pika-2.2"
 
     # Phase 7: Ideogram (image generation)
-    ideogram_api_key: Optional[str] = None  # nosec B105
+    ideogram_api_key: str | None = None  # nosec B105
     ideogram_image_model: str = "ideogram-v3"
 
     # Phase 7: Black Forest Labs (BFL) — direct Flux access
-    bfl_api_key: Optional[str] = None  # nosec B105
+    bfl_api_key: str | None = None  # nosec B105
     bfl_image_model: str = "flux-pro-1.1"
 
     # Mistral AI
-    mistral_api_key: Optional[str] = None
+    mistral_api_key: str | None = None
     mistral_model: str = "mistral-large-latest"
 
     # DeepSeek
-    deepseek_api_key: Optional[str] = None
+    deepseek_api_key: str | None = None
     deepseek_model: str = "deepseek-chat"
 
     # OpenAI-compatible aggregators (used via the openai_compatible driver
     # with a `profile=` arg). Each setting is consumed lazily — only the
     # profile you actually use needs its key set.
-    fireworks_api_key: Optional[str] = None
-    together_api_key: Optional[str] = None
-    cerebras_api_key: Optional[str] = None
-    sambanova_api_key: Optional[str] = None
-    perplexity_api_key: Optional[str] = None
-    nvidia_api_key: Optional[str] = None
-    deepinfra_api_key: Optional[str] = None
-    siliconflow_api_key: Optional[str] = None
+    fireworks_api_key: str | None = None
+    together_api_key: str | None = None
+    cerebras_api_key: str | None = None
+    sambanova_api_key: str | None = None
+    perplexity_api_key: str | None = None
+    nvidia_api_key: str | None = None
+    deepinfra_api_key: str | None = None
+    siliconflow_api_key: str | None = None
 
     # Phase 2: Rerank providers
-    cohere_api_key: Optional[str] = None
-    voyage_api_key: Optional[str] = None
-    jina_api_key: Optional[str] = None
+    cohere_api_key: str | None = None
+    voyage_api_key: str | None = None
+    jina_api_key: str | None = None
 
     # Phase 3: Cohere LLM + Cohere/Voyage/Jina embedding model defaults
     cohere_model: str = "command-r-plus"
@@ -169,38 +168,38 @@ class Settings(BaseSettings):
     jina_embedding_model: str = "jina-embeddings-v3"
 
     # Phase 4: AWS Bedrock
-    aws_access_key_id: Optional[str] = None  # nosec B105
-    aws_secret_access_key: Optional[str] = None  # nosec B105
+    aws_access_key_id: str | None = None  # nosec B105
+    aws_secret_access_key: str | None = None  # nosec B105
     aws_region: str = "us-east-1"
     bedrock_model: str = "anthropic.claude-3-5-haiku-20241022-v1:0"
 
     # ElevenLabs (audio)
-    elevenlabs_api_key: Optional[str] = None
+    elevenlabs_api_key: str | None = None
     elevenlabs_tts_model: str = "eleven_multilingual_v2"
     elevenlabs_endpoint: str = "https://api.elevenlabs.io/v1"
 
     # Phase 5: Audio providers (Cartesia, Deepgram, AssemblyAI)
-    cartesia_api_key: Optional[str] = None  # nosec B105
+    cartesia_api_key: str | None = None  # nosec B105
     cartesia_tts_model: str = "sonic-2"
 
-    deepgram_api_key: Optional[str] = None  # nosec B105
+    deepgram_api_key: str | None = None  # nosec B105
     deepgram_stt_model: str = "nova-3"
     deepgram_tts_model: str = "aura-2-thalia-en"
 
-    assemblyai_api_key: Optional[str] = None  # nosec B105
+    assemblyai_api_key: str | None = None  # nosec B105
     assemblyai_stt_model: str = "universal"
 
     # Phase 8: Nomic, Mixedbread, GitHub Models
-    nomic_api_key: Optional[str] = None  # nosec B105
+    nomic_api_key: str | None = None  # nosec B105
     nomic_embedding_model: str = "nomic-embed-text-v1.5"
 
-    mixedbread_api_key: Optional[str] = None  # nosec B105
+    mixedbread_api_key: str | None = None  # nosec B105
     mxbai_embedding_model: str = "mxbai-embed-large-v1"
     mxbai_rerank_model: str = "mxbai-rerank-large-v1"
 
     # GitHub Models — used through the openai_compatible driver
     # (profile=github_models). A GitHub Personal Access Token.
-    github_token: Optional[str] = None  # nosec B105
+    github_token: str | None = None  # nosec B105
 
     # Model rates cache
     model_rates_ttl_days: int = 7  # How often to refresh models.dev cache
@@ -216,7 +215,7 @@ class Settings(BaseSettings):
 
     # Usage tracking
     usage_tracking_enabled: bool = False
-    usage_db_path: Optional[str] = None  # default ~/.prompture/usage/usage.db
+    usage_db_path: str | None = None  # default ~/.prompture/usage/usage.db
     usage_flush_threshold: int = 10  # batch writes before flushing
 
     # Response cache
@@ -224,24 +223,24 @@ class Settings(BaseSettings):
     cache_backend: str = "memory"
     cache_ttl_seconds: int = 3600
     cache_memory_maxsize: int = 256
-    cache_sqlite_path: Optional[str] = None
-    cache_redis_url: Optional[str] = None
+    cache_sqlite_path: str | None = None
+    cache_redis_url: str | None = None
 
     # Web search providers (used by prompture.tools.WebSearchTool)
-    tavily_api_key: Optional[str] = None
-    serper_api_key: Optional[str] = None
-    brave_search_api_key: Optional[str] = None
-    searxng_endpoint: Optional[str] = None
+    tavily_api_key: str | None = None
+    serper_api_key: str | None = None
+    brave_search_api_key: str | None = None
+    searxng_endpoint: str | None = None
 
     # Coding-agent CLI binary overrides (env var: CODING_AGENT_BIN_<UPPER>)
-    coding_agent_bin_claude: Optional[str] = None
-    coding_agent_bin_codex: Optional[str] = None
-    coding_agent_bin_gemini: Optional[str] = None
-    coding_agent_bin_qwen: Optional[str] = None
-    coding_agent_bin_aider: Optional[str] = None
-    coding_agent_bin_opencode: Optional[str] = None
-    coding_agent_bin_cursor_agent: Optional[str] = None
-    coding_agent_bin_crush: Optional[str] = None
+    coding_agent_bin_claude: str | None = None
+    coding_agent_bin_codex: str | None = None
+    coding_agent_bin_gemini: str | None = None
+    coding_agent_bin_qwen: str | None = None
+    coding_agent_bin_aider: str | None = None
+    coding_agent_bin_opencode: str | None = None
+    coding_agent_bin_cursor_agent: str | None = None
+    coding_agent_bin_crush: str | None = None
 
     # Document ingestion
     ingest_max_file_size: int = 52428800  # 50 MB

--- a/prompture/infra/tracker.py
+++ b/prompture/infra/tracker.py
@@ -411,7 +411,7 @@ class UsageTracker:
     # ------------------------------------------------------------------ #
 
     @contextlib.contextmanager
-    def session(self, session_id: str | None = None) -> Generator[str, None, None]:
+    def session(self, session_id: str | None = None) -> Generator[str]:
         """Set the session scope for nested calls."""
         sid = session_id or str(uuid.uuid4())
         token = _ctx_session_id.set(sid)
@@ -421,7 +421,7 @@ class UsageTracker:
             _ctx_session_id.reset(token)
 
     @contextlib.contextmanager
-    def conversation(self, conversation_id: str) -> Generator[str, None, None]:
+    def conversation(self, conversation_id: str) -> Generator[str]:
         """Set the conversation scope for nested calls."""
         token = _ctx_conversation_id.set(conversation_id)
         try:
@@ -430,7 +430,7 @@ class UsageTracker:
             _ctx_conversation_id.reset(token)
 
     @contextlib.contextmanager
-    def agent(self, agent_id: str) -> Generator[str, None, None]:
+    def agent(self, agent_id: str) -> Generator[str]:
         """Set the agent scope for nested calls."""
         token = _ctx_agent_id.set(agent_id)
         try:
@@ -439,7 +439,7 @@ class UsageTracker:
             _ctx_agent_id.reset(token)
 
     @contextlib.contextmanager
-    def tool(self, tool_name: str) -> Generator[str, None, None]:
+    def tool(self, tool_name: str) -> Generator[str]:
         """Set the tool scope for nested calls."""
         token = _ctx_tool_name.set(tool_name)
         try:
@@ -448,7 +448,7 @@ class UsageTracker:
             _ctx_tool_name.reset(token)
 
     @contextlib.contextmanager
-    def operation(self, operation_name: str) -> Generator[str, None, None]:
+    def operation(self, operation_name: str) -> Generator[str]:
         """Set the operation scope for nested calls."""
         token = _ctx_operation.set(operation_name)
         try:

--- a/prompture/ingestion/parsers/__init__.py
+++ b/prompture/ingestion/parsers/__init__.py
@@ -7,7 +7,7 @@ Follows the same lazy-factory pattern used by
 from __future__ import annotations
 
 import logging
-from typing import Callable
+from collections.abc import Callable
 
 from .base import BaseParser
 

--- a/prompture/integrations/tukuy_bridge.py
+++ b/prompture/integrations/tukuy_bridge.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 import contextvars
 import inspect
 import logging
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from ..agents.tools_schema import ToolDefinition, ToolRegistry
 

--- a/prompture/kg/__init__.py
+++ b/prompture/kg/__init__.py
@@ -1,0 +1,43 @@
+"""Knowledge-graph entity store for Prompture.
+
+Tracks entities (people, organisations, products, places) and the
+relations between them as documents flow through extraction.  Designed
+to pair with:
+
+- :mod:`prompture.swarm` — agents can attach extracted entities to the
+  shared environment.
+- :mod:`prompture.rag` — retrievers can ground citations against
+  entity-mention spans.
+- :mod:`prompture.extraction` — :func:`extract_entities` uses the
+  existing Pydantic-typed extraction machinery.
+
+Three layers:
+
+- :class:`Entity`, :class:`Relation`, :class:`Mention` — graph atoms.
+- :class:`EntityStore` — pluggable backend protocol.  Ships with
+  :class:`InMemoryEntityStore` and :class:`SQLiteEntityStore`.
+- :class:`KnowledgeGraph` — high-level API: ``upsert_entity`` /
+  ``add_relation`` / ``mention`` / ``neighbors`` / ``find``.
+- :func:`extract_entities` / :func:`extract_relations` — LLM-backed
+  helpers that consume free text and populate the graph.
+"""
+
+from .core import KnowledgeGraph, extract_entities, extract_relations
+from .stores import (
+    EntityStore,
+    InMemoryEntityStore,
+    SQLiteEntityStore,
+)
+from .types import Entity, Mention, Relation
+
+__all__ = [
+    "Entity",
+    "EntityStore",
+    "InMemoryEntityStore",
+    "KnowledgeGraph",
+    "Mention",
+    "Relation",
+    "SQLiteEntityStore",
+    "extract_entities",
+    "extract_relations",
+]

--- a/prompture/kg/core.py
+++ b/prompture/kg/core.py
@@ -1,0 +1,367 @@
+"""High-level :class:`KnowledgeGraph` API and LLM-backed extraction helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
+
+from .stores import EntityStore, InMemoryEntityStore
+from .types import Entity, Mention, Relation
+
+if TYPE_CHECKING:
+    pass
+
+
+class KnowledgeGraph:
+    """Convenience facade over an :class:`EntityStore`.
+
+    The store does the raw bookkeeping; this class layers on the
+    ergonomics callers actually want: entity resolution by name,
+    one-call ``upsert_entity`` returning a typed :class:`Entity`,
+    neighbourhood traversal, and helpers that pair with the
+    :func:`extract_entities` / :func:`extract_relations` LLM extractors.
+
+    Args:
+        store: Backing :class:`EntityStore`.  Defaults to
+            :class:`InMemoryEntityStore`.
+
+    Example::
+
+        kg = KnowledgeGraph()
+        sam = kg.upsert_entity("Sam Altman", type="person")
+        oai = kg.upsert_entity("OpenAI", type="organization")
+        kg.add_relation(sam, "works_at", oai)
+        for r in kg.neighbors(sam):
+            print(r.predicate, "→", kg.get(r.object_id).name)
+    """
+
+    def __init__(self, store: EntityStore | None = None) -> None:
+        self._store: EntityStore = store if store is not None else InMemoryEntityStore()
+
+    # ------------------------------------------------------------------
+    # Direct accessors
+    # ------------------------------------------------------------------
+
+    @property
+    def store(self) -> EntityStore:
+        return self._store
+
+    def get(self, entity_id: str) -> Entity | None:
+        """Return an entity by id, or ``None`` if not found."""
+        return self._store.get_entity(entity_id)
+
+    def find(
+        self,
+        *,
+        name: str | None = None,
+        type: str | None = None,
+        limit: int | None = None,
+    ) -> list[Entity]:
+        """Search entities by name (exact, case-insensitive, alias-aware) or type."""
+        return self._store.find_entities(name=name, type=type, limit=limit)
+
+    def resolve(self, name: str, *, type: str | None = None) -> Entity | None:
+        """Look up the most recently-updated entity matching *name*.
+
+        Returns ``None`` when no match exists.  Filters by *type* when
+        supplied — useful when names collide across categories
+        (``Paris`` the city vs ``Paris`` the person).
+        """
+        matches = self.find(name=name, type=type, limit=1)
+        return matches[0] if matches else None
+
+    # ------------------------------------------------------------------
+    # Mutations
+    # ------------------------------------------------------------------
+
+    def upsert_entity(
+        self,
+        name_or_entity: str | Entity,
+        *,
+        type: str = "thing",
+        aliases: Iterable[str] = (),
+        attributes: dict[str, Any] | None = None,
+        entity_id: str | None = None,
+    ) -> Entity:
+        """Insert a new entity or merge into an existing one.
+
+        Accepts either a fully-built :class:`Entity` (returned
+        unchanged after persisting) or a name + descriptor pair.
+
+        Merge semantics:
+        - The id is the canonical key.  If *entity_id* is omitted, the
+          name+type slug from :meth:`Entity.make_id` is used.
+        - Aliases and attributes are *merged* with any existing record;
+          attribute values supplied here win on conflict.
+        - The most recent timestamp wins.
+        """
+        if isinstance(name_or_entity, Entity):
+            self._store.upsert_entity(name_or_entity)
+            return name_or_entity
+
+        eid = entity_id or Entity.make_id(name_or_entity, type=type)
+        existing = self._store.get_entity(eid)
+        if existing is not None:
+            merged_aliases = tuple(dict.fromkeys((*existing.aliases, *aliases)))
+            merged_attrs = {**existing.attributes, **(attributes or {})}
+            entity = Entity(
+                id=eid,
+                name=name_or_entity or existing.name,
+                type=type or existing.type,
+                aliases=merged_aliases,
+                attributes=merged_attrs,
+            )
+        else:
+            entity = Entity(
+                id=eid,
+                name=name_or_entity,
+                type=type,
+                aliases=tuple(aliases),
+                attributes=dict(attributes or {}),
+            )
+        self._store.upsert_entity(entity)
+        return entity
+
+    def add_relation(
+        self,
+        subject: str | Entity,
+        predicate: str,
+        object: str | Entity,
+        *,
+        attributes: dict[str, Any] | None = None,
+    ) -> Relation:
+        """Record a directed edge between two entities.
+
+        Strings are resolved against the graph; unknown names are
+        upserted as ``type="thing"`` so the edge always lands on real
+        nodes.
+        """
+        subj_id = subject.id if isinstance(subject, Entity) else self.upsert_entity(subject).id
+        obj_id = object.id if isinstance(object, Entity) else self.upsert_entity(object).id
+        relation = Relation(
+            subject_id=subj_id,
+            predicate=predicate,
+            object_id=obj_id,
+            attributes=dict(attributes or {}),
+        )
+        self._store.add_relation(relation)
+        return relation
+
+    def mention(
+        self,
+        entity: str | Entity,
+        text: str,
+        *,
+        source: str | None = None,
+        start: int | None = None,
+        end: int | None = None,
+        confidence: float = 1.0,
+        attributes: dict[str, Any] | None = None,
+    ) -> Mention:
+        """Record a surface-form mention of an entity in a document.
+
+        String *entity* values are resolved or upserted as
+        ``type="thing"``.
+        """
+        ent = entity if isinstance(entity, Entity) else self.upsert_entity(entity)
+        m = Mention(
+            entity_id=ent.id,
+            text=text,
+            source=source,
+            start=start,
+            end=end,
+            confidence=confidence,
+            attributes=dict(attributes or {}),
+        )
+        self._store.add_mention(m)
+        return m
+
+    # ------------------------------------------------------------------
+    # Graph queries
+    # ------------------------------------------------------------------
+
+    def neighbors(
+        self,
+        entity: str | Entity,
+        *,
+        predicate: str | None = None,
+        direction: str = "both",
+    ) -> list[Relation]:
+        """Return relations touching *entity*.
+
+        Args:
+            entity: An :class:`Entity` or its id.
+            predicate: Restrict to a specific predicate when set.
+            direction: ``"out"`` (subject only), ``"in"`` (object
+                only), or ``"both"`` (default).
+        """
+        eid = entity.id if isinstance(entity, Entity) else entity
+        as_subject = direction in ("out", "both")
+        as_object = direction in ("in", "both")
+        return self._store.relations_for(
+            eid,
+            as_subject=as_subject,
+            as_object=as_object,
+            predicate=predicate,
+        )
+
+    def mentions(self, entity: str | Entity) -> list[Mention]:
+        """Return every mention of *entity*."""
+        eid = entity.id if isinstance(entity, Entity) else entity
+        return self._store.mentions_for(eid)
+
+
+# ----------------------------------------------------------------------
+# LLM-backed extraction helpers
+# ----------------------------------------------------------------------
+
+
+_ENTITY_EXTRACTION_PROMPT = (
+    "Extract every distinct entity mentioned in the text. "
+    "Return a JSON array where each element has 'name' (canonical "
+    "display name), 'type' (one of: person, organization, location, "
+    "product, event, concept, other), and 'aliases' (array of "
+    "alternative surface forms found in the text). "
+    "Do not include duplicates."
+)
+
+_RELATION_EXTRACTION_PROMPT = (
+    "Extract every directed relation between entities in the text. "
+    "Return a JSON array where each element has 'subject' (entity name), "
+    "'predicate' (verb-like phrase in snake_case, e.g. 'works_at', "
+    "'located_in', 'founded'), and 'object' (entity name). "
+    "Only emit relations explicitly supported by the text."
+)
+
+
+def _resolve_extract_with_model() -> Any:
+    """Lazy import to avoid a heavy dependency at module import time."""
+    from ..extraction.core import extract_with_model
+
+    return extract_with_model
+
+
+def extract_entities(
+    text: str,
+    *,
+    model: str,
+    graph: KnowledgeGraph | None = None,
+    source: str | None = None,
+    instruction: str = _ENTITY_EXTRACTION_PROMPT,
+) -> list[Entity]:
+    """Extract entities from free text using an LLM and upsert into *graph*.
+
+    Uses :func:`prompture.extraction.extract_with_model` with an inline
+    Pydantic schema, so it benefits from the same retry / cleanup
+    handling as the rest of the extraction stack.
+
+    Args:
+        text: Free-form text to analyse.
+        model: Provider/model string (e.g. ``"openai/gpt-4o-mini"``).
+        graph: When supplied, every extracted entity is upserted into
+            it and surface-form mentions are recorded.  When ``None``
+            entities are still returned but nothing is persisted.
+        source: Document id propagated onto :class:`Mention` records.
+        instruction: Override the default extraction directive.
+
+    Returns:
+        List of :class:`Entity` records (newly created or upserted).
+    """
+    from pydantic import BaseModel, Field
+
+    extract_with_model = _resolve_extract_with_model()
+
+    class _ExtractedEntity(BaseModel):
+        name: str = Field(..., description="Canonical display name")
+        type: str = Field("other", description="Coarse class")
+        aliases: list[str] = Field(default_factory=list)
+
+    class _EntityList(BaseModel):
+        entities: list[_ExtractedEntity] = Field(default_factory=list)
+
+    result = extract_with_model(
+        _EntityList,
+        text,
+        model=model,
+        instruction_template=instruction,
+    )
+
+    extracted: list[_ExtractedEntity] = []
+    payload = getattr(result, "data", result)
+    if isinstance(payload, _EntityList):
+        extracted = payload.entities
+    elif isinstance(payload, dict) and "entities" in payload:
+        extracted = [_ExtractedEntity.model_validate(e) for e in payload["entities"]]
+
+    entities: list[Entity] = []
+    for item in extracted:
+        if graph is not None:
+            ent = graph.upsert_entity(item.name, type=item.type, aliases=tuple(item.aliases))
+            for alias in [item.name, *item.aliases]:
+                if alias and alias in text:
+                    graph.mention(ent, alias, source=source)
+        else:
+            ent = Entity(
+                id=Entity.make_id(item.name, type=item.type),
+                name=item.name,
+                type=item.type,
+                aliases=tuple(item.aliases),
+            )
+        entities.append(ent)
+    return entities
+
+
+def extract_relations(
+    text: str,
+    *,
+    model: str,
+    graph: KnowledgeGraph,
+    instruction: str = _RELATION_EXTRACTION_PROMPT,
+) -> list[Relation]:
+    """Extract directed relations from text and add them to *graph*.
+
+    Subjects/objects are resolved against existing entities by name
+    (case-insensitive, alias-aware); unknown names are upserted as
+    ``type="thing"`` so the edge always lands on real nodes.
+
+    Args:
+        text: Free-form text to analyse.
+        model: Provider/model string.
+        graph: Required — relations are persisted into this graph.
+        instruction: Override the default extraction directive.
+
+    Returns:
+        List of :class:`Relation` records that were added.
+    """
+    from pydantic import BaseModel, Field
+
+    extract_with_model = _resolve_extract_with_model()
+
+    class _ExtractedRelation(BaseModel):
+        subject: str
+        predicate: str
+        object: str
+
+    class _RelationList(BaseModel):
+        relations: list[_ExtractedRelation] = Field(default_factory=list)
+
+    result = extract_with_model(
+        _RelationList,
+        text,
+        model=model,
+        instruction_template=instruction,
+    )
+    payload = getattr(result, "data", result)
+    if isinstance(payload, _RelationList):
+        extracted = payload.relations
+    elif isinstance(payload, dict) and "relations" in payload:
+        extracted = [_ExtractedRelation.model_validate(r) for r in payload["relations"]]
+    else:
+        extracted = []
+
+    out: list[Relation] = []
+    for r in extracted:
+        subj = graph.resolve(r.subject) or graph.upsert_entity(r.subject)
+        obj = graph.resolve(r.object) or graph.upsert_entity(r.object)
+        out.append(graph.add_relation(subj, r.predicate, obj))
+    return out

--- a/prompture/kg/stores.py
+++ b/prompture/kg/stores.py
@@ -127,9 +127,7 @@ class InMemoryEntityStore:
                 return False
             self._unindex_entity(ent)
             # Cascade: drop edges referencing this id.
-            for rel_id in list(self._rel_by_subject.get(entity_id, ())) + list(
-                self._rel_by_object.get(entity_id, ())
-            ):
+            for rel_id in list(self._rel_by_subject.get(entity_id, ())) + list(self._rel_by_object.get(entity_id, ())):
                 rel = self._relations.pop(rel_id, None)
                 if rel is not None:
                     self._rel_by_subject[rel.subject_id].discard(rel.id)
@@ -287,9 +285,7 @@ class SQLiteEntityStore:
         with self._lock:
             conn = self._connect()
             try:
-                row = conn.execute(
-                    "SELECT * FROM entities WHERE id = ?", (entity_id,)
-                ).fetchone()
+                row = conn.execute("SELECT * FROM entities WHERE id = ?", (entity_id,)).fetchone()
             finally:
                 conn.close()
         if row is None:
@@ -430,9 +426,7 @@ class SQLiteEntityStore:
         with self._lock:
             conn = self._connect()
             try:
-                rows = conn.execute(
-                    "SELECT * FROM mentions WHERE entity_id = ?", (entity_id,)
-                ).fetchall()
+                rows = conn.execute("SELECT * FROM mentions WHERE entity_id = ?", (entity_id,)).fetchall()
             finally:
                 conn.close()
         return [self._row_to_mention(r) for r in rows]

--- a/prompture/kg/stores.py
+++ b/prompture/kg/stores.py
@@ -385,7 +385,7 @@ class SQLiteEntityStore:
         if as_object:
             clauses.append("object_id = ?")
             params.append(entity_id)
-        sql = f"SELECT * FROM relations WHERE ({' OR '.join(clauses)})"
+        sql = f"SELECT * FROM relations WHERE ({' OR '.join(clauses)})"  # nosec B608 - clauses are library-controlled literals; entity values are parameterized
         if predicate is not None:
             sql += " AND predicate = ?"
             params.append(predicate)

--- a/prompture/kg/stores.py
+++ b/prompture/kg/stores.py
@@ -1,0 +1,475 @@
+"""Storage backends for the knowledge graph.
+
+Two implementations ship out of the box:
+
+- :class:`InMemoryEntityStore` — fast, thread-safe, no dependencies.
+- :class:`SQLiteEntityStore` — file-backed durable storage, single DB
+  file at ``~/.prompture/kg/kg.db`` by default.
+
+Both satisfy the :class:`EntityStore` protocol.  Bring-your-own
+backends (Neo4j, Memgraph, JanusGraph, Zep's GraphRAG) implement the
+same eight methods.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from collections import defaultdict
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from .types import Entity, Mention, Relation
+
+_DEFAULT_DB_DIR = Path.home() / ".prompture" / "kg"
+_DEFAULT_DB_PATH = _DEFAULT_DB_DIR / "kg.db"
+
+
+@runtime_checkable
+class EntityStore(Protocol):
+    """Persistence contract for :class:`KnowledgeGraph`."""
+
+    def upsert_entity(self, entity: Entity) -> None: ...
+    def get_entity(self, entity_id: str) -> Entity | None: ...
+    def find_entities(
+        self, *, name: str | None = None, type: str | None = None, limit: int | None = None
+    ) -> list[Entity]: ...
+    def delete_entity(self, entity_id: str) -> bool: ...
+
+    def add_relation(self, relation: Relation) -> None: ...
+    def relations_for(
+        self,
+        entity_id: str,
+        *,
+        as_subject: bool = True,
+        as_object: bool = True,
+        predicate: str | None = None,
+    ) -> list[Relation]: ...
+
+    def add_mention(self, mention: Mention) -> None: ...
+    def mentions_for(self, entity_id: str) -> list[Mention]: ...
+
+
+# ----------------------------------------------------------------------
+# In-memory
+# ----------------------------------------------------------------------
+
+
+class InMemoryEntityStore:
+    """Thread-safe in-process :class:`EntityStore`."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._entities: dict[str, Entity] = {}
+        # name (lowercased) → set of entity ids — supports alias lookup
+        self._by_name: dict[str, set[str]] = defaultdict(set)
+        self._by_type: dict[str, set[str]] = defaultdict(set)
+        self._relations: dict[str, Relation] = {}
+        self._rel_by_subject: dict[str, set[str]] = defaultdict(set)
+        self._rel_by_object: dict[str, set[str]] = defaultdict(set)
+        self._mentions: dict[str, list[Mention]] = defaultdict(list)
+
+    # ---- entities ------------------------------------------------------
+
+    def upsert_entity(self, entity: Entity) -> None:
+        with self._lock:
+            existing = self._entities.get(entity.id)
+            if existing is not None:
+                # Drop old index entries before re-indexing.
+                self._unindex_entity(existing)
+            self._entities[entity.id] = entity
+            self._index_entity(entity)
+
+    def _index_entity(self, entity: Entity) -> None:
+        self._by_name[entity.name.lower()].add(entity.id)
+        for alias in entity.aliases:
+            self._by_name[alias.lower()].add(entity.id)
+        self._by_type[entity.type].add(entity.id)
+
+    def _unindex_entity(self, entity: Entity) -> None:
+        self._by_name[entity.name.lower()].discard(entity.id)
+        for alias in entity.aliases:
+            self._by_name[alias.lower()].discard(entity.id)
+        self._by_type[entity.type].discard(entity.id)
+
+    def get_entity(self, entity_id: str) -> Entity | None:
+        with self._lock:
+            return self._entities.get(entity_id)
+
+    def find_entities(
+        self,
+        *,
+        name: str | None = None,
+        type: str | None = None,
+        limit: int | None = None,
+    ) -> list[Entity]:
+        with self._lock:
+            if name is not None:
+                ids: Iterable[str] = self._by_name.get(name.lower(), ())
+            elif type is not None:
+                ids = self._by_type.get(type, ())
+            else:
+                ids = self._entities.keys()
+            if type is not None and name is not None:
+                ids = [i for i in ids if self._entities[i].type == type]
+            out = [self._entities[i] for i in ids]
+        out.sort(key=lambda e: e.ts, reverse=True)
+        if limit is not None and limit >= 0:
+            out = out[:limit]
+        return out
+
+    def delete_entity(self, entity_id: str) -> bool:
+        with self._lock:
+            ent = self._entities.pop(entity_id, None)
+            if ent is None:
+                return False
+            self._unindex_entity(ent)
+            # Cascade: drop edges referencing this id.
+            for rel_id in list(self._rel_by_subject.get(entity_id, ())) + list(
+                self._rel_by_object.get(entity_id, ())
+            ):
+                rel = self._relations.pop(rel_id, None)
+                if rel is not None:
+                    self._rel_by_subject[rel.subject_id].discard(rel.id)
+                    self._rel_by_object[rel.object_id].discard(rel.id)
+            self._rel_by_subject.pop(entity_id, None)
+            self._rel_by_object.pop(entity_id, None)
+            self._mentions.pop(entity_id, None)
+            return True
+
+    # ---- relations -----------------------------------------------------
+
+    def add_relation(self, relation: Relation) -> None:
+        with self._lock:
+            self._relations[relation.id] = relation
+            self._rel_by_subject[relation.subject_id].add(relation.id)
+            self._rel_by_object[relation.object_id].add(relation.id)
+
+    def relations_for(
+        self,
+        entity_id: str,
+        *,
+        as_subject: bool = True,
+        as_object: bool = True,
+        predicate: str | None = None,
+    ) -> list[Relation]:
+        with self._lock:
+            ids: set[str] = set()
+            if as_subject:
+                ids.update(self._rel_by_subject.get(entity_id, ()))
+            if as_object:
+                ids.update(self._rel_by_object.get(entity_id, ()))
+            rels = [self._relations[i] for i in ids]
+        if predicate is not None:
+            rels = [r for r in rels if r.predicate == predicate]
+        rels.sort(key=lambda r: r.ts, reverse=True)
+        return rels
+
+    # ---- mentions ------------------------------------------------------
+
+    def add_mention(self, mention: Mention) -> None:
+        with self._lock:
+            self._mentions[mention.entity_id].append(mention)
+
+    def mentions_for(self, entity_id: str) -> list[Mention]:
+        with self._lock:
+            return list(self._mentions.get(entity_id, ()))
+
+
+# ----------------------------------------------------------------------
+# SQLite
+# ----------------------------------------------------------------------
+
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS entities (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL,
+    aliases TEXT NOT NULL DEFAULT '[]',
+    attributes TEXT NOT NULL DEFAULT '{}',
+    ts REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_entities_name ON entities(name);
+CREATE INDEX IF NOT EXISTS idx_entities_type ON entities(type);
+
+CREATE TABLE IF NOT EXISTS relations (
+    id TEXT PRIMARY KEY,
+    subject_id TEXT NOT NULL,
+    predicate TEXT NOT NULL,
+    object_id TEXT NOT NULL,
+    attributes TEXT NOT NULL DEFAULT '{}',
+    ts REAL NOT NULL,
+    FOREIGN KEY (subject_id) REFERENCES entities(id) ON DELETE CASCADE,
+    FOREIGN KEY (object_id) REFERENCES entities(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_relations_subject ON relations(subject_id);
+CREATE INDEX IF NOT EXISTS idx_relations_object ON relations(object_id);
+CREATE INDEX IF NOT EXISTS idx_relations_predicate ON relations(predicate);
+
+CREATE TABLE IF NOT EXISTS mentions (
+    id TEXT PRIMARY KEY,
+    entity_id TEXT NOT NULL,
+    text TEXT NOT NULL,
+    source TEXT,
+    span_start INTEGER,
+    span_end INTEGER,
+    confidence REAL NOT NULL DEFAULT 1.0,
+    attributes TEXT NOT NULL DEFAULT '{}',
+    FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_mentions_entity ON mentions(entity_id);
+"""
+
+
+class SQLiteEntityStore:
+    """File-backed durable :class:`EntityStore`."""
+
+    def __init__(self, db_path: str | Path | None = None) -> None:
+        self._db_path = Path(db_path) if db_path else _DEFAULT_DB_PATH
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._init_db()
+
+    def _init_db(self) -> None:
+        with self._lock:
+            conn = sqlite3.connect(str(self._db_path))
+            try:
+                conn.execute("PRAGMA journal_mode=WAL")
+                conn.executescript(_SCHEMA_SQL)
+                conn.commit()
+            finally:
+                conn.close()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self._db_path))
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    # ---- entities ------------------------------------------------------
+
+    def upsert_entity(self, entity: Entity) -> None:
+        with self._lock:
+            conn = self._connect()
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO entities (id, name, type, aliases, attributes, ts)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(id) DO UPDATE SET
+                        name = excluded.name,
+                        type = excluded.type,
+                        aliases = excluded.aliases,
+                        attributes = excluded.attributes,
+                        ts = excluded.ts
+                    """,
+                    (
+                        entity.id,
+                        entity.name,
+                        entity.type,
+                        json.dumps(list(entity.aliases), ensure_ascii=False),
+                        json.dumps(entity.attributes, ensure_ascii=False),
+                        entity.ts,
+                    ),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+    def get_entity(self, entity_id: str) -> Entity | None:
+        with self._lock:
+            conn = self._connect()
+            try:
+                row = conn.execute(
+                    "SELECT * FROM entities WHERE id = ?", (entity_id,)
+                ).fetchone()
+            finally:
+                conn.close()
+        if row is None:
+            return None
+        return self._row_to_entity(row)
+
+    def find_entities(
+        self,
+        *,
+        name: str | None = None,
+        type: str | None = None,
+        limit: int | None = None,
+    ) -> list[Entity]:
+        sql = "SELECT * FROM entities"
+        params: list[Any] = []
+        wheres: list[str] = []
+        if name is not None:
+            wheres.append("(LOWER(name) = ? OR aliases LIKE ?)")
+            params.extend([name.lower(), f'%"{name}"%'])
+        if type is not None:
+            wheres.append("type = ?")
+            params.append(type)
+        if wheres:
+            sql += " WHERE " + " AND ".join(wheres)
+        sql += " ORDER BY ts DESC"
+        if limit is not None and limit >= 0:
+            sql += " LIMIT ?"
+            params.append(limit)
+
+        with self._lock:
+            conn = self._connect()
+            try:
+                rows = conn.execute(sql, params).fetchall()
+            finally:
+                conn.close()
+        return [self._row_to_entity(r) for r in rows]
+
+    def delete_entity(self, entity_id: str) -> bool:
+        with self._lock:
+            conn = self._connect()
+            try:
+                cursor = conn.execute("DELETE FROM entities WHERE id = ?", (entity_id,))
+                conn.commit()
+                return cursor.rowcount > 0
+            finally:
+                conn.close()
+
+    # ---- relations -----------------------------------------------------
+
+    def add_relation(self, relation: Relation) -> None:
+        with self._lock:
+            conn = self._connect()
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO relations (id, subject_id, predicate, object_id, attributes, ts)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(id) DO UPDATE SET
+                        subject_id = excluded.subject_id,
+                        predicate = excluded.predicate,
+                        object_id = excluded.object_id,
+                        attributes = excluded.attributes,
+                        ts = excluded.ts
+                    """,
+                    (
+                        relation.id,
+                        relation.subject_id,
+                        relation.predicate,
+                        relation.object_id,
+                        json.dumps(relation.attributes, ensure_ascii=False),
+                        relation.ts,
+                    ),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+    def relations_for(
+        self,
+        entity_id: str,
+        *,
+        as_subject: bool = True,
+        as_object: bool = True,
+        predicate: str | None = None,
+    ) -> list[Relation]:
+        if not (as_subject or as_object):
+            return []
+        clauses: list[str] = []
+        params: list[Any] = []
+        if as_subject:
+            clauses.append("subject_id = ?")
+            params.append(entity_id)
+        if as_object:
+            clauses.append("object_id = ?")
+            params.append(entity_id)
+        sql = f"SELECT * FROM relations WHERE ({' OR '.join(clauses)})"
+        if predicate is not None:
+            sql += " AND predicate = ?"
+            params.append(predicate)
+        sql += " ORDER BY ts DESC"
+
+        with self._lock:
+            conn = self._connect()
+            try:
+                rows = conn.execute(sql, params).fetchall()
+            finally:
+                conn.close()
+        return [self._row_to_relation(r) for r in rows]
+
+    # ---- mentions ------------------------------------------------------
+
+    def add_mention(self, mention: Mention) -> None:
+        with self._lock:
+            conn = self._connect()
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO mentions
+                        (id, entity_id, text, source, span_start, span_end, confidence, attributes)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        mention.id,
+                        mention.entity_id,
+                        mention.text,
+                        mention.source,
+                        mention.start,
+                        mention.end,
+                        mention.confidence,
+                        json.dumps(mention.attributes, ensure_ascii=False),
+                    ),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+    def mentions_for(self, entity_id: str) -> list[Mention]:
+        with self._lock:
+            conn = self._connect()
+            try:
+                rows = conn.execute(
+                    "SELECT * FROM mentions WHERE entity_id = ?", (entity_id,)
+                ).fetchall()
+            finally:
+                conn.close()
+        return [self._row_to_mention(r) for r in rows]
+
+    # ---- row decoders --------------------------------------------------
+
+    @staticmethod
+    def _row_to_entity(row: sqlite3.Row) -> Entity:
+        return Entity(
+            id=row["id"],
+            name=row["name"],
+            type=row["type"],
+            aliases=tuple(json.loads(row["aliases"]) if row["aliases"] else ()),
+            attributes=json.loads(row["attributes"]) if row["attributes"] else {},
+            ts=float(row["ts"]),
+        )
+
+    @staticmethod
+    def _row_to_relation(row: sqlite3.Row) -> Relation:
+        return Relation(
+            id=row["id"],
+            subject_id=row["subject_id"],
+            predicate=row["predicate"],
+            object_id=row["object_id"],
+            attributes=json.loads(row["attributes"]) if row["attributes"] else {},
+            ts=float(row["ts"]),
+        )
+
+    @staticmethod
+    def _row_to_mention(row: sqlite3.Row) -> Mention:
+        return Mention(
+            id=row["id"],
+            entity_id=row["entity_id"],
+            text=row["text"],
+            source=row["source"],
+            start=row["span_start"],
+            end=row["span_end"],
+            confidence=float(row["confidence"]),
+            attributes=json.loads(row["attributes"]) if row["attributes"] else {},
+        )

--- a/prompture/kg/types.py
+++ b/prompture/kg/types.py
@@ -1,0 +1,162 @@
+"""Types for the knowledge-graph entity store."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+
+def _slugify(value: str) -> str:
+    """Lowercase + collapse whitespace, used to canonicalise entity ids."""
+    return " ".join(value.lower().split())
+
+
+@dataclass
+class Entity:
+    """A node in the knowledge graph.
+
+    Attributes:
+        id: Stable identifier.  Use a slug, URI, or wikidata id when
+            available; otherwise :meth:`KnowledgeGraph.upsert_entity`
+            derives one from ``name``.
+        name: Canonical human-readable name (used for display).
+        type: Coarse class (``"person"``, ``"organization"``, ``"city"``,
+            ``"product"``, etc.).  Free-form; no enum is enforced.
+        aliases: Alternative surface forms that resolve to this entity.
+        attributes: Free-form structured payload (birth date, market
+            cap, GPS coords).  Backends serialise as JSON.
+        ts: Wall-clock timestamp of last update.
+    """
+
+    id: str
+    name: str
+    type: str = "thing"
+    aliases: tuple[str, ...] = ()
+    attributes: dict[str, Any] = field(default_factory=dict)
+    ts: float = field(default_factory=time.time)
+
+    @classmethod
+    def make_id(cls, name: str, type: str | None = None) -> str:
+        """Derive a deterministic id from a *name* (and optional *type*)."""
+        slug = _slugify(name).replace(" ", "_")
+        if type:
+            return f"{_slugify(type)}:{slug}"
+        return slug
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "type": self.type,
+            "aliases": list(self.aliases),
+            "attributes": self.attributes,
+            "ts": self.ts,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Entity:
+        return cls(
+            id=data["id"],
+            name=data["name"],
+            type=data.get("type", "thing"),
+            aliases=tuple(data.get("aliases") or ()),
+            attributes=dict(data.get("attributes") or {}),
+            ts=float(data.get("ts", time.time())),
+        )
+
+
+@dataclass
+class Relation:
+    """A directed edge between two entities.
+
+    Attributes:
+        id: Stable identifier (auto-generated UUID4 hex when omitted).
+        subject_id: Source entity id.
+        predicate: Relation label (``"works_at"``, ``"located_in"``,
+            ``"acquired"``).  Free-form; no enum is enforced.
+        object_id: Target entity id.
+        attributes: Free-form structured payload (start_date,
+            confidence, source).
+        ts: Wall-clock timestamp.
+    """
+
+    subject_id: str
+    predicate: str
+    object_id: str
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    attributes: dict[str, Any] = field(default_factory=dict)
+    ts: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "subject_id": self.subject_id,
+            "predicate": self.predicate,
+            "object_id": self.object_id,
+            "attributes": self.attributes,
+            "ts": self.ts,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Relation:
+        return cls(
+            id=data.get("id", uuid.uuid4().hex),
+            subject_id=data["subject_id"],
+            predicate=data["predicate"],
+            object_id=data["object_id"],
+            attributes=dict(data.get("attributes") or {}),
+            ts=float(data.get("ts", time.time())),
+        )
+
+
+@dataclass
+class Mention:
+    """A reference to an entity inside a piece of source text.
+
+    Attributes:
+        entity_id: The mentioned entity.
+        text: The exact surface form (the slice of source text).
+        source: Identifier for the document the mention came from (URL,
+            file path, document id).
+        start: Character offset of the mention's start, when available.
+        end: Character offset (exclusive) of the mention's end.
+        confidence: Detector confidence on ``[0.0, 1.0]``.  Defaults to
+            ``1.0`` for hand-asserted mentions.
+        attributes: Free-form structured payload.
+    """
+
+    entity_id: str
+    text: str
+    source: str | None = None
+    start: int | None = None
+    end: int | None = None
+    confidence: float = 1.0
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    attributes: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "entity_id": self.entity_id,
+            "text": self.text,
+            "source": self.source,
+            "start": self.start,
+            "end": self.end,
+            "confidence": self.confidence,
+            "attributes": self.attributes,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Mention:
+        return cls(
+            id=data.get("id", uuid.uuid4().hex),
+            entity_id=data["entity_id"],
+            text=data["text"],
+            source=data.get("source"),
+            start=data.get("start"),
+            end=data.get("end"),
+            confidence=float(data.get("confidence", 1.0)),
+            attributes=dict(data.get("attributes") or {}),
+        )

--- a/prompture/persistence/history.py
+++ b/prompture/persistence/history.py
@@ -9,6 +9,7 @@ import json
 from datetime import datetime, timezone
 from typing import Any
 
+from .._internal.json_encoder import PromptureJSONEncoder
 from ..agents.types import AgentResult, AgentStep, StepType
 
 
@@ -256,7 +257,7 @@ def export_result_json(result: AgentResult, include_messages: bool = True) -> st
             f.write(json_str)
     """
     data = result_to_dict(result, include_messages=include_messages)
-    return json.dumps(data, indent=2, default=str)
+    return json.dumps(data, indent=2, cls=PromptureJSONEncoder)
 
 
 def result_to_dict(result: AgentResult, include_messages: bool = True) -> dict[str, Any]:

--- a/prompture/pipeline/pipeline.py
+++ b/prompture/pipeline/pipeline.py
@@ -21,7 +21,7 @@ import re
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from ..groups.types import ErrorPolicy
 
@@ -50,7 +50,7 @@ class PipelineStep:
             returns False, the step is skipped.
     """
 
-    skill: Union[SkillInfo, Persona, str]
+    skill: SkillInfo | Persona | str
     output_key: str | None = None
     input_template: str | None = None
     condition: Callable[[dict[str, Any]], bool] | None = None
@@ -189,7 +189,7 @@ class SkillPipeline:
 
     def __init__(
         self,
-        steps: list[Union[SkillInfo, Persona, str, PipelineStep]],
+        steps: list[SkillInfo | Persona | str | PipelineStep],
         model_name: str = "openai/gpt-4o",
         share_conversation: bool = True,
         error_policy: ErrorPolicy = ErrorPolicy.fail_fast,
@@ -205,7 +205,7 @@ class SkillPipeline:
 
     def _normalize_steps(
         self,
-        steps: list[Union[SkillInfo, Persona, str, PipelineStep]],
+        steps: list[SkillInfo | Persona | str | PipelineStep],
     ) -> list[PipelineStep]:
         """Convert various step formats to PipelineStep instances.
 
@@ -238,7 +238,7 @@ class SkillPipeline:
                 result.append(PipelineStep(skill=step, output_key=f"step_{i}"))
         return result
 
-    def _resolve_skill(self, skill: Union[SkillInfo, Persona, str]) -> tuple[str, Persona]:
+    def _resolve_skill(self, skill: SkillInfo | Persona | str) -> tuple[str, Persona]:
         """Resolve a skill reference to a Persona instance.
 
         Args:
@@ -543,7 +543,7 @@ class SkillPipeline:
 
 
 def create_pipeline(
-    *steps: Union[SkillInfo, Persona, str, PipelineStep],
+    *steps: SkillInfo | Persona | str | PipelineStep,
     model_name: str = "openai/gpt-4o",
     share_conversation: bool = True,
     **kwargs: Any,

--- a/prompture/rag/chunkers/__init__.py
+++ b/prompture/rag/chunkers/__init__.py
@@ -34,6 +34,7 @@ from .chunker_registry import (
     register_async_chunker,
     register_chunker,
 )
+from .contextual import DEFAULT_CONTEXTUAL_PROMPT, ContextualChunker
 from .markdown import MarkdownChunker
 from .recursive import RecursiveCharacterChunker
 from .semantic import SemanticChunker
@@ -53,6 +54,16 @@ for _name, _cls in _BUILTIN_CHUNKERS.items():
     register_chunker(_name, _cls, overwrite=True)
 
 
+# ContextualChunker is a wrapper, not a primary splitter — it requires a
+# `base` chunker and an LLM driver at instantiation time. Register it under
+# its own factory so users can still discover it via `get_chunker`.
+def _contextual_factory(**kwargs):
+    return ContextualChunker(**kwargs)
+
+
+register_chunker("contextual", _contextual_factory, overwrite=True)
+
+
 # Async siblings: wrap the sync class in _SyncToAsyncChunker.  SemanticChunker
 # and TokenChunker require runtime arguments (embedding_driver / tiktoken
 # installed) — their factories simply forward kwargs so the caller controls
@@ -67,13 +78,23 @@ def _make_async_factory(sync_cls: type[TextChunker]):
 for _name, _cls in _BUILTIN_CHUNKERS.items():
     register_async_chunker(_name, _make_async_factory(_cls), overwrite=True)
 
+# Async sibling for ContextualChunker — same wrapping pattern. The LLM call
+# inside is sync; the adapter handles to_thread.
+register_async_chunker(
+    "contextual",
+    lambda **kw: _SyncToAsyncChunker(ContextualChunker(**kw)),
+    overwrite=True,
+)
+
 del _name, _cls
 
 __all__ = [
     "ASYNC_CHUNKER_REGISTRY",
     "CHUNKER_REGISTRY",
+    "DEFAULT_CONTEXTUAL_PROMPT",
     "AsyncTextChunker",
     "CharacterChunker",
+    "ContextualChunker",
     "MarkdownChunker",
     "RecursiveCharacterChunker",
     "SemanticChunker",

--- a/prompture/rag/chunkers/chunker_registry.py
+++ b/prompture/rag/chunkers/chunker_registry.py
@@ -9,7 +9,8 @@ because each chunker exposes a different set of configuration options
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from .base import AsyncTextChunker, TextChunker
 

--- a/prompture/rag/chunkers/contextual.py
+++ b/prompture/rag/chunkers/contextual.py
@@ -63,10 +63,7 @@ DEFAULT_CONTEXTUAL_PROMPT = (
 #: Fallback combined-prompt template, used when the driver doesn't
 #: expose ``generate_messages``. Less cache-friendly than the
 #: messages path but functionally equivalent.
-_FALLBACK_COMBINED_PROMPT = (
-    "<document>\n{document}\n</document>\n\n"
-    "{user_prompt}"
-)
+_FALLBACK_COMBINED_PROMPT = "<document>\n{document}\n</document>\n\n{user_prompt}"
 
 
 class _LLM(Protocol):
@@ -131,8 +128,7 @@ class ContextualChunker(TextChunker):
     ) -> None:
         if "{chunk}" not in prompt:
             raise ValueError(
-                "ContextualChunker prompt must include a '{chunk}' placeholder; "
-                f"got: {prompt[:80]!r}..."
+                f"ContextualChunker prompt must include a '{{chunk}}' placeholder; got: {prompt[:80]!r}..."
             )
         # NOTE: we deliberately do *not* call super().__init__ with chunk_size
         # because that base check rejects chunk_overlap >= chunk_size, but the
@@ -143,11 +139,15 @@ class ContextualChunker(TextChunker):
         self.base = base
         self.driver = driver
         self.prompt = prompt
-        self.llm_options = llm_options if llm_options is not None else {
-            "temperature": 0.0,
-            "max_tokens": 200,
-            "cache_prompt": True,
-        }
+        self.llm_options = (
+            llm_options
+            if llm_options is not None
+            else {
+                "temperature": 0.0,
+                "max_tokens": 200,
+                "cache_prompt": True,
+            }
+        )
         self.max_context_chars = max_context_chars
         self.max_document_chars = max_document_chars
         self.fail_open = fail_open

--- a/prompture/rag/chunkers/contextual.py
+++ b/prompture/rag/chunkers/contextual.py
@@ -1,0 +1,261 @@
+"""Contextual chunking — Anthropic Sep 2024 technique.
+
+Wraps any base chunker and uses an LLM to generate a short situating
+context (50–100 tokens) for each chunk *within its parent document*.
+The context is prepended to the chunk text before downstream
+embedding, which Anthropic reports reduces failed retrievals by ~49%
+on their own evaluation set.
+
+Cost shape
+~~~~~~~~~~
+
+One extra LLM call per chunk. Because every call for the same document
+shares the document content as its prefix, this technique is **designed
+to be paired with prompt caching**:
+
+* The full document is sent in the system role so the Claude driver's
+  cache_control logic (Phase 1) wraps it as a cacheable prefix.
+* The per-chunk question goes in the user role and varies every call.
+* The first chunk pays the full cache-creation cost (~1.25× input);
+  every subsequent chunk for the same document pays cache-read price
+  (~0.1× input).
+
+For LLMs that don't expose ``generate_messages`` the wrapper falls back
+to a single combined prompt via ``generate()``, which still works
+correctly but loses the caching benefit on Anthropic.
+
+Design notes
+~~~~~~~~~~~~
+
+* The technique inherently needs the *whole document* alongside the
+  chunk — calling :meth:`split_text` on a raw string can't produce
+  contextualised output, so that path silently degrades to the base
+  chunker's behaviour.
+* ``fail_open=True`` (the default) makes the chunker resilient: any
+  per-chunk LLM failure prepends an empty context (no-op) instead of
+  raising. Set ``False`` if you want hard failure on LLM trouble.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol
+
+from ..documents import Document
+from .base import TextChunker
+
+logger = logging.getLogger(__name__)
+
+
+#: Default user-prompt template. ``{chunk}`` is substituted with the
+#: chunk text. The full document is sent separately via the system role
+#: (or prepended in the fallback path) so this prompt stays short and
+#: cache-friendly.
+DEFAULT_CONTEXTUAL_PROMPT = (
+    "Here is a chunk taken from the document above:\n"
+    "<chunk>\n{chunk}\n</chunk>\n\n"
+    "Give a short, succinct context (1–2 sentences) that situates this "
+    "chunk within the overall document. The goal is to improve retrieval "
+    "of this chunk when someone searches for related concepts. Answer "
+    "with the context only — no preamble, no quotes, no labels."
+)
+
+#: Fallback combined-prompt template, used when the driver doesn't
+#: expose ``generate_messages``. Less cache-friendly than the
+#: messages path but functionally equivalent.
+_FALLBACK_COMBINED_PROMPT = (
+    "<document>\n{document}\n</document>\n\n"
+    "{user_prompt}"
+)
+
+
+class _LLM(Protocol):
+    """Minimal LLM contract used by :class:`ContextualChunker`."""
+
+    def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:  # pragma: no cover
+        ...
+
+
+def _response_text(response: Any) -> str:
+    """Extract the text payload from a driver response dict or stringable object."""
+    if isinstance(response, dict):
+        return str(response.get("text") or "").strip()
+    return str(response or "").strip()
+
+
+class ContextualChunker(TextChunker):
+    """Wrap a base chunker; per-chunk LLM-generated context is prepended.
+
+    Args:
+        base: The underlying chunker (e.g. :class:`RecursiveCharacterChunker`).
+            Its ``split_text`` is what we contextualise.
+        driver: Any LLM driver. Best results come from one that supports
+            prompt caching (Claude / OpenAI). When the driver exposes
+            ``generate_messages`` the chunker uses the system-role path
+            for caching; otherwise it falls back to a single combined
+            prompt sent through ``generate``.
+        prompt: User-prompt template containing a ``{chunk}`` placeholder.
+            Defaults to :data:`DEFAULT_CONTEXTUAL_PROMPT`. Do NOT put the
+            document into this template — the chunker handles that.
+        llm_options: Forwarded to the driver. Defaults set a tight
+            ``max_tokens`` budget (the context should be short) and
+            leave ``cache_prompt=True`` so Claude drivers cache the
+            document prefix automatically.
+        max_context_chars: Cap on the per-chunk context length (chars).
+            Defaults to 400 (≈100 tokens). Long contexts dilute the
+            embedding signal of the actual chunk text.
+        max_document_chars: Cap on the document text fed to the LLM.
+            Defaults to 200000 — covers all common model context windows
+            while keeping cache_creation costs bounded.
+        fail_open: When True (default), per-chunk LLM failures fall
+            through to an empty context (= behaviour of the base
+            chunker). When False, the first failure is re-raised.
+        skip_if_only_one_chunk: When True (default), single-chunk
+            documents are returned as-is — no LLM call. Multi-chunk
+            documents always get contextualised.
+    """
+
+    # ContextualChunker doesn't introduce its own chunk_size; it inherits
+    # from the base chunker for any caller that needs to inspect those.
+    def __init__(
+        self,
+        base: TextChunker,
+        driver: _LLM,
+        *,
+        prompt: str = DEFAULT_CONTEXTUAL_PROMPT,
+        llm_options: dict[str, Any] | None = None,
+        max_context_chars: int = 400,
+        max_document_chars: int = 200_000,
+        fail_open: bool = True,
+        skip_if_only_one_chunk: bool = True,
+    ) -> None:
+        if "{chunk}" not in prompt:
+            raise ValueError(
+                "ContextualChunker prompt must include a '{chunk}' placeholder; "
+                f"got: {prompt[:80]!r}..."
+            )
+        # NOTE: we deliberately do *not* call super().__init__ with chunk_size
+        # because that base check rejects chunk_overlap >= chunk_size, but the
+        # base chunker already enforces sizing. We mirror the base's values so
+        # any caller inspecting them sees something sensible.
+        self.chunk_size = getattr(base, "chunk_size", 1000)
+        self.chunk_overlap = getattr(base, "chunk_overlap", 200)
+        self.base = base
+        self.driver = driver
+        self.prompt = prompt
+        self.llm_options = llm_options if llm_options is not None else {
+            "temperature": 0.0,
+            "max_tokens": 200,
+            "cache_prompt": True,
+        }
+        self.max_context_chars = max_context_chars
+        self.max_document_chars = max_document_chars
+        self.fail_open = fail_open
+        self.skip_if_only_one_chunk = skip_if_only_one_chunk
+
+    # ------------------------------------------------------------------
+    # TextChunker contract
+    # ------------------------------------------------------------------
+
+    def split_text(self, text: str) -> list[str]:
+        """Delegate to the base chunker.
+
+        ``split_text`` operates on a raw string and has no access to the
+        surrounding document context, so contextualisation is not
+        applied on this path — call :meth:`split_documents` to get
+        contextualised output.
+        """
+        return self.base.split_text(text)
+
+    def split_documents(self, documents: list[Document]) -> list[Document]:
+        """Split each document and prepend an LLM-generated context per chunk."""
+        result: list[Document] = []
+        for doc in documents:
+            doc_text = doc.content
+            chunks = self.base.split_text(doc_text)
+            count = len(chunks)
+            parent_source = doc.metadata.get("source")
+
+            # Avoid the LLM call entirely when there's nothing to contextualise.
+            do_contextualise = count > 1 or not self.skip_if_only_one_chunk
+
+            # Truncate document for the LLM call (chunks themselves are unaffected).
+            doc_for_llm = doc_text
+            if len(doc_for_llm) > self.max_document_chars:
+                doc_for_llm = doc_for_llm[: self.max_document_chars]
+                logger.debug(
+                    "ContextualChunker: document truncated to %d chars for LLM context generation.",
+                    self.max_document_chars,
+                )
+
+            for i, chunk in enumerate(chunks):
+                context = ""
+                if do_contextualise:
+                    context = self._generate_context(doc_for_llm, chunk)
+                final_content = f"{context}\n\n{chunk}" if context else chunk
+                new_meta = dict(doc.metadata)
+                new_meta["chunk_index"] = i
+                new_meta["chunk_count"] = count
+                if parent_source is not None and "parent_source" not in new_meta:
+                    new_meta["parent_source"] = parent_source
+                if context:
+                    new_meta["contextual_context"] = context
+                result.append(Document(content=final_content, metadata=new_meta))
+        return result
+
+    # ------------------------------------------------------------------
+    # LLM plumbing
+    # ------------------------------------------------------------------
+
+    def _generate_context(self, document: str, chunk: str) -> str:
+        """Produce a 1–2 sentence situating context for ``chunk`` in ``document``.
+
+        Returns an empty string when the LLM is unavailable / fails /
+        produces no usable text and ``fail_open`` is True. Re-raises
+        otherwise.
+        """
+        user_prompt = self.prompt.format(chunk=chunk)
+
+        # Preferred path: system role gets the document so Claude can cache it.
+        gm = getattr(self.driver, "generate_messages", None)
+        if callable(gm):
+            messages = [
+                {"role": "system", "content": document},
+                {"role": "user", "content": user_prompt},
+            ]
+            try:
+                response = gm(messages, self.llm_options)
+            except Exception:
+                logger.warning(
+                    "ContextualChunker: generate_messages failed; falling back to generate().",
+                    exc_info=True,
+                )
+            else:
+                return self._postprocess(_response_text(response))
+
+        # Fallback: single combined prompt.
+        combined = _FALLBACK_COMBINED_PROMPT.format(document=document, user_prompt=user_prompt)
+        try:
+            response = self.driver.generate(combined, self.llm_options)
+        except Exception:
+            if self.fail_open:
+                logger.warning(
+                    "ContextualChunker: LLM call failed; emitting un-contextualised chunk.",
+                    exc_info=True,
+                )
+                return ""
+            raise
+        return self._postprocess(_response_text(response))
+
+    def _postprocess(self, text: str) -> str:
+        """Trim, strip quotes / common label prefixes, cap length."""
+        if not text:
+            return ""
+        cleaned = text.strip().strip(" \"'")
+        # Remove common label prefixes the model might add.
+        for prefix in ("Context:", "Situating context:", "Here is the context:"):
+            if cleaned.lower().startswith(prefix.lower()):
+                cleaned = cleaned[len(prefix) :].lstrip(" :\"'")
+        if len(cleaned) > self.max_context_chars:
+            cleaned = cleaned[: self.max_context_chars].rstrip()
+        return cleaned

--- a/prompture/rag/chunkers/semantic.py
+++ b/prompture/rag/chunkers/semantic.py
@@ -187,7 +187,7 @@ class SemanticChunker(TextChunker):
 def _cosine_distance(a: list[float], b: list[float]) -> float:
     if len(a) != len(b):
         raise ValueError("Embedding vectors must have the same dimensionality")
-    dot = sum(x * y for x, y in zip(a, b))
+    dot = sum(x * y for x, y in zip(a, b, strict=False))
     na = math.sqrt(sum(x * x for x in a))
     nb = math.sqrt(sum(y * y for y in b))
     if na == 0 or nb == 0:

--- a/prompture/rag/loader_registry.py
+++ b/prompture/rag/loader_registry.py
@@ -9,8 +9,8 @@ explicit name (``get_loader("pdf")``) or directly from a file path
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Union
 
 from .documents import AsyncDocumentLoader, DocumentLoader
 
@@ -97,14 +97,14 @@ def get_async_loader(name: str) -> AsyncDocumentLoader:
     return ASYNC_LOADER_REGISTRY[key]()
 
 
-def _extension_of(path: Union[str, Path]) -> str:
+def _extension_of(path: str | Path) -> str:
     suffix = Path(str(path)).suffix.lower()
     if not suffix:
         raise KeyError(f"Path '{path}' has no file extension; cannot auto-detect a loader.")
     return suffix
 
 
-def get_loader_for_path(path: Union[str, Path]) -> DocumentLoader:
+def get_loader_for_path(path: str | Path) -> DocumentLoader:
     """Return a sync loader appropriate for ``path``'s file extension."""
     ext = _extension_of(path)
     if ext not in _EXTENSION_INDEX:
@@ -113,7 +113,7 @@ def get_loader_for_path(path: Union[str, Path]) -> DocumentLoader:
     return get_loader(_EXTENSION_INDEX[ext])
 
 
-def get_async_loader_for_path(path: Union[str, Path]) -> AsyncDocumentLoader:
+def get_async_loader_for_path(path: str | Path) -> AsyncDocumentLoader:
     """Return an async loader appropriate for ``path``'s file extension."""
     ext = _extension_of(path)
     if ext not in _ASYNC_EXTENSION_INDEX:

--- a/prompture/rag/pipeline.py
+++ b/prompture/rag/pipeline.py
@@ -91,6 +91,35 @@ async def _apply_reranker_async(
     return [results[rr.index] for rr in rerank_results]
 
 
+def _resolve_reranker(reranker: Any, *, prefer_async: bool = False) -> Any:
+    """Coerce a ``provider/model`` string into an instantiated rerank driver.
+
+    Already-instantiated drivers and ``None`` are returned unchanged so
+    callers can mix-and-match. When ``prefer_async`` is true (the async
+    pipeline), tries the async registry first and falls back to the sync
+    registry — :func:`_apply_reranker_async` handles either uniformly.
+    """
+    if reranker is None or not isinstance(reranker, str):
+        return reranker
+    if "/" not in reranker:
+        raise ValueError(
+            f"Reranker string {reranker!r} must be in 'provider/model' form "
+            "(e.g. 'cohere/rerank-v3.5'). Pass a pre-instantiated driver instead "
+            "if you need custom construction."
+        )
+    if prefer_async:
+        try:
+            from ..drivers.rerank_registry import get_async_rerank_driver_for_model
+
+            return get_async_rerank_driver_for_model(reranker)
+        except Exception:
+            # Async driver may not exist for this provider; fall through to sync.
+            pass
+    from ..drivers.rerank_registry import get_rerank_driver_for_model
+
+    return get_rerank_driver_for_model(reranker)
+
+
 # ── Sync pipeline ────────────────────────────────────────────────────────────
 
 
@@ -113,9 +142,23 @@ class RAGPipeline:
         top_n_after_rerank: int = 4,
         system_prompt: str | None = None,
     ) -> None:
+        """Construct a RAG pipeline.
+
+        Args:
+            retriever: The retriever providing dense / hybrid / sparse search.
+            llm: An LLM driver for the generation step.
+            reranker: Optional reranker. Accepts either a pre-instantiated
+                rerank driver or a ``"provider/model"`` string such as
+                ``"cohere/rerank-v3.5"`` — the string is resolved via
+                :func:`prompture.drivers.rerank_registry.get_rerank_driver_for_model`.
+            prompt_template: Template containing ``{context}`` and ``{question}``.
+            top_n_after_rerank: How many results to keep after reranking.
+                Ignored when ``reranker`` is ``None``.
+            system_prompt: Optional system prompt for the LLM call.
+        """
         self.retriever = retriever
         self.llm = llm
-        self.reranker = reranker
+        self.reranker = _resolve_reranker(reranker, prefer_async=False)
         self.prompt_template = prompt_template
         self.top_n_after_rerank = top_n_after_rerank
         self.system_prompt = system_prompt
@@ -288,9 +331,22 @@ class AsyncRAGPipeline:
         top_n_after_rerank: int = 4,
         system_prompt: str | None = None,
     ) -> None:
+        """Construct an async RAG pipeline.
+
+        Args:
+            retriever: Sync or async retriever; the pipeline detects and adapts.
+            llm: A sync or async LLM driver.
+            reranker: Optional reranker. Accepts a pre-instantiated rerank
+                driver (sync or async) or a ``"provider/model"`` string. When
+                given a string, the async rerank driver is preferred and a
+                sync one is used as a fallback.
+            prompt_template: Template containing ``{context}`` and ``{question}``.
+            top_n_after_rerank: How many results to keep after reranking.
+            system_prompt: Optional system prompt for the LLM call.
+        """
         self.retriever = retriever
         self.llm = llm
-        self.reranker = reranker
+        self.reranker = _resolve_reranker(reranker, prefer_async=True)
         self.prompt_template = prompt_template
         self.top_n_after_rerank = top_n_after_rerank
         self.system_prompt = system_prompt

--- a/prompture/rag/retrievers/__init__.py
+++ b/prompture/rag/retrievers/__init__.py
@@ -1,6 +1,6 @@
 """Prompture RAG retrievers.
 
-Phase 13 adds retriever abstractions plus three concrete implementations:
+Concrete implementations:
 
 * :class:`VectorStoreRetriever` — thin wrapper over
   :meth:`VectorStore.similarity_search`.
@@ -8,6 +8,12 @@ Phase 13 adds retriever abstractions plus three concrete implementations:
   diverse results.
 * :class:`HybridRetriever` — fuses dense (vector) + sparse (BM25)
   retrieval via Reciprocal Rank Fusion.
+* :class:`HyDERetriever` — LLM drafts a hypothetical answer; the base
+  retriever embeds and looks up neighbours of that text.
+* :class:`MultiQueryRetriever` — LLM emits N reformulations; each is
+  retrieved and the rankings are RRF-fused.
+* :class:`StepBackRetriever` — LLM rephrases the query into a broader
+  one; original and broader rankings are RRF-fused.
 
 All retrievers share the :class:`Retriever` / :class:`AsyncRetriever`
 interface defined in :mod:`prompture.rag.retrievers.base` and return
@@ -19,7 +25,9 @@ from __future__ import annotations
 
 from .base import AsyncRetriever, Retriever
 from .hybrid import HybridRetriever, reciprocal_rank_fusion
+from .hyde import DEFAULT_HYDE_PROMPT, HyDERetriever
 from .mmr import MMRRetriever
+from .multi_query import DEFAULT_MULTI_QUERY_PROMPT, MultiQueryRetriever
 from .retriever_registry import (
     ASYNC_RETRIEVER_REGISTRY,
     RETRIEVER_REGISTRY,
@@ -29,6 +37,7 @@ from .retriever_registry import (
     register_retriever,
 )
 from .similarity import VectorStoreRetriever
+from .step_back import DEFAULT_STEP_BACK_PROMPT, StepBackRetriever
 
 # ── Register built-in retrievers ─────────────────────────────────────────────
 
@@ -45,19 +54,42 @@ def _hybrid_factory(**kwargs):
     return HybridRetriever(**kwargs)
 
 
+def _hyde_factory(**kwargs):
+    return HyDERetriever(**kwargs)
+
+
+def _multi_query_factory(**kwargs):
+    return MultiQueryRetriever(**kwargs)
+
+
+def _step_back_factory(**kwargs):
+    return StepBackRetriever(**kwargs)
+
+
 register_retriever("similarity", _similarity_factory, overwrite=True)
 register_retriever("vector", _similarity_factory, overwrite=True)
 register_retriever("mmr", _mmr_factory, overwrite=True)
 register_retriever("hybrid", _hybrid_factory, overwrite=True)
+register_retriever("hyde", _hyde_factory, overwrite=True)
+register_retriever("multi_query", _multi_query_factory, overwrite=True)
+register_retriever("multi-query", _multi_query_factory, overwrite=True)
+register_retriever("step_back", _step_back_factory, overwrite=True)
+register_retriever("step-back", _step_back_factory, overwrite=True)
 
 
 __all__ = [
     "ASYNC_RETRIEVER_REGISTRY",
+    "DEFAULT_HYDE_PROMPT",
+    "DEFAULT_MULTI_QUERY_PROMPT",
+    "DEFAULT_STEP_BACK_PROMPT",
     "RETRIEVER_REGISTRY",
     "AsyncRetriever",
+    "HyDERetriever",
     "HybridRetriever",
     "MMRRetriever",
+    "MultiQueryRetriever",
     "Retriever",
+    "StepBackRetriever",
     "VectorStoreRetriever",
     "get_async_retriever",
     "get_retriever",

--- a/prompture/rag/retrievers/_fusion.py
+++ b/prompture/rag/retrievers/_fusion.py
@@ -1,0 +1,70 @@
+"""Internal fusion helpers shared by the query-side retriever wrappers.
+
+These keep :mod:`multi_query` and :mod:`step_back` from re-implementing
+the RRF + per-doc max-score bookkeeping. Not part of the public API.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from ..vectorstores.base import VectorSearchResult
+from .hybrid import reciprocal_rank_fusion
+
+
+def _document_id(result: VectorSearchResult) -> str:
+    """Return a stable identifier for a search result.
+
+    Prefer ``document.metadata['id']`` when the store provided one;
+    otherwise hash the content. This lets us fuse rankings across
+    multiple retrieval calls even when the backend doesn't surface IDs.
+    """
+    meta_id = result.document.metadata.get("id")
+    if meta_id is not None:
+        return str(meta_id)
+    return "sha1:" + hashlib.sha1(result.document.content.encode("utf-8")).hexdigest()
+
+
+def fuse_search_results(
+    result_lists: list[list[VectorSearchResult]],
+    *,
+    rrf_k: int = 60,
+    top_n: int | None = None,
+) -> list[VectorSearchResult]:
+    """Reciprocal-Rank-Fuse multiple ranked ``VectorSearchResult`` lists.
+
+    Args:
+        result_lists: One ranked list per upstream retrieval call. Empty
+            lists are tolerated.
+        rrf_k: RRF damping constant (default 60, per the original paper).
+        top_n: Cap the output at the top ``top_n`` fused results. ``None``
+            returns the full fused ranking.
+
+    Returns:
+        A single ranked list of :class:`VectorSearchResult` objects. Each
+        document appears once with whichever copy carried the highest
+        upstream score (so downstream ``score`` reflects the best
+        evidence seen, not the fused RRF score).
+    """
+    id_lists: list[list[str]] = []
+    best_result: dict[str, VectorSearchResult] = {}
+
+    for results in result_lists:
+        ids: list[str] = []
+        for r in results:
+            rid = _document_id(r)
+            ids.append(rid)
+            current = best_result.get(rid)
+            if current is None or r.score > current.score:
+                best_result[rid] = r
+        id_lists.append(ids)
+
+    if not best_result:
+        return []
+
+    fused = reciprocal_rank_fusion(id_lists, rrf_k=rrf_k)
+    ranked_ids = sorted(fused.keys(), key=lambda i: (-fused[i], i))
+    out = [best_result[i] for i in ranked_ids if i in best_result]
+    if top_n is not None:
+        out = out[:top_n]
+    return out

--- a/prompture/rag/retrievers/_fusion.py
+++ b/prompture/rag/retrievers/_fusion.py
@@ -22,7 +22,7 @@ def _document_id(result: VectorSearchResult) -> str:
     meta_id = result.document.metadata.get("id")
     if meta_id is not None:
         return str(meta_id)
-    return "sha1:" + hashlib.sha1(result.document.content.encode("utf-8")).hexdigest()
+    return "sha1:" + hashlib.sha1(result.document.content.encode("utf-8"), usedforsecurity=False).hexdigest()
 
 
 def fuse_search_results(

--- a/prompture/rag/retrievers/hyde.py
+++ b/prompture/rag/retrievers/hyde.py
@@ -72,10 +72,7 @@ class HyDERetriever(Retriever):
         max_hypothetical_chars: int = 2000,
     ) -> None:
         if "{query}" not in prompt:
-            raise ValueError(
-                "HyDE prompt must include a '{query}' placeholder; got: "
-                f"{prompt[:60]!r}..."
-            )
+            raise ValueError(f"HyDE prompt must include a '{{query}}' placeholder; got: {prompt[:60]!r}...")
         self.base = base
         self.llm = llm
         self.prompt = prompt

--- a/prompture/rag/retrievers/hyde.py
+++ b/prompture/rag/retrievers/hyde.py
@@ -1,0 +1,119 @@
+"""HyDE (Hypothetical Document Embeddings) retriever wrapper.
+
+HyDE — `Gao et al. 2022 <https://arxiv.org/abs/2212.10496>`_ — observes
+that an LLM-generated hypothetical answer to the user query is often a
+better embedding-space neighbour of the *real* answer than the question
+itself. The wrapper:
+
+1. Asks an LLM to draft a hypothetical answer to ``query``.
+2. Passes that hypothetical answer through to a base retriever (which
+   embeds and looks up nearest neighbours as usual).
+3. Returns the base retriever's results.
+
+Trades one extra LLM call per query for a measurable lift in retrieval
+quality. Particularly effective when queries are short / under-specified
+and the corpus contains long-form passages.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol
+
+from ..vectorstores.base import VectorSearchResult
+from .base import Retriever
+
+logger = logging.getLogger(__name__)
+
+
+#: Default prompt used to draft the hypothetical answer. ``{query}`` is
+#: substituted with the user's question. Override via the ``prompt``
+#: constructor argument.
+DEFAULT_HYDE_PROMPT = (
+    "Write a concise, factual answer to the question below. Include enough "
+    "specific detail that the answer could plausibly appear verbatim in a "
+    "reference document. Do not say you are unsure — write the most likely "
+    "answer.\n\n"
+    "Question: {query}\n\n"
+    "Answer:"
+)
+
+
+class _LLM(Protocol):
+    """Minimal LLM contract used by the HyDE wrapper."""
+
+    def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:  # pragma: no cover - protocol
+        ...
+
+
+class HyDERetriever(Retriever):
+    """Retriever that swaps the user query for an LLM-drafted hypothetical answer.
+
+    Args:
+        base: The underlying retriever (typically a
+            :class:`VectorStoreRetriever`) that does the actual lookup.
+        llm: Any LLM driver exposing ``generate(prompt, options) -> {"text": ...}``.
+        prompt: Template containing a ``{query}`` placeholder. Defaults to
+            :data:`DEFAULT_HYDE_PROMPT`.
+        llm_options: Options forwarded to the LLM (e.g. temperature). Defaults
+            to a low-temperature deterministic generation.
+        max_hypothetical_chars: Truncate the LLM output to this many characters
+            before forwarding to the base retriever. Long hypotheticals waste
+            embedding context. Defaults to 2000.
+    """
+
+    def __init__(
+        self,
+        base: Retriever,
+        llm: _LLM,
+        *,
+        prompt: str = DEFAULT_HYDE_PROMPT,
+        llm_options: dict[str, Any] | None = None,
+        max_hypothetical_chars: int = 2000,
+    ) -> None:
+        if "{query}" not in prompt:
+            raise ValueError(
+                "HyDE prompt must include a '{query}' placeholder; got: "
+                f"{prompt[:60]!r}..."
+            )
+        self.base = base
+        self.llm = llm
+        self.prompt = prompt
+        self.llm_options = llm_options or {"temperature": 0.0, "max_tokens": 256}
+        self.max_hypothetical_chars = max_hypothetical_chars
+
+    def _draft_hypothetical(self, query: str) -> str:
+        """Call the LLM to produce a hypothetical answer for ``query``.
+
+        Falls back to the original query when the LLM returns nothing
+        useful so HyDE can never make a query *worse* than the baseline.
+        """
+        rendered = self.prompt.format(query=query)
+        try:
+            response = self.llm.generate(rendered, self.llm_options)
+        except Exception:
+            logger.warning(
+                "HyDERetriever: LLM call failed; falling back to the original query.",
+                exc_info=True,
+            )
+            return query
+        text = (response.get("text") if isinstance(response, dict) else str(response)) or ""
+        text = text.strip()
+        if not text:
+            logger.debug("HyDERetriever: LLM returned empty text; using original query.")
+            return query
+        if len(text) > self.max_hypothetical_chars:
+            text = text[: self.max_hypothetical_chars]
+        return text
+
+    def retrieve(
+        self,
+        query: str,
+        k: int = 4,
+        filter: dict | None = None,
+        **options: Any,
+    ) -> list[VectorSearchResult]:
+        hypothetical = self._draft_hypothetical(query)
+        # The base retriever handles embedding + search. Reuse its k/filter
+        # contract verbatim — HyDE only swaps the *query text*.
+        return self.base.retrieve(hypothetical, k=k, filter=filter, **options)

--- a/prompture/rag/retrievers/multi_query.py
+++ b/prompture/rag/retrievers/multi_query.py
@@ -1,0 +1,176 @@
+"""Multi-Query retriever — LLM-generated reformulations fused via RRF.
+
+For a given user query, asks an LLM to produce ``n_queries`` distinct
+reformulations, runs the base retriever once per reformulation (the
+original is included by default), and fuses the resulting ranked lists
+via Reciprocal Rank Fusion (see :func:`reciprocal_rank_fusion`).
+
+Multi-Query helps when:
+
+* The user's wording is non-canonical relative to the corpus (e.g. uses
+  jargon the corpus doesn't, or vice-versa).
+* Single-query embedding-space retrieval has high variance — averaging
+  across multiple paraphrases stabilises the top-k.
+
+Cost trade: 1 extra LLM call (the reformulation step) + N base-retriever
+calls. The reformulation call is small (returns N short strings); the
+extra retrievals are cheap if the vector store is local.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Protocol
+
+from ..vectorstores.base import VectorSearchResult
+from ._fusion import fuse_search_results
+from .base import Retriever
+
+logger = logging.getLogger(__name__)
+
+
+#: Default reformulation prompt. ``{query}`` and ``{n}`` are substituted.
+DEFAULT_MULTI_QUERY_PROMPT = (
+    "You generate alternative phrasings of a user's question to help a "
+    "search engine find relevant documents.\n\n"
+    "Generate exactly {n} alternative versions of the question below. "
+    "Vary the wording, synonyms, and level of abstraction — but preserve "
+    "the original intent. Each version should be a complete, standalone "
+    "question on a single line. Do NOT echo the original question. Do NOT "
+    "number the alternatives.\n\n"
+    "Question: {query}\n\n"
+    "Alternatives:"
+)
+
+
+class _LLM(Protocol):
+    """Minimal LLM contract used by the MultiQuery wrapper."""
+
+    def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:  # pragma: no cover - protocol
+        ...
+
+
+_LEADING_NUMBER = re.compile(r"^\s*(?:\d+[.)]|\*|-)\s+")
+
+
+def _parse_alternatives(raw: str, max_count: int) -> list[str]:
+    """Pull individual reformulation lines out of an LLM response.
+
+    Handles common shapes:
+
+    * one per line, no numbering — emitted directly
+    * ``1. Foo``, ``1) Foo``, ``- Foo``, ``* Foo`` — leading marker stripped
+    * blank lines and surrounding whitespace are dropped
+    * de-duplicates (case-insensitive)
+    * caps the result at ``max_count`` lines
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for line in raw.splitlines():
+        stripped = _LEADING_NUMBER.sub("", line.strip()).strip(" \"'")
+        if not stripped:
+            continue
+        key = stripped.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(stripped)
+        if len(out) >= max_count:
+            break
+    return out
+
+
+class MultiQueryRetriever(Retriever):
+    """Wraps a base retriever, RRF-fusing results across LLM reformulations.
+
+    Args:
+        base: The underlying retriever called once per query variant.
+        llm: LLM driver exposing ``generate(prompt, options) -> {"text": ...}``.
+        n_queries: How many *additional* reformulations to generate. Total
+            retrieval calls = ``n_queries + 1`` when ``include_original`` is
+            true. Defaults to 3.
+        include_original: Include the user's original query in the fan-out.
+            Recommended (cheap safety net). Defaults to True.
+        prompt: Template containing ``{query}`` and ``{n}`` placeholders.
+            Defaults to :data:`DEFAULT_MULTI_QUERY_PROMPT`.
+        llm_options: Options forwarded to the LLM. Higher temperature gives
+            more diversity in reformulations.
+        fetch_k: Per-variant retrieval size. Defaults to ``k`` from the
+            ``retrieve()`` call when ``None``; oversample (e.g. 2× the final
+            ``k``) when you need wider coverage before fusion.
+        rrf_k: Reciprocal Rank Fusion damping constant. Defaults to 60.
+    """
+
+    def __init__(
+        self,
+        base: Retriever,
+        llm: _LLM,
+        *,
+        n_queries: int = 3,
+        include_original: bool = True,
+        prompt: str = DEFAULT_MULTI_QUERY_PROMPT,
+        llm_options: dict[str, Any] | None = None,
+        fetch_k: int | None = None,
+        rrf_k: int = 60,
+    ) -> None:
+        if n_queries < 1:
+            raise ValueError(f"n_queries must be >= 1, got {n_queries}")
+        if "{query}" not in prompt or "{n}" not in prompt:
+            raise ValueError(
+                "MultiQuery prompt must include '{query}' and '{n}' placeholders; "
+                f"got: {prompt[:60]!r}..."
+            )
+        self.base = base
+        self.llm = llm
+        self.n_queries = n_queries
+        self.include_original = include_original
+        self.prompt = prompt
+        self.llm_options = llm_options or {"temperature": 0.7, "max_tokens": 512}
+        self.fetch_k = fetch_k
+        self.rrf_k = rrf_k
+
+    def _generate_alternatives(self, query: str) -> list[str]:
+        rendered = self.prompt.format(query=query, n=self.n_queries)
+        try:
+            response = self.llm.generate(rendered, self.llm_options)
+        except Exception:
+            logger.warning(
+                "MultiQueryRetriever: LLM call failed; falling back to original-query only.",
+                exc_info=True,
+            )
+            return []
+        text = (response.get("text") if isinstance(response, dict) else str(response)) or ""
+        alternatives = _parse_alternatives(text, max_count=self.n_queries)
+        # Drop any reformulation that turned out identical to the user's query.
+        q = query.casefold().strip()
+        return [a for a in alternatives if a.casefold().strip() != q]
+
+    def retrieve(
+        self,
+        query: str,
+        k: int = 4,
+        filter: dict | None = None,
+        **options: Any,
+    ) -> list[VectorSearchResult]:
+        alternatives = self._generate_alternatives(query)
+        # Always start with the original (when requested) so a degenerate LLM
+        # output can never make this retriever worse than the base.
+        variants: list[str] = []
+        if self.include_original or not alternatives:
+            variants.append(query)
+        variants.extend(alternatives)
+
+        per_query_k = self.fetch_k or k
+        result_lists: list[list[VectorSearchResult]] = []
+        for v in variants:
+            try:
+                result_lists.append(self.base.retrieve(v, k=per_query_k, filter=filter, **options))
+            except Exception:
+                logger.warning(
+                    "MultiQueryRetriever: base.retrieve failed for variant %r; skipping.",
+                    v[:80],
+                    exc_info=True,
+                )
+
+        return fuse_search_results(result_lists, rrf_k=self.rrf_k, top_n=k)

--- a/prompture/rag/retrievers/multi_query.py
+++ b/prompture/rag/retrievers/multi_query.py
@@ -118,8 +118,7 @@ class MultiQueryRetriever(Retriever):
             raise ValueError(f"n_queries must be >= 1, got {n_queries}")
         if "{query}" not in prompt or "{n}" not in prompt:
             raise ValueError(
-                "MultiQuery prompt must include '{query}' and '{n}' placeholders; "
-                f"got: {prompt[:60]!r}..."
+                f"MultiQuery prompt must include '{{query}}' and '{{n}}' placeholders; got: {prompt[:60]!r}..."
             )
         self.base = base
         self.llm = llm

--- a/prompture/rag/retrievers/retriever_registry.py
+++ b/prompture/rag/retrievers/retriever_registry.py
@@ -10,7 +10,8 @@ because each retriever exposes a different set of configuration options
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from .base import AsyncRetriever, Retriever
 

--- a/prompture/rag/retrievers/step_back.py
+++ b/prompture/rag/retrievers/step_back.py
@@ -1,0 +1,144 @@
+"""Step-Back retriever — broader-query abstraction fused with the original.
+
+Based on the Step-Back Prompting technique
+(`Zheng et al. 2023 <https://arxiv.org/abs/2310.06117>`_): for queries
+that are very specific, the relevant evidence often only appears when
+the retriever sees the *broader concept* the query is about. Step-Back
+asks an LLM to rephrase the query into a more general one, retrieves
+both, and RRF-fuses the two ranked lists.
+
+Useful when:
+
+* Questions are narrow / detail-oriented and the corpus contains
+  background context the query doesn't lexically overlap with.
+* You want to surface "supporting evidence" passages, not just direct
+  answer passages, before the generation step.
+
+Cost trade: 1 extra LLM call + 1 extra retrieval call per query.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol
+
+from ..vectorstores.base import VectorSearchResult
+from ._fusion import fuse_search_results
+from .base import Retriever
+
+logger = logging.getLogger(__name__)
+
+
+#: Default step-back prompt. ``{query}`` is substituted with the user's
+#: question. Adapted from the original paper's exemplar instruction
+#: (without the few-shot examples).
+DEFAULT_STEP_BACK_PROMPT = (
+    "You are an expert at rephrasing questions to be more general.\n\n"
+    "Given a specific question, write a single broader, more abstract "
+    "question that asks about the underlying concept or topic. The broader "
+    "question should make it easier to retrieve background context that "
+    "could help answer the original. Output only the broader question, on "
+    "one line, with no prefix.\n\n"
+    "Original: {query}\n\n"
+    "Broader:"
+)
+
+
+class _LLM(Protocol):
+    """Minimal LLM contract used by the StepBack wrapper."""
+
+    def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:  # pragma: no cover - protocol
+        ...
+
+
+class StepBackRetriever(Retriever):
+    """Retriever that fuses results from the original query and a step-back query.
+
+    Args:
+        base: The underlying retriever called twice (once per variant).
+        llm: LLM driver exposing ``generate(prompt, options) -> {"text": ...}``.
+        prompt: Template containing a ``{query}`` placeholder. Defaults to
+            :data:`DEFAULT_STEP_BACK_PROMPT`.
+        llm_options: Options forwarded to the LLM. Defaults to a low-temperature
+            generation since we want a single deterministic rephrasing.
+        fetch_k: Per-variant retrieval size. Defaults to ``k`` from the
+            ``retrieve()`` call when ``None``.
+        rrf_k: Reciprocal Rank Fusion damping constant. Defaults to 60.
+    """
+
+    def __init__(
+        self,
+        base: Retriever,
+        llm: _LLM,
+        *,
+        prompt: str = DEFAULT_STEP_BACK_PROMPT,
+        llm_options: dict[str, Any] | None = None,
+        fetch_k: int | None = None,
+        rrf_k: int = 60,
+    ) -> None:
+        if "{query}" not in prompt:
+            raise ValueError(
+                "StepBack prompt must include a '{query}' placeholder; got: "
+                f"{prompt[:60]!r}..."
+            )
+        self.base = base
+        self.llm = llm
+        self.prompt = prompt
+        self.llm_options = llm_options or {"temperature": 0.0, "max_tokens": 128}
+        self.fetch_k = fetch_k
+        self.rrf_k = rrf_k
+
+    def _draft_step_back(self, query: str) -> str | None:
+        """Ask the LLM for a broader version of ``query``.
+
+        Returns ``None`` when the LLM produces nothing useful or when its
+        output is identical to the original (case-insensitive). In either
+        case the wrapper falls back to original-only retrieval.
+        """
+        rendered = self.prompt.format(query=query)
+        try:
+            response = self.llm.generate(rendered, self.llm_options)
+        except Exception:
+            logger.warning(
+                "StepBackRetriever: LLM call failed; falling back to original-only retrieval.",
+                exc_info=True,
+            )
+            return None
+        text = (response.get("text") if isinstance(response, dict) else str(response)) or ""
+        # Some models emit a label-y prefix ("Broader question:") or quote
+        # the answer. Strip both before comparing to the original.
+        cleaned = text.strip().strip(" \"'")
+        # If the model returned multiple lines, keep the first non-empty one.
+        for line in cleaned.splitlines():
+            line = line.strip(" \"'")
+            if line:
+                cleaned = line
+                break
+        if not cleaned or cleaned.casefold() == query.casefold():
+            return None
+        return cleaned
+
+    def retrieve(
+        self,
+        query: str,
+        k: int = 4,
+        filter: dict | None = None,
+        **options: Any,
+    ) -> list[VectorSearchResult]:
+        broader = self._draft_step_back(query)
+        per_query_k = self.fetch_k or k
+        # Original retrieval is always done. Broader is added only when the
+        # LLM produced something distinct.
+        result_lists: list[list[VectorSearchResult]] = [
+            self.base.retrieve(query, k=per_query_k, filter=filter, **options)
+        ]
+        if broader:
+            try:
+                result_lists.append(self.base.retrieve(broader, k=per_query_k, filter=filter, **options))
+            except Exception:
+                logger.warning(
+                    "StepBackRetriever: base.retrieve failed for step-back variant %r; ignoring.",
+                    broader[:80],
+                    exc_info=True,
+                )
+        return fuse_search_results(result_lists, rrf_k=self.rrf_k, top_n=k)

--- a/prompture/rag/retrievers/step_back.py
+++ b/prompture/rag/retrievers/step_back.py
@@ -77,10 +77,7 @@ class StepBackRetriever(Retriever):
         rrf_k: int = 60,
     ) -> None:
         if "{query}" not in prompt:
-            raise ValueError(
-                "StepBack prompt must include a '{query}' placeholder; got: "
-                f"{prompt[:60]!r}..."
-            )
+            raise ValueError(f"StepBack prompt must include a '{{query}}' placeholder; got: {prompt[:60]!r}...")
         self.base = base
         self.llm = llm
         self.prompt = prompt

--- a/prompture/rag/vectorstores/base.py
+++ b/prompture/rag/vectorstores/base.py
@@ -49,7 +49,7 @@ def _cosine_sim_py(a: list[float], b: list[float]) -> float:
     """Pure-Python cosine similarity (fallback when numpy is missing)."""
     if not a or not b:
         return 0.0
-    dot = sum(x * y for x, y in zip(a, b))
+    dot = sum(x * y for x, y in zip(a, b, strict=False))
     na = math.sqrt(sum(x * x for x in a))
     nb = math.sqrt(sum(y * y for y in b))
     if na == 0 or nb == 0:

--- a/prompture/rag/vectorstores/chroma.py
+++ b/prompture/rag/vectorstores/chroma.py
@@ -102,7 +102,7 @@ class ChromaVectorStore(VectorStore):
         dists = (result.get("distances") or [[]])[0]
         embs = (result.get("embeddings") or [[None] * len(docs)])[0]
         out: list[VectorSearchResult] = []
-        for content, meta, dist, emb in zip(docs, metas, dists, embs):
+        for content, meta, dist, emb in zip(docs, metas, dists, embs, strict=False):
             out.append(
                 VectorSearchResult(
                     document=Document(content=content or "", metadata=dict(meta or {})),

--- a/prompture/rag/vectorstores/faiss.py
+++ b/prompture/rag/vectorstores/faiss.py
@@ -111,7 +111,7 @@ class FAISSVectorStore(VectorStore):
         ids = ids or [str(uuid.uuid4()) for _ in documents]
         int_ids: list[int] = []
         prepped: list[list[float]] = []
-        for sid, vec, doc in zip(ids, vectors, documents):
+        for sid, vec, doc in zip(ids, vectors, documents, strict=False):
             int_id = self._next_int_id
             self._next_int_id += 1
             pvec = self._prep_vec(vec)
@@ -149,7 +149,7 @@ class FAISSVectorStore(VectorStore):
         q = np.array([self._prep_vec(vector)], dtype="float32")
         scores, ids = self._index.search(q, min(k, self._index.ntotal))
         out: list[VectorSearchResult] = []
-        for raw_score, raw_id in zip(scores[0].tolist(), ids[0].tolist()):
+        for raw_score, raw_id in zip(scores[0].tolist(), ids[0].tolist(), strict=False):
             if raw_id == -1:
                 continue
             entry = self._docstore.get(int(raw_id))

--- a/prompture/rag/vectorstores/pgvector.py
+++ b/prompture/rag/vectorstores/pgvector.py
@@ -115,7 +115,7 @@ class PgVectorStore(VectorStore):
         size = self._infer_vector_size(vectors)
         self._ensure_table(size)
         with self._conn.cursor() as cur:
-            for _id, vec, doc in zip(ids, vectors, documents):
+            for _id, vec, doc in zip(ids, vectors, documents, strict=False):
                 cur.execute(
                     f"""
                     INSERT INTO {self.table_name} (id, content, metadata, embedding)

--- a/prompture/rag/vectorstores/pinecone.py
+++ b/prompture/rag/vectorstores/pinecone.py
@@ -62,7 +62,7 @@ class PineconeVectorStore(VectorStore):
         documents: list[Document],
     ) -> list[dict[str, Any]]:
         items: list[dict[str, Any]] = []
-        for _id, vec, doc in zip(ids, vectors, documents):
+        for _id, vec, doc in zip(ids, vectors, documents, strict=False):
             md = dict(doc.metadata)
             md.setdefault("_content", doc.content)
             items.append({"id": _id, "values": list(vec), "metadata": md})

--- a/prompture/rag/vectorstores/qdrant.py
+++ b/prompture/rag/vectorstores/qdrant.py
@@ -116,7 +116,7 @@ class QdrantVectorStore(VectorStore):
         documents: list[Document],
     ):
         points = []
-        for _id, vec, doc in zip(ids, vectors, documents):
+        for _id, vec, doc in zip(ids, vectors, documents, strict=False):
             payload = dict(doc.metadata)
             payload["_content"] = doc.content
             if self._qmodels is not None:

--- a/prompture/rag/vectorstores/vectorstore_registry.py
+++ b/prompture/rag/vectorstores/vectorstore_registry.py
@@ -9,7 +9,8 @@ at instantiation time.
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from .base import AsyncVectorStore, VectorStore
 

--- a/prompture/rag/vectorstores/weaviate.py
+++ b/prompture/rag/vectorstores/weaviate.py
@@ -87,7 +87,7 @@ class WeaviateVectorStore(VectorStore):
     ) -> list[str]:
         ids = ids or [str(uuid.uuid4()) for _ in documents]
         coll = self._coll()
-        for _id, vec, doc in zip(ids, vectors, documents):
+        for _id, vec, doc in zip(ids, vectors, documents, strict=False):
             props = {"content": doc.content, "metadata": doc.metadata}
             coll.data.insert(properties=props, uuid=_id, vector=list(vec))
         return ids

--- a/prompture/refusal/evaluator.py
+++ b/prompture/refusal/evaluator.py
@@ -254,7 +254,7 @@ class RefusalEvaluator:
         # Group flagged responses by category so the sample set covers
         # the spectrum instead of repeating one type.
         by_cat: dict[RefusalCategory, list[tuple[str, str, RefusalResult]]] = {}
-        for prompt, response, result in zip(prompts, responses, results):
+        for prompt, response, result in zip(prompts, responses, results, strict=False):
             if not result.is_refusal or result.category is None:
                 continue
             by_cat.setdefault(result.category, []).append((prompt, response, result))

--- a/prompture/security/redaction.py
+++ b/prompture/security/redaction.py
@@ -37,9 +37,9 @@ from __future__ import annotations
 
 import enum
 import re
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any
 
 
 class PIICategory(str, enum.Enum):

--- a/prompture/session_memory/__init__.py
+++ b/prompture/session_memory/__init__.py
@@ -1,0 +1,42 @@
+"""Cross-session memory for Prompture.
+
+Distinct from :class:`~prompture.swarm.MemoryStore` — which is a
+per-agent, per-run scratchpad — :class:`SessionMemory` persists across
+*conversations*, keyed by ``(user_id, session_id)``.  Designed to plug
+into :class:`~prompture.agents.Conversation` and
+:class:`~prompture.agents.Agent` (especially with
+``persistent_conversation=True``) so user-specific facts survive a
+process restart.
+
+Three layers:
+
+- :class:`MemoryFact` — an atomic remembered item (a recalled snippet,
+  a summarised round, a user preference).
+- :class:`SessionMemoryStore` — pluggable backend protocol; ships with
+  :class:`InMemorySessionStore` and :class:`SQLiteSessionStore`.
+- :class:`SessionMemory` — high-level API: ``remember`` /
+  ``recall`` / ``summarize`` / ``render_for_prompt``.
+"""
+
+from .core import (
+    SessionMemory,
+    Summarizer,
+    default_summarizer,
+)
+from .stores import (
+    InMemorySessionStore,
+    SessionMemoryStore,
+    SQLiteSessionStore,
+)
+from .types import MemoryFact, MemoryKind
+
+__all__ = [
+    "InMemorySessionStore",
+    "MemoryFact",
+    "MemoryKind",
+    "SQLiteSessionStore",
+    "SessionMemory",
+    "SessionMemoryStore",
+    "Summarizer",
+    "default_summarizer",
+]

--- a/prompture/session_memory/core.py
+++ b/prompture/session_memory/core.py
@@ -1,0 +1,318 @@
+"""High-level :class:`SessionMemory` API.
+
+Sits in front of a :class:`SessionMemoryStore` and provides the
+ergonomics callers actually want:
+
+- ``remember(text)`` — write a single fact.
+- ``recall(query)`` — fetch the most relevant facts as a list, or as a
+  ready-to-paste prompt fragment via :meth:`SessionMemory.render_for_prompt`.
+- ``summarize(messages)`` — collapse a chunk of conversation into a
+  rolling summary (uses a user-supplied :class:`Summarizer` callable).
+
+Hooks into :class:`~prompture.agents.Conversation` /
+:class:`~prompture.agents.Agent` via the ``before_turn`` mechanism: the
+caller builds a system-prompt fragment from :meth:`render_for_prompt`
+and concatenates it onto the agent's system prompt.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Any, Protocol, runtime_checkable
+
+from .stores import InMemorySessionStore, SessionMemoryStore
+from .types import MemoryFact, MemoryKind
+
+
+@runtime_checkable
+class Summarizer(Protocol):
+    """Callable that compresses a list of messages into a summary string.
+
+    Used by :meth:`SessionMemory.summarize` to roll up long
+    conversations.  The contract is intentionally simple: receive
+    role/content message dicts, return a single short paragraph.
+    """
+
+    def __call__(self, messages: list[dict[str, Any]]) -> str:
+        ...
+
+
+def default_summarizer(messages: list[dict[str, Any]]) -> str:
+    """Pure-Python fallback summarizer used when none is configured.
+
+    Picks the first and last user messages and joins them.  This is a
+    *placeholder* — for real summarisation pass an LLM-backed summarizer
+    (e.g. wrap a :class:`~prompture.agents.Conversation`).
+    """
+    if not messages:
+        return ""
+    user_msgs = [m for m in messages if m.get("role") == "user"]
+    if not user_msgs:
+        return ""
+    first = user_msgs[0].get("content", "")
+    last = user_msgs[-1].get("content", "")
+    if first == last:
+        return f"User said: {first}"
+    return f"Conversation started with: {first} … and recently: {last}"
+
+
+class SessionMemory:
+    """User- and session-scoped persistent memory.
+
+    Args:
+        user_id: Owning user identifier.  Required.
+        session_id: Optional session identifier.  ``None`` means
+            "user-wide" — these facts persist across every session.
+        store: Backing :class:`SessionMemoryStore`.  Defaults to a fresh
+            :class:`InMemorySessionStore`.
+        recall_k: Default number of facts surfaced by
+            :meth:`render_for_prompt`.
+        summarizer: Optional callable used by :meth:`summarize`.  When
+            ``None``, :func:`default_summarizer` is used.
+
+    Example::
+
+        from prompture import Conversation, SessionMemory
+
+        memory = SessionMemory(user_id="alice", session_id="trip-2026")
+        memory.remember("User prefers concise answers.", kind="preference")
+
+        conv = Conversation(model_name="openai/gpt-4o-mini",
+                            system_prompt=memory.render_for_prompt())
+        conv.ask("What's the weather?")
+    """
+
+    def __init__(
+        self,
+        user_id: str,
+        *,
+        session_id: str | None = None,
+        store: SessionMemoryStore | None = None,
+        recall_k: int = 5,
+        summarizer: Summarizer | None = None,
+    ) -> None:
+        if not user_id:
+            raise ValueError("SessionMemory requires a non-empty user_id")
+        self._user_id = user_id
+        self._session_id = session_id
+        self._store: SessionMemoryStore = store if store is not None else InMemorySessionStore()
+        self._recall_k = recall_k
+        self._summarizer = summarizer
+
+    # ------------------------------------------------------------------
+    # Read-only access
+    # ------------------------------------------------------------------
+
+    @property
+    def user_id(self) -> str:
+        return self._user_id
+
+    @property
+    def session_id(self) -> str | None:
+        return self._session_id
+
+    @property
+    def store(self) -> SessionMemoryStore:
+        return self._store
+
+    # ------------------------------------------------------------------
+    # Write
+    # ------------------------------------------------------------------
+
+    def remember(
+        self,
+        content: str,
+        *,
+        kind: str = MemoryKind.fact.value,
+        importance: float = 0.5,
+        metadata: dict[str, Any] | None = None,
+        session_scoped: bool = False,
+    ) -> MemoryFact:
+        """Persist a memory and return the typed :class:`MemoryFact`.
+
+        Args:
+            content: Free-form text to remember.
+            kind: Classification (see :class:`MemoryKind`).  Custom
+                strings are allowed.
+            importance: ``[0.0, 1.0]`` — higher values rank higher in
+                :meth:`recall`.
+            metadata: Optional structured payload.
+            session_scoped: When ``True`` the fact is recorded against
+                this :class:`SessionMemory`'s ``session_id``; when
+                ``False`` (default) the fact is user-wide (no session
+                key).  User-wide facts surface across every session.
+        """
+        sid: str | None = self._session_id if session_scoped else None
+        fact = MemoryFact(
+            user_id=self._user_id,
+            session_id=sid,
+            content=content,
+            kind=kind,
+            importance=float(importance),
+            metadata=dict(metadata) if metadata else {},
+        )
+        self._store.add(fact)
+        return fact
+
+    def forget(self, fact_id: str) -> bool:
+        """Drop a specific fact by id.  Returns ``True`` when removed."""
+        removed = self._store.delete(self._user_id, fact_id=fact_id)
+        return removed > 0
+
+    def clear_session(self) -> int:
+        """Drop every fact tied to this session.  User-wide facts remain.
+
+        Returns the number of removed records.
+        """
+        if self._session_id is None:
+            # Caller asked to clear "this session" but it has no id;
+            # interpret as the user-wide bucket.
+            return self._store.delete(self._user_id, session_id="__user__")
+        return self._store.delete(self._user_id, session_id=self._session_id)
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    def all(
+        self,
+        *,
+        kinds: tuple[str, ...] | None = None,
+        include_user_wide: bool = True,
+        limit: int | None = None,
+    ) -> list[MemoryFact]:
+        """List facts visible to this session.
+
+        Returns the session's own facts plus user-wide facts when
+        ``include_user_wide`` is ``True`` (the default).
+        """
+        out: list[MemoryFact] = []
+        if include_user_wide:
+            out.extend(self._store.list(self._user_id, session_id="__user__", kinds=kinds))
+        if self._session_id is not None:
+            out.extend(self._store.list(self._user_id, session_id=self._session_id, kinds=kinds))
+        out.sort(key=lambda f: f.ts)
+        if limit is not None and limit >= 0:
+            out = out[-limit:]
+        return out
+
+    def recall(
+        self,
+        query: str,
+        *,
+        k: int | None = None,
+        kinds: tuple[str, ...] | None = None,
+        include_user_wide: bool = True,
+    ) -> list[MemoryFact]:
+        """Return up to *k* facts most relevant to *query*.
+
+        Searches both this session's facts and user-wide facts when
+        ``include_user_wide`` is ``True``, merges the candidate lists,
+        and re-scores them so the top-*k* spans both buckets.
+        """
+        effective_k = k if k is not None else self._recall_k
+        # The store scorer combines overlap + importance + recency.
+        # Querying both buckets and merging by score is fine because the
+        # ranking is over (overlap, importance, recency), not bucket.
+        merged: list[MemoryFact] = []
+        if include_user_wide:
+            merged.extend(
+                self._store.search(
+                    self._user_id,
+                    query,
+                    session_id="__user__",
+                    kinds=kinds,
+                    k=effective_k,
+                )
+            )
+        if self._session_id is not None:
+            merged.extend(
+                self._store.search(
+                    self._user_id,
+                    query,
+                    session_id=self._session_id,
+                    kinds=kinds,
+                    k=effective_k,
+                )
+            )
+        # De-duplicate by id while preserving order, then truncate.
+        seen: set[str] = set()
+        out: list[MemoryFact] = []
+        for f in merged:
+            if f.id in seen:
+                continue
+            seen.add(f.id)
+            out.append(f)
+            if effective_k >= 0 and len(out) >= effective_k:
+                break
+        return out
+
+    # ------------------------------------------------------------------
+    # Prompt assembly
+    # ------------------------------------------------------------------
+
+    def render_for_prompt(
+        self,
+        query: str | None = None,
+        *,
+        k: int | None = None,
+        header: str = "## Long-term memory",
+        include_user_wide: bool = True,
+    ) -> str:
+        """Render relevant memories as a prompt-ready string.
+
+        When *query* is ``None`` the most recent ``k`` facts are
+        included; otherwise :meth:`recall` is used to score by
+        relevance.  Returns an empty string when no facts apply.
+        """
+        if query is None:
+            facts = self.all(include_user_wide=include_user_wide, limit=k or self._recall_k)
+        else:
+            facts = self.recall(query, k=k, include_user_wide=include_user_wide)
+        if not facts:
+            return ""
+
+        lines = [header]
+        for f in facts:
+            lines.append(f"- ({f.kind}) {f.content}")
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Summarisation
+    # ------------------------------------------------------------------
+
+    def summarize(
+        self,
+        messages: Iterable[dict[str, Any]],
+        *,
+        importance: float = 0.6,
+        summarizer: Summarizer | Callable[[list[dict[str, Any]]], str] | None = None,
+    ) -> MemoryFact | None:
+        """Collapse a slice of conversation into a stored summary memory.
+
+        Args:
+            messages: Iterable of role/content message dicts (typically
+                :attr:`Conversation.messages`).
+            importance: Importance score for the resulting fact.
+            summarizer: Override the configured summarizer for this
+                call only.  Useful when wiring up an LLM-backed
+                summarizer dynamically.
+
+        Returns:
+            The persisted :class:`MemoryFact`, or ``None`` when the
+            summarizer produced an empty string.
+        """
+        msg_list = list(messages)
+        if not msg_list:
+            return None
+        fn = summarizer or self._summarizer or default_summarizer
+        summary_text = fn(msg_list)
+        if not summary_text:
+            return None
+        return self.remember(
+            summary_text,
+            kind=MemoryKind.summary.value,
+            importance=importance,
+            metadata={"message_count": len(msg_list)},
+            session_scoped=True,
+        )

--- a/prompture/session_memory/core.py
+++ b/prompture/session_memory/core.py
@@ -33,8 +33,7 @@ class Summarizer(Protocol):
     role/content message dicts, return a single short paragraph.
     """
 
-    def __call__(self, messages: list[dict[str, Any]]) -> str:
-        ...
+    def __call__(self, messages: list[dict[str, Any]]) -> str: ...
 
 
 def default_summarizer(messages: list[dict[str, Any]]) -> str:

--- a/prompture/session_memory/stores.py
+++ b/prompture/session_memory/stores.py
@@ -1,0 +1,389 @@
+"""Storage backends for :class:`SessionMemory`.
+
+Two implementations ship out of the box:
+
+- :class:`InMemorySessionStore` — thread-safe, no dependencies.
+  Suitable for tests, scripts, and single-process services.
+- :class:`SQLiteSessionStore` — file-backed durable storage with the
+  same indexing pattern as :class:`~prompture.persistence.ConversationStore`.
+
+Both satisfy the :class:`SessionMemoryStore` protocol.  Bring-your-own
+backends (Postgres, Redis, a vector store, Zep, Mem0) implement the
+same four methods.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import threading
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from .types import MemoryFact
+
+_DEFAULT_DB_DIR = Path.home() / ".prompture" / "session_memory"
+_DEFAULT_DB_PATH = _DEFAULT_DB_DIR / "session_memory.db"
+_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+
+
+def _tokens(text: str) -> set[str]:
+    return {m.group(0).lower() for m in _TOKEN_RE.finditer(text)}
+
+
+@runtime_checkable
+class SessionMemoryStore(Protocol):
+    """Pluggable persistence contract for :class:`SessionMemory`.
+
+    All operations are user-scoped: callers identify themselves with a
+    ``user_id`` and an optional ``session_id``.  Implementations should
+    be thread-safe.
+    """
+
+    def add(self, fact: MemoryFact) -> None:
+        """Persist a new :class:`MemoryFact` (or upsert by id)."""
+        ...
+
+    def list(
+        self,
+        user_id: str,
+        *,
+        session_id: str | None = None,
+        kinds: tuple[str, ...] | None = None,
+        limit: int | None = None,
+    ) -> list[MemoryFact]:
+        """Return facts for *user_id*, optionally narrowed to a session/kind.
+
+        Results are oldest-first.  When ``session_id`` is ``None``
+        every session for the user is included; pass a string to
+        restrict to one session (use the literal sentinel value
+        ``"__user__"`` to mean "user-wide facts only").
+        """
+        ...
+
+    def search(
+        self,
+        user_id: str,
+        query: str,
+        *,
+        session_id: str | None = None,
+        kinds: tuple[str, ...] | None = None,
+        k: int = 5,
+    ) -> list[MemoryFact]:
+        """Return up to *k* facts relevant to *query* for *user_id*.
+
+        Relevance is implementation-defined; default backends use
+        token-overlap scoring weighted by importance and recency.
+        """
+        ...
+
+    def delete(self, user_id: str, *, session_id: str | None = None, fact_id: str | None = None) -> int:
+        """Drop facts.  Returns the number deleted.
+
+        At least one of ``session_id`` / ``fact_id`` should be supplied
+        — implementations may choose to refuse a totally-unscoped
+        delete to avoid accidental data loss.
+        """
+        ...
+
+
+# ----------------------------------------------------------------------
+# In-memory backend
+# ----------------------------------------------------------------------
+
+
+class InMemorySessionStore:
+    """Thread-safe in-process implementation of :class:`SessionMemoryStore`."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        # Two-level index: user_id → list[MemoryFact]
+        self._by_user: dict[str, list[MemoryFact]] = defaultdict(list)
+
+    def add(self, fact: MemoryFact) -> None:
+        with self._lock:
+            records = self._by_user[fact.user_id]
+            # Upsert by id
+            for i, existing in enumerate(records):
+                if existing.id == fact.id:
+                    records[i] = fact
+                    return
+            records.append(fact)
+
+    def list(
+        self,
+        user_id: str,
+        *,
+        session_id: str | None = None,
+        kinds: tuple[str, ...] | None = None,
+        limit: int | None = None,
+    ) -> list[MemoryFact]:
+        with self._lock:
+            records = list(self._by_user.get(user_id, ()))
+
+        out: list[MemoryFact] = []
+        for r in records:
+            if session_id == "__user__":
+                if r.session_id is not None:
+                    continue
+            elif session_id is not None and r.session_id != session_id:
+                continue
+            if kinds is not None and r.kind not in kinds:
+                continue
+            out.append(r)
+        out.sort(key=lambda r: r.ts)
+        if limit is not None and limit >= 0:
+            out = out[-limit:]
+        return out
+
+    def search(
+        self,
+        user_id: str,
+        query: str,
+        *,
+        session_id: str | None = None,
+        kinds: tuple[str, ...] | None = None,
+        k: int = 5,
+    ) -> list[MemoryFact]:
+        candidates = self.list(user_id, session_id=session_id, kinds=kinds)
+        q = _tokens(query)
+        if not q:
+            return candidates[-k:] if k > 0 else []
+
+        now = time.time()
+        scored: list[tuple[float, MemoryFact]] = []
+        for fact in candidates:
+            overlap = len(_tokens(fact.content) & q)
+            if overlap == 0:
+                continue
+            # Importance + recency boost.  Half-life ~7 days.
+            age_days = max(0.0, (now - fact.ts) / 86400.0)
+            recency = 0.5 ** (age_days / 7.0)
+            score = overlap + (fact.importance * 0.5) + (recency * 0.25)
+            scored.append((score, fact))
+
+        scored.sort(key=lambda t: t[0], reverse=True)
+        return [f for _, f in scored[:k]] if k > 0 else []
+
+    def delete(self, user_id: str, *, session_id: str | None = None, fact_id: str | None = None) -> int:
+        if session_id is None and fact_id is None:
+            raise ValueError(
+                "Refusing to delete every memory for a user without a "
+                "session_id or fact_id filter — pass session_id='__user__' "
+                "to clear user-wide facts explicitly."
+            )
+
+        with self._lock:
+            records = self._by_user.get(user_id, [])
+            keep: list[MemoryFact] = []
+            removed = 0
+            for r in records:
+                drop = False
+                if fact_id is not None and r.id == fact_id:
+                    drop = True
+                elif session_id is not None:
+                    if session_id == "__user__":
+                        drop = r.session_id is None
+                    else:
+                        drop = r.session_id == session_id
+                if drop:
+                    removed += 1
+                else:
+                    keep.append(r)
+            self._by_user[user_id] = keep
+            return removed
+
+
+# ----------------------------------------------------------------------
+# SQLite backend
+# ----------------------------------------------------------------------
+
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS session_memory (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    session_id TEXT,
+    content TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    ts REAL NOT NULL,
+    importance REAL NOT NULL DEFAULT 0.5,
+    metadata TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_memory_user
+    ON session_memory(user_id);
+CREATE INDEX IF NOT EXISTS idx_session_memory_user_session
+    ON session_memory(user_id, session_id);
+CREATE INDEX IF NOT EXISTS idx_session_memory_ts
+    ON session_memory(user_id, ts);
+"""
+
+
+class SQLiteSessionStore:
+    """File-backed durable :class:`SessionMemoryStore`.
+
+    Mirrors :class:`~prompture.persistence.ConversationStore`: single
+    file at ``~/.prompture/session_memory/session_memory.db`` by
+    default, WAL mode, thread-safe via a single ``threading.Lock``.
+
+    Args:
+        db_path: Override the default DB location.
+    """
+
+    def __init__(self, db_path: str | Path | None = None) -> None:
+        self._db_path = Path(db_path) if db_path else _DEFAULT_DB_PATH
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._init_db()
+
+    def _init_db(self) -> None:
+        with self._lock:
+            conn = sqlite3.connect(str(self._db_path))
+            try:
+                conn.execute("PRAGMA journal_mode=WAL")
+                conn.executescript(_SCHEMA_SQL)
+                conn.commit()
+            finally:
+                conn.close()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self._db_path))
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def add(self, fact: MemoryFact) -> None:
+        with self._lock:
+            conn = self._connect()
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO session_memory
+                        (id, user_id, session_id, content, kind, ts, importance, metadata)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(id) DO UPDATE SET
+                        content = excluded.content,
+                        kind = excluded.kind,
+                        ts = excluded.ts,
+                        importance = excluded.importance,
+                        metadata = excluded.metadata
+                    """,
+                    (
+                        fact.id,
+                        fact.user_id,
+                        fact.session_id,
+                        fact.content,
+                        fact.kind,
+                        fact.ts,
+                        fact.importance,
+                        json.dumps(fact.metadata, ensure_ascii=False),
+                    ),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+    def list(
+        self,
+        user_id: str,
+        *,
+        session_id: str | None = None,
+        kinds: tuple[str, ...] | None = None,
+        limit: int | None = None,
+    ) -> list[MemoryFact]:
+        sql = "SELECT * FROM session_memory WHERE user_id = ?"
+        params: list[Any] = [user_id]
+        if session_id == "__user__":
+            sql += " AND session_id IS NULL"
+        elif session_id is not None:
+            sql += " AND session_id = ?"
+            params.append(session_id)
+        if kinds is not None and len(kinds) > 0:
+            placeholders = ",".join("?" * len(kinds))
+            sql += f" AND kind IN ({placeholders})"
+            params.extend(kinds)
+        sql += " ORDER BY ts ASC"
+
+        with self._lock:
+            conn = self._connect()
+            try:
+                rows = conn.execute(sql, params).fetchall()
+            finally:
+                conn.close()
+
+        out = [self._row_to_fact(r) for r in rows]
+        if limit is not None and limit >= 0:
+            out = out[-limit:]
+        return out
+
+    def search(
+        self,
+        user_id: str,
+        query: str,
+        *,
+        session_id: str | None = None,
+        kinds: tuple[str, ...] | None = None,
+        k: int = 5,
+    ) -> list[MemoryFact]:
+        # Reuse the in-memory scorer over the SQL-filtered candidate set.
+        candidates = self.list(user_id, session_id=session_id, kinds=kinds)
+        q = _tokens(query)
+        if not q:
+            return candidates[-k:] if k > 0 else []
+
+        now = time.time()
+        scored: list[tuple[float, MemoryFact]] = []
+        for fact in candidates:
+            overlap = len(_tokens(fact.content) & q)
+            if overlap == 0:
+                continue
+            age_days = max(0.0, (now - fact.ts) / 86400.0)
+            recency = 0.5 ** (age_days / 7.0)
+            score = overlap + (fact.importance * 0.5) + (recency * 0.25)
+            scored.append((score, fact))
+        scored.sort(key=lambda t: t[0], reverse=True)
+        return [f for _, f in scored[:k]] if k > 0 else []
+
+    def delete(self, user_id: str, *, session_id: str | None = None, fact_id: str | None = None) -> int:
+        if session_id is None and fact_id is None:
+            raise ValueError(
+                "Refusing to delete every memory for a user without a "
+                "session_id or fact_id filter."
+            )
+
+        sql = "DELETE FROM session_memory WHERE user_id = ?"
+        params: list[Any] = [user_id]
+        if fact_id is not None:
+            sql += " AND id = ?"
+            params.append(fact_id)
+        elif session_id == "__user__":
+            sql += " AND session_id IS NULL"
+        elif session_id is not None:
+            sql += " AND session_id = ?"
+            params.append(session_id)
+
+        with self._lock:
+            conn = self._connect()
+            try:
+                cursor = conn.execute(sql, params)
+                conn.commit()
+                return int(cursor.rowcount)
+            finally:
+                conn.close()
+
+    @staticmethod
+    def _row_to_fact(row: sqlite3.Row) -> MemoryFact:
+        return MemoryFact(
+            id=row["id"],
+            user_id=row["user_id"],
+            session_id=row["session_id"],
+            content=row["content"],
+            kind=row["kind"],
+            ts=float(row["ts"]),
+            importance=float(row["importance"]),
+            metadata=json.loads(row["metadata"]) if row["metadata"] else {},
+        )

--- a/prompture/session_memory/stores.py
+++ b/prompture/session_memory/stores.py
@@ -350,10 +350,7 @@ class SQLiteSessionStore:
 
     def delete(self, user_id: str, *, session_id: str | None = None, fact_id: str | None = None) -> int:
         if session_id is None and fact_id is None:
-            raise ValueError(
-                "Refusing to delete every memory for a user without a "
-                "session_id or fact_id filter."
-            )
+            raise ValueError("Refusing to delete every memory for a user without a session_id or fact_id filter.")
 
         sql = "DELETE FROM session_memory WHERE user_id = ?"
         params: list[Any] = [user_id]

--- a/prompture/session_memory/types.py
+++ b/prompture/session_memory/types.py
@@ -1,0 +1,87 @@
+"""Types for cross-session memory."""
+
+from __future__ import annotations
+
+import enum
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class MemoryKind(str, enum.Enum):
+    """Categorisation tag used by :class:`MemoryFact`.
+
+    Values are stored as plain strings so callers can introduce custom
+    kinds without modifying the enum (memory backends compare kinds by
+    string equality).
+    """
+
+    fact = "fact"
+    """An atomic stable fact about the user or world."""
+
+    preference = "preference"
+    """A user-stated preference (likes/dislikes/conventions)."""
+
+    summary = "summary"
+    """A rolling summary of a chunk of conversation."""
+
+    note = "note"
+    """A free-form note the caller asked to persist."""
+
+    instruction = "instruction"
+    """A persistent system-instruction the user asked Claude to follow."""
+
+
+@dataclass
+class MemoryFact:
+    """A single record persisted by :class:`SessionMemory`.
+
+    Attributes:
+        id: Unique identifier (auto-generated UUID4 hex if omitted).
+        user_id: Owner of the memory.  Required.
+        session_id: Optional sub-key for session-scoped memories.  Use
+            ``None`` for user-wide memories.
+        content: The remembered text.
+        kind: Classification (see :class:`MemoryKind`).
+        ts: Wall-clock timestamp of authorship.
+        importance: Float on ``[0.0, 1.0]``.  Higher values are more
+            likely to surface in :meth:`SessionMemory.recall`.
+        metadata: Free-form structured payload.
+    """
+
+    user_id: str
+    content: str
+    kind: str = MemoryKind.fact.value
+    session_id: str | None = None
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    ts: float = field(default_factory=time.time)
+    importance: float = 0.5
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-serialisable representation."""
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "session_id": self.session_id,
+            "content": self.content,
+            "kind": self.kind,
+            "ts": self.ts,
+            "importance": self.importance,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MemoryFact:
+        """Inverse of :meth:`to_dict`."""
+        return cls(
+            id=data["id"],
+            user_id=data["user_id"],
+            session_id=data.get("session_id"),
+            content=data["content"],
+            kind=data.get("kind", MemoryKind.fact.value),
+            ts=float(data.get("ts", time.time())),
+            importance=float(data.get("importance", 0.5)),
+            metadata=dict(data.get("metadata") or {}),
+        )

--- a/prompture/swarm/__init__.py
+++ b/prompture/swarm/__init__.py
@@ -1,0 +1,102 @@
+"""Swarm intelligence runtime for Prompture.
+
+A :class:`Swarm` orchestrates a population of :class:`SwarmAgent`
+participants against a shared :class:`Environment` over multiple
+rounds (ticks).  Each agent observes a filtered slice of the
+environment's event log and (optional) long-term memory, then acts —
+writing observations back into the environment for the next round.
+
+Top-level pieces:
+
+- :class:`Swarm` — the orchestrator (ticks, scheduling, budget,
+  callbacks, error policy).
+- :class:`SwarmAgent` — a participant wrapping any
+  :class:`~prompture.agents.Agent`-shaped object via composition.
+- :class:`Environment` — append-only event log + mutable world state.
+- :class:`MemoryStore` / :class:`InMemoryStore` — per-agent long-term
+  memory contract and default backend.
+- :class:`Scheduler` and friends — pluggable tick activation policies.
+- :class:`Event`, :class:`SwarmResult`, :class:`SwarmStep`,
+  :class:`SwarmCallbacks` — data types.
+
+Example::
+
+    from prompture import Agent, Persona
+    from prompture.swarm import Swarm, SwarmAgent, Environment, InMemoryStore
+
+    journalist = Agent(
+        "openai/gpt-4o",
+        system_prompt=Persona(name="journo", system_prompt="You are a city desk reporter."),
+    )
+    contrarian = Agent(
+        "openai/gpt-4o",
+        system_prompt=Persona(name="contra", system_prompt="You always argue the opposite."),
+    )
+
+    memory = InMemoryStore()
+    swarm = Swarm(
+        agents=[
+            SwarmAgent(journalist, name="journo", role="reporter"),
+            SwarmAgent(contrarian, name="contra", role="contrarian"),
+        ],
+        memory=memory,
+        max_ticks=4,
+    )
+    result = swarm.run(seed="Breaking: city council passes new tax.")
+    for ev in result.events:
+        print(ev.tick, ev.agent_id, ev.content)
+"""
+
+from .environment import ENV_AGENT_ID, Environment
+from .memory import InMemoryStore, MemoryStore
+from .scheduler import (
+    AllScheduler,
+    CallableScheduler,
+    PriorityScheduler,
+    RoundRobinScheduler,
+    SampleScheduler,
+    Scheduler,
+    make_scheduler,
+)
+from .swarm import Swarm
+from .swarm_agent import (
+    SwarmAgent,
+    default_observe,
+    default_post_act,
+    default_remember,
+)
+from .types import (
+    Event,
+    EventKind,
+    Memory,
+    SwarmCallbacks,
+    SwarmResult,
+    SwarmStep,
+    aggregate_usage,
+)
+
+__all__ = [
+    "ENV_AGENT_ID",
+    "AllScheduler",
+    "CallableScheduler",
+    "Environment",
+    "Event",
+    "EventKind",
+    "InMemoryStore",
+    "Memory",
+    "MemoryStore",
+    "PriorityScheduler",
+    "RoundRobinScheduler",
+    "SampleScheduler",
+    "Scheduler",
+    "Swarm",
+    "SwarmAgent",
+    "SwarmCallbacks",
+    "SwarmResult",
+    "SwarmStep",
+    "aggregate_usage",
+    "default_observe",
+    "default_post_act",
+    "default_remember",
+    "make_scheduler",
+]

--- a/prompture/swarm/environment.py
+++ b/prompture/swarm/environment.py
@@ -1,0 +1,245 @@
+"""Shared world state for a swarm.
+
+The :class:`Environment` is the swarm's blackboard: an append-only
+event log plus a mutable world-state dict.  Agents perceive the world
+by reading filtered slices of the event log (and, optionally, world
+state); they act by emitting events back into it.
+
+Visibility model
+----------------
+Every event carries a ``targets`` tuple.  An empty tuple means
+*broadcast* — every agent sees it.  A non-empty tuple addresses the
+event to those agents only.  The emitting agent always sees their own
+event regardless of targets.  Topics provide a parallel filtering axis
+agents can subscribe to.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable, Iterable
+from typing import Any
+
+from .types import Event
+
+ENV_AGENT_ID = "__env__"
+
+
+class Environment:
+    """Append-only event log + mutable world state shared by all swarm agents.
+
+    The environment is the only mutable surface every agent shares.
+    Reads (``state``, ``events_for``) return defensive copies so callers
+    cannot mutate the log in place.
+
+    Args:
+        initial_state: Optional starting values for the world-state dict.
+        on_event: Optional callback fired for every event written to the
+            log.  Receives the :class:`Event` instance.  Useful for
+            piping the timeline to a UI without subscribing through
+            :class:`~prompture.swarm.types.SwarmCallbacks`.
+        on_state_update: Optional callback ``(key, value)`` fired
+            whenever :meth:`set` mutates the world-state dict.
+    """
+
+    def __init__(
+        self,
+        *,
+        initial_state: dict[str, Any] | None = None,
+        on_event: Callable[[Event], None] | None = None,
+        on_state_update: Callable[[str, Any], None] | None = None,
+    ) -> None:
+        self._lock = threading.RLock()
+        self._state: dict[str, Any] = dict(initial_state) if initial_state else {}
+        self._events: list[Event] = []
+        self._on_event = on_event
+        self._on_state_update = on_state_update
+        self._tick: int = 0
+
+    # ------------------------------------------------------------------
+    # Tick bookkeeping
+    # ------------------------------------------------------------------
+
+    @property
+    def tick(self) -> int:
+        """The current round index, controlled by :class:`Swarm`."""
+        return self._tick
+
+    def advance_tick(self) -> int:
+        """Move to the next round.  Returns the new tick index.
+
+        Called by :class:`~prompture.swarm.Swarm` at the start of every
+        round.  Direct callers normally do not invoke this.
+        """
+        with self._lock:
+            self._tick += 1
+            return self._tick
+
+    # ------------------------------------------------------------------
+    # World state
+    # ------------------------------------------------------------------
+
+    @property
+    def state(self) -> dict[str, Any]:
+        """Return a shallow copy of the current world-state dict."""
+        with self._lock:
+            return dict(self._state)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Read a single world-state value."""
+        with self._lock:
+            return self._state.get(key, default)
+
+    def set(self, key: str, value: Any) -> None:
+        """Write a world-state value and fire the update callback."""
+        with self._lock:
+            self._state[key] = value
+        if self._on_state_update is not None:
+            self._on_state_update(key, value)
+
+    def update(self, values: dict[str, Any]) -> None:
+        """Merge *values* into the world state.
+
+        Fires ``on_state_update`` once per key.
+        """
+        for k, v in values.items():
+            self.set(k, v)
+
+    # ------------------------------------------------------------------
+    # Event log
+    # ------------------------------------------------------------------
+
+    def emit(
+        self,
+        agent_id: str,
+        content: str,
+        *,
+        kind: str = "say",
+        targets: Iterable[str] = (),
+        topic: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        tick: int | None = None,
+        ts: float | None = None,
+    ) -> Event:
+        """Append a new :class:`Event` to the log.
+
+        Args:
+            agent_id: Author of the event.  Use :data:`ENV_AGENT_ID`
+                for events authored by the environment itself.
+            content: Free-form text payload.
+            kind: Event classification (see :class:`EventKind`).
+            targets: Iterable of agent IDs the event is addressed to.
+                Empty means broadcast.
+            topic: Optional topic tag.
+            metadata: Optional structured metadata.
+            tick: Override the recorded tick (defaults to the current).
+            ts: Override the timestamp (defaults to ``time.time()``).
+        """
+        event = Event(
+            tick=tick if tick is not None else self._tick,
+            ts=ts if ts is not None else time.time(),
+            agent_id=agent_id,
+            kind=kind,
+            content=content,
+            targets=tuple(targets),
+            topic=topic,
+            metadata=dict(metadata) if metadata else {},
+        )
+        with self._lock:
+            self._events.append(event)
+        if self._on_event is not None:
+            self._on_event(event)
+        return event
+
+    def seed(self, content: str, *, topic: str | None = None, metadata: dict[str, Any] | None = None) -> Event:
+        """Broadcast a seed event from the environment itself.
+
+        Convenience wrapper for the common case of injecting an external
+        signal (breaking news, a financial signal, a story prompt) that
+        every agent should see in round 0.
+        """
+        return self.emit(
+            ENV_AGENT_ID,
+            content,
+            kind="seed",
+            targets=(),
+            topic=topic,
+            metadata=metadata,
+        )
+
+    @property
+    def events(self) -> list[Event]:
+        """Return a shallow copy of the full event log."""
+        with self._lock:
+            return list(self._events)
+
+    def events_for(
+        self,
+        agent_id: str,
+        *,
+        since_tick: int | None = None,
+        last_n: int | None = None,
+        kinds: Iterable[str] | None = None,
+        topics: Iterable[str] | None = None,
+        include_own: bool = True,
+    ) -> list[Event]:
+        """Return events visible to *agent_id*, filtered.
+
+        Visibility rules:
+        - The agent sees every event addressed to it (``agent_id`` in
+          ``event.targets``) and every broadcast event (empty ``targets``).
+        - It sees its own events when ``include_own=True``.
+
+        Additional filters:
+
+        Args:
+            since_tick: Drop events from earlier ticks (inclusive lower
+                bound when set).  Useful for "give me everything since
+                last round."
+            last_n: Cap the result to the most recent *n* matching
+                events.  Applied last.
+            kinds: Restrict to events whose ``kind`` is in this iterable.
+            topics: Restrict to events whose ``topic`` is in this
+                iterable (``None``-topic events are kept only when
+                ``None`` itself appears in *topics*).
+        """
+        kinds_set = set(kinds) if kinds is not None else None
+        topics_set = set(topics) if topics is not None else None
+
+        with self._lock:
+            candidates = list(self._events)
+
+        visible: list[Event] = []
+        for ev in candidates:
+            if since_tick is not None and ev.tick < since_tick:
+                continue
+            is_own = ev.agent_id == agent_id
+            if is_own and not include_own:
+                continue
+            if ev.targets and agent_id not in ev.targets and not is_own:
+                continue
+            if kinds_set is not None and ev.kind not in kinds_set:
+                continue
+            if topics_set is not None and ev.topic not in topics_set:
+                continue
+            visible.append(ev)
+
+        if last_n is not None and last_n >= 0:
+            visible = visible[-last_n:]
+        return visible
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._events)
+
+    def clear(self) -> None:
+        """Drop the event log and world state.  Mostly for tests."""
+        with self._lock:
+            self._events.clear()
+            self._state.clear()
+            self._tick = 0

--- a/prompture/swarm/memory.py
+++ b/prompture/swarm/memory.py
@@ -1,0 +1,164 @@
+"""Pluggable long-term memory for swarm agents.
+
+The :class:`MemoryStore` protocol defines the contract every backend
+must satisfy.  :class:`InMemoryStore` is the default implementation: a
+thread-safe per-agent recency log with token-overlap keyword search.
+
+Third-party backends (Zep, Mem0, a vector store, etc.) plug in by
+implementing the same four methods.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+import time
+from collections import defaultdict
+from typing import Any, Protocol, runtime_checkable
+
+from .types import Memory
+
+_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+
+
+def _tokens(text: str) -> set[str]:
+    """Lower-cased word tokens for naive keyword overlap scoring."""
+    return {m.group(0).lower() for m in _TOKEN_RE.finditer(text)}
+
+
+@runtime_checkable
+class MemoryStore(Protocol):
+    """Per-agent long-term memory store.
+
+    All operations are agent-scoped: an agent only ever sees its own
+    memories.  Implementations should be thread-safe — the swarm
+    runtime may invoke ``add``, ``search``, and ``recent`` concurrently
+    when an async/parallel scheduler is used.
+    """
+
+    def add(
+        self,
+        agent_id: str,
+        content: str,
+        *,
+        metadata: dict[str, Any] | None = None,
+        ts: float | None = None,
+        tick: int | None = None,
+    ) -> None:
+        """Append a memory for *agent_id*.
+
+        Args:
+            agent_id: Owning agent.
+            content: Free-form text payload.
+            metadata: Optional structured metadata.
+            ts: Wall-clock timestamp.  Defaults to ``time.time()``.
+            tick: Optional round index of authorship.
+        """
+        ...
+
+    def search(self, agent_id: str, query: str, *, k: int = 5) -> list[Memory]:
+        """Return the *k* memories most relevant to *query* for *agent_id*.
+
+        Relevance is implementation-defined.  Backends may use exact
+        keyword match, BM25, embeddings, or a remote service.
+        """
+        ...
+
+    def recent(self, agent_id: str, *, k: int = 5) -> list[Memory]:
+        """Return the *k* most recently added memories for *agent_id*.
+
+        Results are ordered oldest-first so they read naturally when
+        spliced into a prompt.
+        """
+        ...
+
+    def clear(self, agent_id: str | None = None) -> None:
+        """Drop memories.
+
+        When *agent_id* is ``None`` clear the entire store; otherwise
+        clear only memories owned by that agent.
+        """
+        ...
+
+
+class InMemoryStore:
+    """Thread-safe in-process implementation of :class:`MemoryStore`.
+
+    Stores a per-agent list of :class:`Memory` records.  Keyword search
+    scores each candidate by the number of query tokens that appear in
+    the memory's content (case-insensitive); ties break toward more
+    recent memories.
+
+    This is the default backend; it has no external dependencies and is
+    suitable for tests, short-lived runs, and small populations.  For
+    long-running simulations consider plugging in a vector store or a
+    hosted service (Zep, Mem0) by implementing :class:`MemoryStore`.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._records: dict[str, list[Memory]] = defaultdict(list)
+
+    def add(
+        self,
+        agent_id: str,
+        content: str,
+        *,
+        metadata: dict[str, Any] | None = None,
+        ts: float | None = None,
+        tick: int | None = None,
+    ) -> None:
+        record = Memory(
+            agent_id=agent_id,
+            content=content,
+            ts=ts if ts is not None else time.time(),
+            tick=tick,
+            metadata=dict(metadata) if metadata else {},
+        )
+        with self._lock:
+            self._records[agent_id].append(record)
+
+    def search(self, agent_id: str, query: str, *, k: int = 5) -> list[Memory]:
+        q_tokens = _tokens(query)
+        if not q_tokens:
+            return self.recent(agent_id, k=k)
+
+        with self._lock:
+            candidates = list(self._records.get(agent_id, ()))
+
+        scored: list[tuple[int, float, Memory]] = []
+        for m in candidates:
+            overlap = len(_tokens(m.content) & q_tokens)
+            if overlap > 0:
+                scored.append((overlap, m.ts, m))
+
+        scored.sort(key=lambda t: (t[0], t[1]), reverse=True)
+        return [m for _, _, m in scored[:k]]
+
+    def recent(self, agent_id: str, *, k: int = 5) -> list[Memory]:
+        with self._lock:
+            records = list(self._records.get(agent_id, ()))
+        if k <= 0:
+            return []
+        return records[-k:]
+
+    def clear(self, agent_id: str | None = None) -> None:
+        with self._lock:
+            if agent_id is None:
+                self._records.clear()
+            else:
+                self._records.pop(agent_id, None)
+
+    # ------------------------------------------------------------------
+    # Introspection helpers (not part of the protocol)
+    # ------------------------------------------------------------------
+
+    def all_for(self, agent_id: str) -> list[Memory]:
+        """Return every memory owned by *agent_id* (test/debug helper)."""
+        with self._lock:
+            return list(self._records.get(agent_id, ()))
+
+    def agent_ids(self) -> list[str]:
+        """Return every agent ID with at least one stored memory."""
+        with self._lock:
+            return list(self._records.keys())

--- a/prompture/swarm/scheduler.py
+++ b/prompture/swarm/scheduler.py
@@ -69,7 +69,7 @@ class SampleScheduler:
         if k < 0:
             raise ValueError("SampleScheduler k must be non-negative")
         self._k = k
-        self._rng = rng or random.Random()
+        self._rng = rng or random.Random()  # nosec B311 - non-cryptographic agent sampling
 
     def select(
         self,

--- a/prompture/swarm/scheduler.py
+++ b/prompture/swarm/scheduler.py
@@ -1,0 +1,206 @@
+"""Scheduling policies for :class:`~prompture.swarm.Swarm`.
+
+A scheduler decides which agents act in each tick.  Implementations
+satisfy the simple :class:`Scheduler` protocol::
+
+    def select(agents, env, tick) -> list[SwarmAgent]
+
+The returned list is processed in order (left-to-right) within the
+tick.  Returning an empty list is allowed — the swarm will still advance
+ticks (useful when waiting for an external signal via callbacks).
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from .environment import Environment
+    from .swarm_agent import SwarmAgent
+
+
+@runtime_checkable
+class Scheduler(Protocol):
+    """Decides which agents act in each tick."""
+
+    def select(
+        self,
+        agents: Sequence[SwarmAgent],
+        env: Environment,
+        tick: int,
+    ) -> list[SwarmAgent]:
+        """Return the subset of agents that should run this tick."""
+        ...
+
+
+class AllScheduler:
+    """Every agent acts every tick.  Default.
+
+    Use when every agent should observe and react each round — the
+    classic broadcast simulation.  Order matches the swarm's agent
+    list.
+    """
+
+    def select(
+        self,
+        agents: Sequence[SwarmAgent],
+        env: Environment,
+        tick: int,
+    ) -> list[SwarmAgent]:
+        return list(agents)
+
+
+class SampleScheduler:
+    """Sample *k* agents uniformly at random per tick.
+
+    Use for gossip-style or stochastic simulations where only part of
+    the population activates each round.
+
+    Args:
+        k: Number of agents to sample per tick.  Clamped to the
+            population size.
+        rng: Optional :class:`random.Random` instance for reproducible
+            sampling.  When ``None`` the module-level ``random`` is used.
+    """
+
+    def __init__(self, k: int, *, rng: random.Random | None = None) -> None:
+        if k < 0:
+            raise ValueError("SampleScheduler k must be non-negative")
+        self._k = k
+        self._rng = rng or random.Random()
+
+    def select(
+        self,
+        agents: Sequence[SwarmAgent],
+        env: Environment,
+        tick: int,
+    ) -> list[SwarmAgent]:
+        if not agents:
+            return []
+        k = min(self._k, len(agents))
+        return self._rng.sample(list(agents), k)
+
+
+class RoundRobinScheduler:
+    """Activate one agent per tick, rotating through the population.
+
+    Args:
+        batch_size: Number of agents to activate per tick (default 1).
+            The window slides by ``batch_size`` each tick.
+    """
+
+    def __init__(self, batch_size: int = 1) -> None:
+        if batch_size < 1:
+            raise ValueError("RoundRobinScheduler batch_size must be >= 1")
+        self._batch_size = batch_size
+        self._cursor = 0
+
+    def select(
+        self,
+        agents: Sequence[SwarmAgent],
+        env: Environment,
+        tick: int,
+    ) -> list[SwarmAgent]:
+        if not agents:
+            return []
+        n = len(agents)
+        out: list[SwarmAgent] = []
+        for i in range(self._batch_size):
+            out.append(agents[(self._cursor + i) % n])
+        self._cursor = (self._cursor + self._batch_size) % n
+        return out
+
+
+class PriorityScheduler:
+    """Activate agents whose priority score exceeds a threshold.
+
+    The scoring function is called once per agent per tick.  The
+    threshold is checked with ``>=``.  Activated agents are returned in
+    score-descending order so highest-priority actors run first.
+
+    Args:
+        score_fn: Callable ``(agent, env, tick) -> float`` producing a
+            per-tick activation score.
+        threshold: Minimum score required to activate.  Default ``1.0``.
+        max_active: Optional hard cap on activations per tick.
+    """
+
+    def __init__(
+        self,
+        score_fn: Callable[[SwarmAgent, Environment, int], float],
+        *,
+        threshold: float = 1.0,
+        max_active: int | None = None,
+    ) -> None:
+        self._score_fn = score_fn
+        self._threshold = threshold
+        self._max_active = max_active
+
+    def select(
+        self,
+        agents: Sequence[SwarmAgent],
+        env: Environment,
+        tick: int,
+    ) -> list[SwarmAgent]:
+        scored: list[tuple[float, SwarmAgent]] = []
+        for agent in agents:
+            score = self._score_fn(agent, env, tick)
+            if score >= self._threshold:
+                scored.append((score, agent))
+        scored.sort(key=lambda t: t[0], reverse=True)
+        if self._max_active is not None:
+            scored = scored[: self._max_active]
+        return [a for _, a in scored]
+
+
+class CallableScheduler:
+    """Adapter that turns any callable into a :class:`Scheduler`.
+
+    Useful for one-off scheduling logic without subclassing::
+
+        scheduler = CallableScheduler(
+            lambda agents, env, tick: [a for a in agents if a.name != "spectator"]
+        )
+
+    The wrapped callable must accept ``(agents, env, tick)`` and return
+    a list of :class:`SwarmAgent`.
+    """
+
+    def __init__(
+        self,
+        fn: Callable[[Sequence[SwarmAgent], Environment, int], list[SwarmAgent]],
+    ) -> None:
+        self._fn = fn
+
+    def select(
+        self,
+        agents: Sequence[SwarmAgent],
+        env: Environment,
+        tick: int,
+    ) -> list[SwarmAgent]:
+        return list(self._fn(agents, env, tick))
+
+
+def make_scheduler(spec: Any) -> Scheduler:
+    """Coerce *spec* to a :class:`Scheduler`.
+
+    Accepts:
+    - A :class:`Scheduler` instance (returned as-is).
+    - The string ``"all"`` (→ :class:`AllScheduler`).
+    - A callable matching :class:`CallableScheduler`'s signature.
+
+    Used by :class:`~prompture.swarm.Swarm` to accept friendly inputs.
+    """
+    if spec is None:
+        return AllScheduler()
+    if isinstance(spec, Scheduler):
+        return spec
+    if isinstance(spec, str):
+        if spec == "all":
+            return AllScheduler()
+        raise ValueError(f"Unknown scheduler spec: {spec!r}")
+    if callable(spec):
+        return CallableScheduler(spec)
+    raise TypeError(f"Cannot coerce {type(spec).__name__} to Scheduler")

--- a/prompture/swarm/swarm.py
+++ b/prompture/swarm/swarm.py
@@ -28,9 +28,7 @@ from .types import SwarmCallbacks, SwarmResult, SwarmStep, aggregate_usage
 logger = logging.getLogger("prompture.swarm")
 
 _DEFAULT_MAX_TICKS = 10
-_DEFAULT_ACTION_PROMPT = (
-    "React to the current situation. Stay in character and respond concisely."
-)
+_DEFAULT_ACTION_PROMPT = "React to the current situation. Stay in character and respond concisely."
 
 
 class Swarm:
@@ -203,9 +201,7 @@ class Swarm:
             if self._max_total_cost is not None:
                 total_so_far = sum(s.get("total_cost", s.get("cost", 0.0)) for s in usage_summaries)
                 if total_so_far >= self._max_total_cost:
-                    self._stop_reason = (
-                        f"budget exceeded ({total_so_far:.4f} >= {self._max_total_cost:.4f})"
-                    )
+                    self._stop_reason = f"budget exceeded ({total_so_far:.4f} >= {self._max_total_cost:.4f})"
                     break
 
             self._env.advance_tick()
@@ -252,9 +248,7 @@ class Swarm:
                     )
 
                     if self._callbacks.on_agent_complete:
-                        self._callbacks.on_agent_complete(
-                            swarm_agent.name, result, tick_idx
-                        )
+                        self._callbacks.on_agent_complete(swarm_agent.name, result, tick_idx)
 
                 except Exception as exc:
                     duration_ms = (time.perf_counter() - step_t0) * 1000
@@ -273,9 +267,7 @@ class Swarm:
                     )
 
                     if self._callbacks.on_agent_error:
-                        self._callbacks.on_agent_error(
-                            swarm_agent.name, exc, tick_idx
-                        )
+                        self._callbacks.on_agent_error(swarm_agent.name, exc, tick_idx)
 
                     if self._error_policy == ErrorPolicy.raise_on_error:
                         self._stop_reason = f"raise_on_error: {swarm_agent.name}"

--- a/prompture/swarm/swarm.py
+++ b/prompture/swarm/swarm.py
@@ -1,0 +1,325 @@
+"""The :class:`Swarm` orchestrator.
+
+A swarm is a population of :class:`SwarmAgent` instances acting against
+a shared :class:`Environment` over multiple rounds (ticks).  Each tick
+the active subset (chosen by a :class:`Scheduler`) takes one action,
+writing observations back into the environment for the next round.
+
+The runtime mirrors conventions established in
+:mod:`prompture.groups`: an :class:`ErrorPolicy` enum reuse, a
+:class:`SwarmCallbacks` dataclass, a ``stop()`` cooperative shutdown,
+and a ``max_total_cost`` budget cap.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable, Iterable
+from typing import Any
+
+from ..groups.types import ErrorPolicy
+from .environment import Environment
+from .memory import MemoryStore
+from .scheduler import AllScheduler, Scheduler, make_scheduler
+from .swarm_agent import SwarmAgent
+from .types import SwarmCallbacks, SwarmResult, SwarmStep, aggregate_usage
+
+logger = logging.getLogger("prompture.swarm")
+
+_DEFAULT_MAX_TICKS = 10
+_DEFAULT_ACTION_PROMPT = (
+    "React to the current situation. Stay in character and respond concisely."
+)
+
+
+class Swarm:
+    """A population of agents acting over rounds against a shared environment.
+
+    Args:
+        agents: The participating :class:`SwarmAgent` instances.
+            Names must be unique within the swarm.
+        env: Pre-built :class:`Environment` to use.  When ``None`` a
+            fresh environment is created.
+        memory: Default :class:`MemoryStore` applied to every agent
+            that does not already have one.  Pass ``None`` to leave
+            agents memory-less by default.
+        scheduler: A :class:`Scheduler` instance, the string ``"all"``,
+            or a callable accepted by
+            :func:`~prompture.swarm.scheduler.make_scheduler`.
+            Defaults to :class:`AllScheduler` — every agent acts every
+            tick.
+        max_ticks: Hard cap on rounds.  Default 10.
+        action_prompt: Per-tick action directive passed to every agent
+            (via :attr:`SwarmAgent._pending_prompt`).  Either a literal
+            string (with ``{tick}`` placeholder) or a callable
+            ``(env, tick) -> str``.
+        max_total_cost: Optional USD budget cap.  When the aggregate
+            cost crosses this threshold the run stops at the next tick
+            boundary.
+        error_policy: Reuses :class:`~prompture.groups.types.ErrorPolicy`.
+            ``fail_fast`` (default) ends the run on the first error;
+            ``continue_on_error`` records errors and keeps going;
+            ``raise_on_error`` propagates the exception immediately.
+            ``retry_failed`` is treated as ``continue_on_error`` here —
+            scheduler-driven re-activation is the recommended retry
+            mechanism.
+        callbacks: Optional :class:`SwarmCallbacks` for observability.
+        stop_when: Optional callable ``(env, tick) -> bool`` evaluated
+            at the start of every tick.  Returning ``True`` ends the
+            run before the tick executes.
+
+    Example::
+
+        swarm = Swarm(
+            agents=[journalist, contrarian, moderator],
+            scheduler=AllScheduler(),
+            max_ticks=5,
+        )
+        swarm.environment.seed("Breaking: city council passes new tax.")
+        result = swarm.run()
+        for ev in result.events:
+            print(ev.tick, ev.agent_id, ev.content)
+    """
+
+    def __init__(
+        self,
+        agents: Iterable[SwarmAgent],
+        *,
+        env: Environment | None = None,
+        memory: MemoryStore | None = None,
+        scheduler: Scheduler | str | Callable[..., Any] | None = None,
+        max_ticks: int = _DEFAULT_MAX_TICKS,
+        action_prompt: str | Callable[[Environment, int], str] = _DEFAULT_ACTION_PROMPT,
+        max_total_cost: float | None = None,
+        error_policy: ErrorPolicy = ErrorPolicy.fail_fast,
+        callbacks: SwarmCallbacks | None = None,
+        stop_when: Callable[[Environment, int], bool] | None = None,
+    ) -> None:
+        self._agents: list[SwarmAgent] = list(agents)
+        if not self._agents:
+            raise ValueError("Swarm requires at least one agent")
+
+        seen: set[str] = set()
+        for a in self._agents:
+            if a.name in seen:
+                raise ValueError(f"Duplicate swarm agent name: {a.name!r}")
+            seen.add(a.name)
+
+        if memory is not None:
+            for a in self._agents:
+                if a.memory is None:
+                    a.memory = memory
+
+        self._env = env if env is not None else Environment()
+        self._memory_default = memory
+        self._scheduler: Scheduler = make_scheduler(scheduler) if not isinstance(scheduler, Scheduler) else scheduler
+        if self._scheduler is None:  # pragma: no cover — defensive
+            self._scheduler = AllScheduler()
+        if max_ticks < 0:
+            raise ValueError("max_ticks must be non-negative")
+        self._max_ticks = max_ticks
+        self._action_prompt = action_prompt
+        self._max_total_cost = max_total_cost
+        self._error_policy = error_policy
+        self._callbacks = callbacks or SwarmCallbacks()
+        self._stop_when = stop_when
+
+        self._stop_requested: bool = False
+        self._stop_reason: str | None = None
+
+        # Wire environment callbacks into swarm callbacks so emit/state
+        # events bubble up through the SwarmCallbacks surface too.
+        cb_event = self._callbacks.on_event
+        if cb_event is not None and self._env._on_event is None:
+            self._env._on_event = cb_event  # type: ignore[assignment]
+        cb_state = self._callbacks.on_state_update
+        if cb_state is not None and self._env._on_state_update is None:
+            self._env._on_state_update = cb_state  # type: ignore[assignment]
+
+    # ------------------------------------------------------------------
+    # Public surface
+    # ------------------------------------------------------------------
+
+    @property
+    def environment(self) -> Environment:
+        """The shared environment for this swarm."""
+        return self._env
+
+    @property
+    def agents(self) -> list[SwarmAgent]:
+        """Return a shallow copy of the agent list."""
+        return list(self._agents)
+
+    def stop(self, reason: str = "stop() called") -> None:
+        """Request graceful shutdown after the current tick finishes."""
+        self._stop_requested = True
+        if self._stop_reason is None:
+            self._stop_reason = reason
+
+    # ------------------------------------------------------------------
+    # Main loop
+    # ------------------------------------------------------------------
+
+    def run(self, seed: str | None = None) -> SwarmResult:
+        """Execute the swarm's tick loop to completion.
+
+        Args:
+            seed: Optional seed text broadcast through the environment
+                before tick 1.  Equivalent to calling
+                :meth:`Environment.seed` yourself.
+
+        Returns:
+            :class:`SwarmResult` with the full timeline, errors, final
+            environment state, and aggregate usage.
+        """
+        if seed is not None:
+            self._env.seed(seed)
+
+        self._stop_requested = False
+        self._stop_reason = None
+        t0 = time.perf_counter()
+
+        timeline: list[SwarmStep] = []
+        agent_results: dict[str, Any] = {}
+        errors: list[tuple[str, Exception]] = []
+        usage_summaries: list[dict[str, Any]] = []
+        ticks_run = 0
+
+        for tick_idx in range(1, self._max_ticks + 1):
+            if self._stop_requested:
+                break
+
+            if self._stop_when is not None:
+                try:
+                    if self._stop_when(self._env, tick_idx):
+                        self._stop_reason = self._stop_reason or "stop_when returned True"
+                        break
+                except Exception:
+                    logger.warning("stop_when raised; ending swarm run", exc_info=True)
+                    self._stop_reason = "stop_when raised"
+                    break
+
+            if self._max_total_cost is not None:
+                total_so_far = sum(s.get("total_cost", s.get("cost", 0.0)) for s in usage_summaries)
+                if total_so_far >= self._max_total_cost:
+                    self._stop_reason = (
+                        f"budget exceeded ({total_so_far:.4f} >= {self._max_total_cost:.4f})"
+                    )
+                    break
+
+            self._env.advance_tick()
+            active = list(self._scheduler.select(self._agents, self._env, tick_idx))
+
+            if self._callbacks.on_tick_start:
+                self._callbacks.on_tick_start(tick_idx, [a.name for a in active])
+
+            action_prompt = self._resolve_action_prompt(tick_idx)
+            tick_had_error = False
+
+            for swarm_agent in active:
+                if self._stop_requested:
+                    break
+
+                step_t0 = time.perf_counter()
+                if self._callbacks.on_agent_start:
+                    self._callbacks.on_agent_start(
+                        swarm_agent.name,
+                        action_prompt,
+                        tick_idx,
+                    )
+
+                try:
+                    result = swarm_agent.run_step(self._env, tick_idx, action_prompt)
+                    duration_ms = (time.perf_counter() - step_t0) * 1000
+
+                    key = f"{swarm_agent.name}@tick{tick_idx}"
+                    agent_results[key] = result
+                    usage = getattr(result, "run_usage", {}) or {}
+                    usage_summaries.append(usage)
+
+                    timeline.append(
+                        SwarmStep(
+                            tick=tick_idx,
+                            agent_id=swarm_agent.name,
+                            step_type="agent_run",
+                            timestamp=step_t0,
+                            duration_ms=duration_ms,
+                            usage_delta=usage,
+                            observation=swarm_agent._pending_prompt,
+                            output=getattr(result, "output_text", str(result)),
+                        )
+                    )
+
+                    if self._callbacks.on_agent_complete:
+                        self._callbacks.on_agent_complete(
+                            swarm_agent.name, result, tick_idx
+                        )
+
+                except Exception as exc:
+                    duration_ms = (time.perf_counter() - step_t0) * 1000
+                    errors.append((swarm_agent.name, exc))
+                    tick_had_error = True
+                    timeline.append(
+                        SwarmStep(
+                            tick=tick_idx,
+                            agent_id=swarm_agent.name,
+                            step_type="agent_error",
+                            timestamp=step_t0,
+                            duration_ms=duration_ms,
+                            observation=swarm_agent._pending_prompt,
+                            error=str(exc),
+                        )
+                    )
+
+                    if self._callbacks.on_agent_error:
+                        self._callbacks.on_agent_error(
+                            swarm_agent.name, exc, tick_idx
+                        )
+
+                    if self._error_policy == ErrorPolicy.raise_on_error:
+                        self._stop_reason = f"raise_on_error: {swarm_agent.name}"
+                        if self._callbacks.on_stop:
+                            self._callbacks.on_stop(self._stop_reason)
+                        raise
+                    if self._error_policy == ErrorPolicy.fail_fast:
+                        self._stop_reason = f"fail_fast on {swarm_agent.name}: {exc}"
+                        break
+                    # continue_on_error / retry_failed: continue with next agent.
+
+            ticks_run = tick_idx
+            if self._callbacks.on_tick_complete:
+                self._callbacks.on_tick_complete(tick_idx)
+
+            if tick_had_error and self._error_policy == ErrorPolicy.fail_fast:
+                break
+
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+
+        if self._stop_reason is None and ticks_run >= self._max_ticks:
+            self._stop_reason = "max_ticks reached"
+        if self._callbacks.on_stop and self._stop_reason is not None:
+            self._callbacks.on_stop(self._stop_reason)
+
+        return SwarmResult(
+            agent_results=agent_results,
+            aggregate_usage=aggregate_usage(*usage_summaries),
+            environment_state=self._env.state,
+            events=self._env.events,
+            elapsed_ms=elapsed_ms,
+            timeline=timeline,
+            errors=errors,
+            ticks_run=ticks_run,
+            success=len(errors) == 0,
+            stopped_reason=self._stop_reason,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_action_prompt(self, tick: int) -> str:
+        spec = self._action_prompt
+        if callable(spec):
+            return spec(self._env, tick)
+        return spec.format(tick=tick) if "{tick}" in spec else spec

--- a/prompture/swarm/swarm_agent.py
+++ b/prompture/swarm/swarm_agent.py
@@ -1,0 +1,239 @@
+"""Swarm participant wrapping a Prompture :class:`~prompture.agents.Agent`.
+
+:class:`SwarmAgent` composes (does not subclass) an existing agent so
+that any object exposing a ``run(prompt) -> AgentResult``-shaped result
+can participate — :class:`Agent`, :class:`DeepAgent`, a mock agent in
+tests, or even a :class:`~prompture.groups.GroupAsAgent` wrapper.
+
+The wrapper supplies three pluggable policies:
+
+- **observe**: assemble the prompt this agent will see this tick.
+- **post_act**: write the agent's output back to the environment
+  (typically as an :class:`~prompture.swarm.types.Event`).
+- **remember**: persist the result to the swarm's memory store.
+
+Each policy has a sensible default; override any of them by passing a
+callable in the constructor.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from ..agents.types import AgentResult
+    from .environment import Environment
+    from .memory import MemoryStore
+
+
+@runtime_checkable
+class _AgentLike(Protocol):
+    """The minimal duck-typed interface a swarm participant needs.
+
+    Anything exposing ``run(prompt: str) -> object`` with an
+    ``output_text`` attribute on the result satisfies this — including
+    :class:`~prompture.agents.Agent`, :class:`~prompture.agents.DeepAgent`,
+    and :class:`~prompture.groups.GroupAsAgent`.
+    """
+
+    def run(self, prompt: str, **kwargs: Any) -> Any:
+        ...
+
+
+ObserveFn = Callable[["SwarmAgent", "Environment", int], str]
+PostActFn = Callable[["SwarmAgent", "AgentResult", "Environment", int], None]
+RememberFn = Callable[["SwarmAgent", "AgentResult", "Environment", int], None]
+
+
+# ----------------------------------------------------------------------
+# Default policies
+# ----------------------------------------------------------------------
+
+
+def default_observe(agent: SwarmAgent, env: Environment, tick: int) -> str:
+    """Default observation: persona-relevant slice of the event log + memory.
+
+    Builds a prompt with three sections:
+
+    1. ``ROLE`` — agent name and role (if any).
+    2. ``WORLD`` — relevant world-state keys (when ``observe_state_keys``
+       is non-empty on the swarm agent).
+    3. ``RECENT EVENTS`` — events visible to this agent since the last
+       tick it acted (or all events on the first run), filtered by
+       ``observe_kinds`` and ``observe_topics`` when set.
+    4. ``MEMORY`` — last *k* memories, when a memory store is attached.
+    5. ``TICK`` — current round and the action prompt the swarm passed in.
+
+    Returns a single concatenated string the underlying agent will see.
+    """
+    parts: list[str] = []
+
+    role_line = f"You are agent '{agent.name}'."
+    if agent.role:
+        role_line += f" Role: {agent.role}."
+    parts.append(role_line)
+
+    if agent.observe_state_keys:
+        snippets = []
+        for key in agent.observe_state_keys:
+            if key in env.state:
+                snippets.append(f"- {key}: {env.state[key]}")
+        if snippets:
+            parts.append("## World state\n" + "\n".join(snippets))
+
+    since = agent._last_acted_tick + 1 if agent._last_acted_tick is not None else None
+    events = env.events_for(
+        agent.name,
+        since_tick=since,
+        last_n=agent.observe_window,
+        kinds=agent.observe_kinds,
+        topics=agent.observe_topics,
+        include_own=False,
+    )
+    if events:
+        lines = [
+            f"- [t{e.tick}] {e.agent_id} ({e.kind}): {e.content}" for e in events
+        ]
+        parts.append("## Recent events\n" + "\n".join(lines))
+
+    if agent.memory is not None and agent.memory_recent_k > 0:
+        memories = agent.memory.recent(agent.name, k=agent.memory_recent_k)
+        if memories:
+            lines = [f"- {m.content}" for m in memories]
+            parts.append("## Your memory\n" + "\n".join(lines))
+
+    parts.append(f"## Tick {tick}\n{agent._pending_prompt}")
+    return "\n\n".join(parts)
+
+
+def default_post_act(
+    agent: SwarmAgent,
+    result: AgentResult,
+    env: Environment,
+    tick: int,
+) -> None:
+    """Default action: emit a broadcast ``say`` event with the agent's output."""
+    text = getattr(result, "output_text", str(result))
+    env.emit(
+        agent.name,
+        text,
+        kind=agent.default_event_kind,
+        topic=agent.default_topic,
+        metadata={"output_type": type(getattr(result, "output", None)).__name__},
+    )
+
+
+def default_remember(
+    agent: SwarmAgent,
+    result: AgentResult,
+    env: Environment,
+    tick: int,
+) -> None:
+    """Default memory write: store this tick's output as a memory entry."""
+    if agent.memory is None:
+        return
+    text = getattr(result, "output_text", str(result))
+    agent.memory.add(
+        agent.name,
+        text,
+        tick=tick,
+        metadata={"kind": "self_act"},
+    )
+
+
+# ----------------------------------------------------------------------
+# SwarmAgent
+# ----------------------------------------------------------------------
+
+
+@dataclass
+class SwarmAgent:
+    """A swarm participant wrapping an underlying agent.
+
+    Use the constructor directly; the dataclass is mutable so swarms
+    can update tick bookkeeping on each instance.
+
+    Args:
+        agent: The underlying agent.  Anything with a ``run(prompt)``
+            method whose result exposes ``output_text``.
+        name: Unique identifier within the swarm.  Used in event
+            attribution and memory partitioning.
+        role: Optional short role description (e.g. ``"journalist"``,
+            ``"contrarian voter"``).  Appears in the default observation.
+        memory: Optional :class:`MemoryStore` for this agent's long-term
+            memory.  When ``None`` no memory is read or written.
+        observe: Override for the observation policy.  Signature
+            ``(agent, env, tick) -> str``.
+        post_act: Override for the post-action policy.  Signature
+            ``(agent, result, env, tick) -> None``.
+        remember: Override for the memory-write policy.  Signature
+            ``(agent, result, env, tick) -> None``.
+        observe_window: Cap on how many events the default observer
+            includes per tick.  Use ``None`` to disable the cap.
+            Default 20.
+        observe_kinds: Optional iterable of event kinds to include in
+            the observation.  When ``None`` every kind is included.
+        observe_topics: Optional iterable of topics to include in the
+            observation.
+        observe_state_keys: Iterable of world-state keys to surface in
+            the default observation.
+        memory_recent_k: Number of recent memories the default observer
+            should include.  Default 5.
+        default_event_kind: The ``kind`` written by :func:`default_post_act`.
+            Default ``"say"``.
+        default_topic: Optional topic for the default emitted event.
+        priority: Static priority hint readable by
+            :class:`~prompture.swarm.scheduler.PriorityScheduler` or
+            custom schedulers.
+    """
+
+    agent: _AgentLike
+    name: str
+    role: str = ""
+    memory: MemoryStore | None = None
+    observe: ObserveFn | None = None
+    post_act: PostActFn | None = None
+    remember: RememberFn | None = None
+    observe_window: int | None = 20
+    observe_kinds: tuple[str, ...] | None = None
+    observe_topics: tuple[str, ...] | None = None
+    observe_state_keys: tuple[str, ...] = ()
+    memory_recent_k: int = 5
+    default_event_kind: str = "say"
+    default_topic: str | None = None
+    priority: float = 1.0
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    # Mutable bookkeeping — updated by the Swarm runtime.
+    _pending_prompt: str = field(default="", repr=False)
+    _last_acted_tick: int | None = field(default=None, repr=False)
+
+    # ------------------------------------------------------------------
+    # Tick-side API used by Swarm
+    # ------------------------------------------------------------------
+
+    def build_observation(self, env: Environment, tick: int) -> str:
+        """Run the observation policy and return the prompt."""
+        fn = self.observe or default_observe
+        return fn(self, env, tick)
+
+    def run_step(self, env: Environment, tick: int, prompt: str) -> AgentResult:
+        """Execute one swarm tick for this agent.
+
+        Sets the pending prompt, invokes the observation policy, runs
+        the underlying agent, fires the post-action and remember
+        policies, and updates ``_last_acted_tick``.
+        """
+        self._pending_prompt = prompt
+        observation = self.build_observation(env, tick)
+        result = self.agent.run(observation)
+
+        post_act = self.post_act or default_post_act
+        remember = self.remember or default_remember
+        post_act(self, result, env, tick)
+        remember(self, result, env, tick)
+
+        self._last_acted_tick = tick
+        return result  # type: ignore[return-value]

--- a/prompture/swarm/swarm_agent.py
+++ b/prompture/swarm/swarm_agent.py
@@ -38,8 +38,7 @@ class _AgentLike(Protocol):
     and :class:`~prompture.groups.GroupAsAgent`.
     """
 
-    def run(self, prompt: str, **kwargs: Any) -> Any:
-        ...
+    def run(self, prompt: str, **kwargs: Any) -> Any: ...
 
 
 ObserveFn = Callable[["SwarmAgent", "Environment", int], str]
@@ -93,9 +92,7 @@ def default_observe(agent: SwarmAgent, env: Environment, tick: int) -> str:
         include_own=False,
     )
     if events:
-        lines = [
-            f"- [t{e.tick}] {e.agent_id} ({e.kind}): {e.content}" for e in events
-        ]
+        lines = [f"- [t{e.tick}] {e.agent_id} ({e.kind}): {e.content}" for e in events]
         parts.append("## Recent events\n" + "\n".join(lines))
 
     if agent.memory is not None and agent.memory_recent_k > 0:

--- a/prompture/swarm/types.py
+++ b/prompture/swarm/types.py
@@ -1,0 +1,261 @@
+"""Shared types for the Prompture swarm runtime.
+
+Defines event records, memory records, swarm-level callbacks, and the
+result/step shapes returned by :class:`~prompture.swarm.Swarm`.
+"""
+
+from __future__ import annotations
+
+import enum
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..agents.types import AgentResult
+
+
+class EventKind(str, enum.Enum):
+    """Classification for entries in the environment event log.
+
+    Values are stored as plain strings so callers may freely add their
+    own custom kinds without modifying the enum (kinds are compared by
+    string equality everywhere in the swarm runtime).
+    """
+
+    say = "say"
+    act = "act"
+    observe = "observe"
+    arrive = "arrive"
+    leave = "leave"
+    seed = "seed"
+    system = "system"
+    custom = "custom"
+
+
+@dataclass
+class Event:
+    """A single record in the environment's append-only event log.
+
+    Attributes:
+        tick: Round index at which the event was emitted.
+        ts: Wall-clock timestamp (seconds since epoch).
+        agent_id: Identifier of the agent that emitted the event.  Use
+            ``"__env__"`` for events authored by the environment itself
+            (seed material, system messages, etc.).
+        kind: Event classification.  See :class:`EventKind`.
+        content: Free-form payload, typically a short natural-language
+            string describing what happened.
+        targets: Tuple of agent IDs the event is addressed to.  Empty
+            tuple means broadcast — visible to every agent.
+        topic: Optional topic tag for subscription-style filtering.
+        metadata: Arbitrary structured payload (parsed JSON output,
+            sentiment scores, etc.).
+    """
+
+    tick: int
+    ts: float
+    agent_id: str
+    kind: str
+    content: str
+    targets: tuple[str, ...] = ()
+    topic: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Memory:
+    """A single record stored in a :class:`MemoryStore`.
+
+    Attributes:
+        agent_id: Identifier of the agent that owns this memory.
+        content: Free-form text.
+        ts: Wall-clock timestamp (seconds since epoch).
+        tick: Optional round index of authorship.
+        metadata: Arbitrary structured payload.
+    """
+
+    agent_id: str
+    content: str
+    ts: float = field(default_factory=time.time)
+    tick: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class SwarmStep:
+    """One agent invocation recorded during a swarm tick.
+
+    Mirrors the shape of :class:`~prompture.groups.types.GroupStep` so
+    consumers of group results can read swarm timelines with the same
+    code path.
+
+    Attributes:
+        tick: Round index in which the step ran.
+        agent_id: The acting agent's identifier.
+        step_type: ``"agent_run"`` on success, ``"agent_error"`` on
+            failure, ``"agent_skipped"`` when the scheduler omitted the
+            agent.
+        timestamp: ``time.perf_counter()`` reading at step start.
+        duration_ms: Wall-clock duration of the agent's ``run()`` call.
+        usage_delta: Per-step usage summary harvested from the agent
+            result's ``run_usage``.
+        observation: The text prompt the agent was given for this step.
+        output: The agent's textual output (``output_text``).  ``None``
+            for skipped or errored steps.
+        error: String form of any raised exception, or ``None``.
+    """
+
+    tick: int
+    agent_id: str
+    step_type: str = "agent_run"
+    timestamp: float = 0.0
+    duration_ms: float = 0.0
+    usage_delta: dict[str, Any] = field(default_factory=dict)
+    observation: str = ""
+    output: str | None = None
+    error: str | None = None
+
+
+@dataclass
+class SwarmResult:
+    """Outcome of a :meth:`Swarm.run` invocation.
+
+    Attributes:
+        agent_results: Mapping of ``"{agent_id}@tick{n}"`` to the
+            corresponding :class:`~prompture.agents.types.AgentResult`.
+        aggregate_usage: Combined token/cost totals across every agent
+            invocation in the run.
+        environment_state: Snapshot of the environment's world-state
+            dict at the end of the run.
+        events: Full event timeline from the environment.
+        elapsed_ms: Wall-clock duration of the swarm run.
+        timeline: Ordered list of :class:`SwarmStep` records, one per
+            agent invocation (including skips and errors).
+        errors: List of ``(agent_id, exception)`` for failed steps.
+        ticks_run: Number of completed ticks (some may have been cut
+            short by ``stop()`` or budget exhaustion).
+        success: ``True`` when no errors were recorded.
+        stopped_reason: Human-readable reason the run stopped, or
+            ``None`` when the loop completed normally.
+    """
+
+    agent_results: dict[str, AgentResult] = field(default_factory=dict)
+    aggregate_usage: dict[str, Any] = field(default_factory=dict)
+    environment_state: dict[str, Any] = field(default_factory=dict)
+    events: list[Event] = field(default_factory=list)
+    elapsed_ms: float = 0.0
+    timeline: list[SwarmStep] = field(default_factory=list)
+    errors: list[tuple[str, Exception]] = field(default_factory=list)
+    ticks_run: int = 0
+    success: bool = True
+    stopped_reason: str | None = None
+
+    def export(self) -> dict[str, Any]:
+        """Return a JSON-serialisable dict representation."""
+        return {
+            "ticks_run": self.ticks_run,
+            "success": self.success,
+            "stopped_reason": self.stopped_reason,
+            "elapsed_ms": self.elapsed_ms,
+            "aggregate_usage": self.aggregate_usage,
+            "environment_state": self.environment_state,
+            "agent_results": {
+                k: {
+                    "output_text": getattr(v, "output_text", str(v)),
+                    "usage": getattr(v, "run_usage", {}),
+                }
+                for k, v in self.agent_results.items()
+            },
+            "timeline": [
+                {
+                    "tick": s.tick,
+                    "agent_id": s.agent_id,
+                    "step_type": s.step_type,
+                    "duration_ms": s.duration_ms,
+                    "usage_delta": s.usage_delta,
+                    "observation": s.observation,
+                    "output": s.output,
+                    "error": s.error,
+                }
+                for s in self.timeline
+            ],
+            "events": [
+                {
+                    "tick": e.tick,
+                    "ts": e.ts,
+                    "agent_id": e.agent_id,
+                    "kind": e.kind,
+                    "content": e.content,
+                    "targets": list(e.targets),
+                    "topic": e.topic,
+                    "metadata": e.metadata,
+                }
+                for e in self.events
+            ],
+            "errors": [
+                {"agent_id": aid, "error": str(exc)}
+                for aid, exc in self.errors
+            ],
+        }
+
+
+@dataclass
+class SwarmCallbacks:
+    """Observability hooks fired during a swarm run.
+
+    All callbacks are optional.  Set any subset to receive notifications;
+    leave the rest as ``None`` to no-op.
+
+    Attributes:
+        on_tick_start: ``(tick, scheduled_agent_ids)`` at the start of
+            each round, after scheduling has run.
+        on_tick_complete: ``(tick,)`` at the end of each round.
+        on_agent_start: ``(agent_id, observation, tick)`` before the
+            agent's underlying ``Agent.run`` is invoked.
+        on_agent_complete: ``(agent_id, result, tick)`` after a
+            successful agent run.
+        on_agent_error: ``(agent_id, exception, tick)`` on failure.
+        on_event: ``(event,)`` for every event written to the
+            environment.
+        on_state_update: ``(key, value)`` whenever the environment's
+            world state is mutated via :meth:`Environment.set`.
+        on_stop: ``(reason,)`` when the loop ends (normal or otherwise).
+    """
+
+    on_tick_start: Callable[..., Any] | None = None
+    on_tick_complete: Callable[..., Any] | None = None
+    on_agent_start: Callable[..., Any] | None = None
+    on_agent_complete: Callable[..., Any] | None = None
+    on_agent_error: Callable[..., Any] | None = None
+    on_event: Callable[..., Any] | None = None
+    on_state_update: Callable[..., Any] | None = None
+    on_stop: Callable[..., Any] | None = None
+
+
+def aggregate_usage(*sessions: dict[str, Any]) -> dict[str, Any]:
+    """Merge multiple usage summary dicts into one.
+
+    Tolerates both ``cost`` and ``total_cost`` keys (different parts of
+    the codebase emit different names) by summing whichever is present
+    into a single ``total_cost`` figure.
+    """
+    agg: dict[str, Any] = {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+        "total_cost": 0.0,
+        "call_count": 0,
+        "errors": 0,
+    }
+    for s in sessions:
+        if not s:
+            continue
+        agg["prompt_tokens"] += s.get("prompt_tokens", 0)
+        agg["completion_tokens"] += s.get("completion_tokens", 0)
+        agg["total_tokens"] += s.get("total_tokens", 0)
+        agg["total_cost"] += s.get("total_cost", s.get("cost", 0.0))
+        agg["call_count"] += s.get("call_count", 0)
+        agg["errors"] += s.get("errors", 0)
+    return agg

--- a/prompture/swarm/types.py
+++ b/prompture/swarm/types.py
@@ -194,10 +194,7 @@ class SwarmResult:
                 }
                 for e in self.events
             ],
-            "errors": [
-                {"agent_id": aid, "error": str(exc)}
-                for aid, exc in self.errors
-            ],
+            "errors": [{"agent_id": aid, "error": str(exc)} for aid, exc in self.errors],
         }
 
 

--- a/prompture/testing/driver_contract.py
+++ b/prompture/testing/driver_contract.py
@@ -18,6 +18,7 @@ from ..drivers.base import Driver
 # by overriding a separate method, so they are excluded from this contract.
 FLAG_TO_METHOD: dict[str, str] = {
     "supports_streaming": "generate_messages_stream",
+    "supports_streaming_tool_use": "generate_messages_with_tools_stream",
     "supports_tool_use": "generate_messages_with_tools",
     "supports_messages": "generate_messages",
 }

--- a/prompture/tools/web_search.py
+++ b/prompture/tools/web_search.py
@@ -24,8 +24,9 @@ Example::
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any
 
 import requests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "prompture"
 description = "Ask LLMs to return structured JSON and run cross-model tests. API-first."
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [{ name = "Juan Denis", email = "juan@vene.co" }]
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -111,7 +111,7 @@ version_file = "prompture/_version.py"
 fallback_version = "1.0.0"
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 line-length = 120
 exclude = ["prompture/_version.py"]
 

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -1,0 +1,334 @@
+"""Tests for prompture.checkpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from prompture.checkpoints import (
+    Checkpoint,
+    CheckpointManager,
+    FileCheckpointStore,
+    InMemoryCheckpointStore,
+    RunStatus,
+    SQLiteCheckpointStore,
+    restore_conversation,
+    snapshot_conversation,
+)
+
+# ----------------------------------------------------------------------
+# Checkpoint dataclass round-trip
+# ----------------------------------------------------------------------
+
+
+class TestCheckpoint:
+    def test_round_trip(self) -> None:
+        cp = Checkpoint(
+            run_id="r1",
+            messages=[{"role": "user", "content": "hi"}],
+            iteration=3,
+            status=RunStatus.paused.value,
+            prompt="hi",
+            metadata={"todo": ["a", "b"]},
+        )
+        d = cp.to_dict()
+        cp2 = Checkpoint.from_dict(d)
+        assert cp2.run_id == "r1"
+        assert cp2.iteration == 3
+        assert cp2.status == RunStatus.paused.value
+        assert cp2.metadata == {"todo": ["a", "b"]}
+
+    def test_from_dict_ignores_unknown_keys(self) -> None:
+        cp = Checkpoint.from_dict({"run_id": "r1", "extra_garbage": 99})
+        assert cp.run_id == "r1"
+
+    def test_default_status_is_running(self) -> None:
+        cp = Checkpoint(run_id="r1")
+        assert cp.status == "running"
+
+
+# ----------------------------------------------------------------------
+# InMemoryCheckpointStore
+# ----------------------------------------------------------------------
+
+
+class TestInMemoryStore:
+    def test_save_load(self) -> None:
+        store = InMemoryCheckpointStore()
+        cp = Checkpoint(run_id="r1", iteration=2)
+        store.save(cp)
+        loaded = store.load("r1")
+        assert loaded is not None
+        assert loaded.iteration == 2
+
+    def test_load_missing_returns_none(self) -> None:
+        assert InMemoryCheckpointStore().load("nope") is None
+
+    def test_save_upserts_by_run_id(self) -> None:
+        store = InMemoryCheckpointStore()
+        store.save(Checkpoint(run_id="r1", iteration=1))
+        store.save(Checkpoint(run_id="r1", iteration=5))
+        assert store.load("r1").iteration == 5
+        assert len(store.list_runs()) == 1
+
+    def test_list_runs_filter_by_status(self) -> None:
+        store = InMemoryCheckpointStore()
+        store.save(Checkpoint(run_id="a", status=RunStatus.completed.value))
+        store.save(Checkpoint(run_id="b", status=RunStatus.running.value))
+        runs = store.list_runs(status=RunStatus.completed.value)
+        assert [c.run_id for c in runs] == ["a"]
+
+    def test_delete(self) -> None:
+        store = InMemoryCheckpointStore()
+        store.save(Checkpoint(run_id="r1"))
+        assert store.delete("r1") is True
+        assert store.delete("r1") is False
+
+
+# ----------------------------------------------------------------------
+# FileCheckpointStore
+# ----------------------------------------------------------------------
+
+
+class TestFileStore:
+    def test_save_load(self, tmp_path) -> None:
+        store = FileCheckpointStore(tmp_path)
+        cp = Checkpoint(run_id="r1", iteration=2, messages=[{"role": "user", "content": "hi"}])
+        store.save(cp)
+        loaded = store.load("r1")
+        assert loaded is not None
+        assert loaded.iteration == 2
+        assert loaded.messages[0]["content"] == "hi"
+
+    def test_load_missing(self, tmp_path) -> None:
+        assert FileCheckpointStore(tmp_path).load("nope") is None
+
+    def test_path_traversal_neutralised(self, tmp_path) -> None:
+        store = FileCheckpointStore(tmp_path)
+        # Hostile run id with separators should not escape the directory.
+        store.save(Checkpoint(run_id="../../etc/passwd"))
+        # File should still exist within tmp_path
+        files = list(tmp_path.glob("*.json"))
+        assert len(files) == 1
+        assert files[0].parent == tmp_path
+
+    def test_list_runs(self, tmp_path) -> None:
+        store = FileCheckpointStore(tmp_path)
+        store.save(Checkpoint(run_id="a"))
+        store.save(Checkpoint(run_id="b"))
+        runs = store.list_runs()
+        assert {c.run_id for c in runs} == {"a", "b"}
+
+    def test_atomic_write_doesnt_leave_temp_files(self, tmp_path) -> None:
+        store = FileCheckpointStore(tmp_path)
+        store.save(Checkpoint(run_id="r1"))
+        # No leftover temp file in the directory.
+        leftovers = [p for p in tmp_path.iterdir() if p.name.startswith(".chkpt-")]
+        assert not leftovers
+
+    def test_delete(self, tmp_path) -> None:
+        store = FileCheckpointStore(tmp_path)
+        store.save(Checkpoint(run_id="r1"))
+        assert store.delete("r1") is True
+        assert store.delete("r1") is False
+
+    def test_corrupt_file_returns_none(self, tmp_path) -> None:
+        store = FileCheckpointStore(tmp_path)
+        bad = tmp_path / "broken.json"
+        bad.write_text("{not json")
+        assert store.load("broken") is None
+
+
+# ----------------------------------------------------------------------
+# SQLiteCheckpointStore
+# ----------------------------------------------------------------------
+
+
+class TestSQLiteStore:
+    def test_save_load(self, tmp_path) -> None:
+        store = SQLiteCheckpointStore(db_path=tmp_path / "cp.db")
+        store.save(Checkpoint(run_id="r1", iteration=4))
+        loaded = store.load("r1")
+        assert loaded is not None
+        assert loaded.iteration == 4
+
+    def test_persistence_across_instances(self, tmp_path) -> None:
+        path = tmp_path / "cp.db"
+        SQLiteCheckpointStore(db_path=path).save(Checkpoint(run_id="r1", iteration=9))
+        loaded = SQLiteCheckpointStore(db_path=path).load("r1")
+        assert loaded is not None
+        assert loaded.iteration == 9
+
+    def test_list_runs_filter(self, tmp_path) -> None:
+        store = SQLiteCheckpointStore(db_path=tmp_path / "cp.db")
+        store.save(Checkpoint(run_id="a", status=RunStatus.completed.value))
+        store.save(Checkpoint(run_id="b", status=RunStatus.running.value))
+        runs = store.list_runs(status=RunStatus.running.value)
+        assert [c.run_id for c in runs] == ["b"]
+
+    def test_delete(self, tmp_path) -> None:
+        store = SQLiteCheckpointStore(db_path=tmp_path / "cp.db")
+        store.save(Checkpoint(run_id="r1"))
+        assert store.delete("r1") is True
+        assert store.delete("r1") is False
+
+
+# ----------------------------------------------------------------------
+# snapshot_conversation / restore_conversation
+# ----------------------------------------------------------------------
+
+
+def _fake_conv(messages: list[dict[str, Any]] | None = None) -> MagicMock:
+    conv = MagicMock()
+    conv.messages = list(messages) if messages else [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ]
+    conv.usage = {"total_tokens": 42}
+    conv.system_prompt = "you are helpful"
+    conv.model_name = "openai/gpt-4o"
+    return conv
+
+
+class TestSnapshot:
+    def test_snapshot_captures_conversation_fields(self) -> None:
+        conv = _fake_conv()
+        cp = snapshot_conversation(conv, iteration=2, prompt="hi", agent_name="researcher")
+        assert cp.messages == conv.messages
+        assert cp.usage == conv.usage
+        assert cp.system_prompt == "you are helpful"
+        assert cp.iteration == 2
+        assert cp.agent_name == "researcher"
+        assert cp.model == "openai/gpt-4o"
+
+    def test_metadata_is_copied(self) -> None:
+        conv = _fake_conv()
+        md = {"todo": ["a"]}
+        cp = snapshot_conversation(conv, metadata=md)
+        assert cp.metadata == md
+        md["todo"].append("b")
+        # Snapshot's metadata is decoupled
+        assert cp.metadata == {"todo": ["a"]}
+
+
+# ----------------------------------------------------------------------
+# CheckpointManager
+# ----------------------------------------------------------------------
+
+
+class TestCheckpointManager:
+    def test_save_conversation_writes_to_store(self) -> None:
+        store = InMemoryCheckpointStore()
+        mgr = CheckpointManager(store, run_id="run-1", agent_name="a")
+        conv = _fake_conv()
+        cp = mgr.save_conversation(conv, iteration=3, prompt="go")
+        assert cp.run_id == "run-1"
+        assert cp.agent_name == "a"
+        assert store.load("run-1").iteration == 3
+
+    def test_save_agent_returns_none_without_conversation(self) -> None:
+        agent = MagicMock()
+        agent.conversation = None
+        agent._conversation = None
+        mgr = CheckpointManager(InMemoryCheckpointStore(), run_id="r")
+        assert mgr.save_agent(agent) is None
+
+    def test_save_agent_uses_persistent_conversation(self) -> None:
+        agent = MagicMock()
+        agent.conversation = _fake_conv()
+        mgr = CheckpointManager(InMemoryCheckpointStore(), run_id="r")
+        cp = mgr.save_agent(agent, iteration=1)
+        assert cp is not None
+        assert cp.iteration == 1
+        assert cp.messages == agent.conversation.messages
+
+    def test_load_returns_latest(self) -> None:
+        store = InMemoryCheckpointStore()
+        mgr = CheckpointManager(store, run_id="r")
+        mgr.save_conversation(_fake_conv(), iteration=1)
+        mgr.save_conversation(_fake_conv(), iteration=2)
+        assert mgr.load().iteration == 2
+
+    def test_load_missing_returns_none(self) -> None:
+        mgr = CheckpointManager(InMemoryCheckpointStore(), run_id="ghost")
+        assert mgr.load() is None
+        assert mgr.exists() is False
+
+    def test_mark_updates_status(self) -> None:
+        mgr = CheckpointManager(InMemoryCheckpointStore(), run_id="r")
+        mgr.save_conversation(_fake_conv())
+        mgr.mark(RunStatus.completed.value, metadata={"final": True})
+        cp = mgr.load()
+        assert cp.status == RunStatus.completed.value
+        assert cp.metadata["final"] is True
+
+    def test_mark_without_existing_returns_none(self) -> None:
+        mgr = CheckpointManager(InMemoryCheckpointStore(), run_id="ghost")
+        assert mgr.mark(RunStatus.failed.value) is None
+
+    def test_resume_raises_when_no_checkpoint(self) -> None:
+        mgr = CheckpointManager(InMemoryCheckpointStore(), run_id="ghost")
+        with pytest.raises(LookupError):
+            mgr.resume_conversation(model="openai/gpt-4o-mini")
+
+    def test_delete(self) -> None:
+        store = InMemoryCheckpointStore()
+        mgr = CheckpointManager(store, run_id="r")
+        mgr.save_conversation(_fake_conv())
+        assert mgr.delete() is True
+        assert mgr.delete() is False
+
+
+# ----------------------------------------------------------------------
+# Round-trip with a real Conversation (using a stub driver)
+# ----------------------------------------------------------------------
+
+
+class TestRoundTripWithRealConversation:
+    """Smoke test: snapshot a real Conversation, then restore it."""
+
+    def test_round_trip(self) -> None:
+        from prompture.agents.conversation import Conversation
+        from prompture.drivers.base import Driver
+
+        class StubDriver(Driver):
+            supports_messages = True
+            supports_tool_use = False
+
+            def __init__(self) -> None:
+                self.model = "stub/model"
+
+            def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+                return self._make()
+
+            def generate_messages(
+                self, messages: list[dict[str, Any]], options: dict[str, Any]
+            ) -> dict[str, Any]:
+                return self._make()
+
+            def _make(self) -> dict[str, Any]:
+                return {
+                    "text": "ok",
+                    "meta": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2,
+                        "cost": 0.0,
+                        "raw_response": {},
+                    },
+                }
+
+        conv = Conversation(driver=StubDriver(), system_prompt="be brief")
+        conv.ask("hi")
+        cp = snapshot_conversation(conv, iteration=1)
+        assert cp.messages
+        assert cp.system_prompt == "be brief"
+
+        restored = restore_conversation(cp, driver=StubDriver())
+        # History was carried over
+        assert restored.messages == cp.messages
+        # New question continues from the existing history
+        restored.ask("again")
+        assert len(restored.messages) >= len(cp.messages) + 1

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -1,0 +1,179 @@
+"""Tests for prompture.citations."""
+
+from __future__ import annotations
+
+import pytest
+
+from prompture.citations import (
+    CITATION_INSTRUCTION,
+    CitationTracker,
+    CitedAnswer,
+    Source,
+    extract_citations,
+)
+from prompture.rag.documents import Document
+from prompture.rag.vectorstores.base import VectorSearchResult
+
+
+def _src(i: str, text: str, **kw) -> Source:
+    return Source(id=i, text=text, **kw)
+
+
+# ----------------------------------------------------------------------
+# extract_citations
+# ----------------------------------------------------------------------
+
+
+class TestExtractCitations:
+    def test_single_bracket(self) -> None:
+        sources = [_src("1", "Paris is the capital of France.")]
+        text = "Paris is the capital of France [1]."
+        cites, clean, cited = extract_citations(text, sources)
+        assert len(cites) == 1
+        assert cites[0].source_ids == ["1"]
+        assert cites[0].text == "Paris is the capital of France"
+        assert clean == "Paris is the capital of France ."
+        assert cited == {"1"}
+
+    def test_multi_id_bracket(self) -> None:
+        sources = [_src("1", "a"), _src("2", "b"), _src("3", "c")]
+        text = "Both routes are viable [1, 3]."
+        cites, _, cited = extract_citations(text, sources)
+        assert cites[0].source_ids == ["1", "3"]
+        assert cited == {"1", "3"}
+
+    def test_unknown_id_recorded_but_not_in_cited_set(self) -> None:
+        sources = [_src("1", "a")]
+        text = "Made-up claim [9]."
+        cites, _, cited = extract_citations(text, sources)
+        assert cites[0].source_ids == ["9"]
+        assert cited == set()
+
+    def test_no_citations(self) -> None:
+        cites, clean, cited = extract_citations("No marks here.", [_src("1", "a")])
+        assert cites == []
+        assert clean == "No marks here."
+        assert cited == set()
+
+    def test_claim_extraction_walks_to_sentence_boundary(self) -> None:
+        sources = [_src("1", "x"), _src("2", "y")]
+        text = "First fact [1]. Second separate fact [2]."
+        cites, _, _ = extract_citations(text, sources)
+        assert cites[0].text == "First fact"
+        assert cites[1].text == "Second separate fact"
+
+    def test_claim_extraction_uses_newline_boundary(self) -> None:
+        sources = [_src("1", "x")]
+        text = "Header line\nThe claim [1]."
+        cites, _, _ = extract_citations(text, sources)
+        assert cites[0].text == "The claim"
+
+    def test_clean_text_collapses_extra_spaces(self) -> None:
+        sources = [_src("1", "x"), _src("2", "y")]
+        text = "A [1] and B [2]."
+        _, clean, _ = extract_citations(text, sources)
+        # Markers stripped; surrounding spaces collapsed.
+        assert "  " not in clean
+
+    def test_offsets_align_to_input(self) -> None:
+        sources = [_src("1", "x")]
+        text = "Hello world [1]."
+        cites, _, _ = extract_citations(text, sources)
+        assert text[cites[0].start : cites[0].end].endswith("[1]")
+
+
+# ----------------------------------------------------------------------
+# CitationTracker
+# ----------------------------------------------------------------------
+
+
+class TestCitationTracker:
+    def test_from_documents_assigns_sequential_ids(self) -> None:
+        docs = [
+            Document(content="alpha", metadata={"title": "A"}),
+            Document(content="beta", metadata={"title": "B"}),
+        ]
+        tracker = CitationTracker.from_documents(docs)
+        sources = tracker.sources
+        assert [s.id for s in sources] == ["1", "2"]
+        assert sources[0].title == "A"
+        assert sources[0].text == "alpha"
+
+    def test_from_retrieval_results_preserves_scores(self) -> None:
+        results = [
+            VectorSearchResult(document=Document(content="a", metadata={}), score=0.91),
+            VectorSearchResult(document=Document(content="b", metadata={}), score=0.42),
+        ]
+        tracker = CitationTracker.from_retrieval_results(results)
+        scores = [s.score for s in tracker.sources]
+        assert scores == [0.91, 0.42]
+
+    def test_build_prompt_includes_instruction_and_sources(self) -> None:
+        docs = [Document(content="The Eiffel Tower is in Paris.", metadata={"title": "Wiki"})]
+        tracker = CitationTracker.from_documents(docs)
+        prompt = tracker.build_prompt(question="Where is the Eiffel Tower?")
+        assert CITATION_INSTRUCTION.strip() in prompt
+        assert "[1] Wiki" in prompt
+        assert "Eiffel Tower is in Paris" in prompt
+        assert "Question: Where is the Eiffel Tower?" in prompt
+
+    def test_build_prompt_omits_question_when_absent(self) -> None:
+        tracker = CitationTracker(sources=[_src("1", "x")])
+        prompt = tracker.build_prompt()
+        assert "Question:" not in prompt
+
+    def test_build_prompt_uses_stored_question_when_no_arg(self) -> None:
+        tracker = CitationTracker(sources=[_src("1", "x")], question="stored?")
+        prompt = tracker.build_prompt()
+        assert "Question: stored?" in prompt
+
+    def test_no_sources_renders_placeholder(self) -> None:
+        tracker = CitationTracker()
+        prompt = tracker.build_prompt(question="hi?")
+        assert "(no sources available)" in prompt
+
+    def test_add_source_assigns_next_id(self) -> None:
+        tracker = CitationTracker(sources=[_src("1", "x")])
+        added = tracker.add_source(Document(content="y", metadata={}))
+        assert added.id == "2"
+        assert tracker.sources[-1].id == "2"
+
+    def test_parse_response_builds_cited_answer(self) -> None:
+        tracker = CitationTracker(
+            sources=[_src("1", "a"), _src("2", "b")],
+            question="why?",
+        )
+        ans = tracker.parse_response("Claim one [1]. Claim two [2].", usage={"total_tokens": 7})
+        assert isinstance(ans, CitedAnswer)
+        assert ans.is_grounded
+        assert ans.coverage == 1.0
+        assert ans.cited_source_ids == {"1", "2"}
+        assert ans.usage["total_tokens"] == 7
+        # answer preserves brackets; clean_answer strips them.
+        assert "[1]" in ans.answer
+        assert "[1]" not in ans.clean_answer
+
+    def test_coverage_partial(self) -> None:
+        tracker = CitationTracker(sources=[_src("1", "a"), _src("2", "b"), _src("3", "c")])
+        ans = tracker.parse_response("Only one is cited [1].")
+        assert pytest.approx(ans.coverage) == 1 / 3
+        uncited = {s.id for s in ans.uncited_sources()}
+        assert uncited == {"2", "3"}
+
+    def test_not_grounded_when_no_citations(self) -> None:
+        tracker = CitationTracker(sources=[_src("1", "a")])
+        ans = tracker.parse_response("No citations at all.")
+        assert not ans.is_grounded
+        assert ans.coverage == 0.0
+
+    def test_to_dict_round_trip_shape(self) -> None:
+        tracker = CitationTracker(sources=[_src("1", "a")])
+        ans = tracker.parse_response("Yes [1].")
+        d = ans.to_dict()
+        assert d["is_grounded"] is True
+        assert d["citations"][0]["source_ids"] == ["1"]
+        assert d["sources"][0]["id"] == "1"
+
+    def test_unsupported_source_type_raises(self) -> None:
+        with pytest.raises(TypeError, match="Source"):
+            CitationTracker(sources=[12345])  # type: ignore[list-item]

--- a/tests/test_claude_prompt_caching.py
+++ b/tests/test_claude_prompt_caching.py
@@ -1,0 +1,307 @@
+"""Tests for Anthropic prompt caching (Phase 1).
+
+Two layers:
+
+1. **Unit tests** — exercise ``_apply_cache_control_to_system`` and
+   ``_apply_cache_control_to_tools`` directly. No network, no SDK,
+   always run.
+2. **Driver integration tests** — instantiate ``ClaudeDriver`` and
+   ``AsyncClaudeDriver`` with a stub Anthropic SDK and verify the
+   request kwargs include ``cache_control`` markers when expected.
+3. **Live integration test** — marked ``integration``, hits the real
+   Anthropic API to verify ``cache_creation_input_tokens > 0`` on the
+   first call and ``cache_read_input_tokens > 0`` on the second.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+from prompture.drivers.claude_driver import (
+    CACHE_PROMPT_MIN_CHARS,
+    _apply_cache_control_to_system,
+    _apply_cache_control_to_tools,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests — helper behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestApplyCacheControlToSystem:
+    def test_none_returns_none(self) -> None:
+        assert _apply_cache_control_to_system(None, cache_prompt=True) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert _apply_cache_control_to_system("", cache_prompt=True) is None
+
+    def test_short_prompt_returns_string(self) -> None:
+        out = _apply_cache_control_to_system("short", cache_prompt=True)
+        assert out == "short"
+
+    def test_long_prompt_wraps_with_cache_control(self) -> None:
+        text = "x" * (CACHE_PROMPT_MIN_CHARS + 1)
+        out = _apply_cache_control_to_system(text, cache_prompt=True)
+        assert isinstance(out, list)
+        assert len(out) == 1
+        block = out[0]
+        assert block["type"] == "text"
+        assert block["text"] == text
+        assert block["cache_control"] == {"type": "ephemeral"}
+
+    def test_cache_prompt_false_returns_string_even_when_long(self) -> None:
+        text = "x" * (CACHE_PROMPT_MIN_CHARS + 1)
+        out = _apply_cache_control_to_system(text, cache_prompt=False)
+        assert out == text
+
+    def test_custom_min_chars_threshold(self) -> None:
+        text = "x" * 100
+        # Below custom threshold -> plain string
+        assert _apply_cache_control_to_system(text, cache_prompt=True, min_chars=200) == text
+        # At/above custom threshold -> wrapped
+        out = _apply_cache_control_to_system(text, cache_prompt=True, min_chars=50)
+        assert isinstance(out, list) and out[0]["cache_control"]["type"] == "ephemeral"
+
+
+class TestApplyCacheControlToTools:
+    def _make_tool(self, name: str, description: str = "") -> dict[str, Any]:
+        return {"name": name, "description": description, "input_schema": {"type": "object"}}
+
+    def test_empty_tools_returned_unchanged(self) -> None:
+        assert _apply_cache_control_to_tools([], cache_prompt=True) == []
+
+    def test_cache_prompt_false_returns_unchanged(self) -> None:
+        tools = [self._make_tool("t1", description="x" * 5000)]
+        out = _apply_cache_control_to_tools(tools, cache_prompt=False)
+        assert out is tools  # no copy when bypassing
+        assert "cache_control" not in tools[0]
+
+    def test_small_tool_bundle_unchanged(self) -> None:
+        tools = [self._make_tool("t1")]
+        out = _apply_cache_control_to_tools(tools, cache_prompt=True)
+        assert "cache_control" not in out[0]
+
+    def test_large_tool_bundle_marks_last(self) -> None:
+        big_desc = "y" * (CACHE_PROMPT_MIN_CHARS + 100)
+        tools = [self._make_tool("t1", description=big_desc), self._make_tool("t2")]
+        out = _apply_cache_control_to_tools(tools, cache_prompt=True)
+        # Only the LAST tool gets cache_control.
+        assert "cache_control" not in out[0]
+        assert out[1]["cache_control"] == {"type": "ephemeral"}
+
+    def test_input_tools_not_mutated(self) -> None:
+        big_desc = "y" * (CACHE_PROMPT_MIN_CHARS + 100)
+        tools = [self._make_tool("t1", description=big_desc)]
+        out = _apply_cache_control_to_tools(tools, cache_prompt=True)
+        # Output dict has the marker; input dict does NOT.
+        assert "cache_control" in out[0]
+        assert "cache_control" not in tools[0]
+
+    def test_returns_list_not_tuple(self) -> None:
+        big_desc = "y" * (CACHE_PROMPT_MIN_CHARS + 100)
+        tools = [self._make_tool("t1", description=big_desc)]
+        out = _apply_cache_control_to_tools(tools, cache_prompt=True)
+        assert isinstance(out, list)
+
+
+# ---------------------------------------------------------------------------
+# Driver integration — stub the Anthropic SDK, capture request kwargs
+# ---------------------------------------------------------------------------
+
+
+class _StubUsage:
+    input_tokens = 100
+    output_tokens = 50
+    cache_creation_input_tokens = 0
+    cache_read_input_tokens = 0
+
+
+class _StubContentBlock:
+    def __init__(self, text: str = "ok") -> None:
+        self.type = "text"
+        self.text = text
+
+
+class _StubResponse:
+    def __init__(self) -> None:
+        self.usage = _StubUsage()
+        self.content = [_StubContentBlock()]
+        self.stop_reason = "end_turn"
+
+    # ClaudeDriver._build_anthropic_meta does dict(resp); make it iterable as a mapping.
+    def keys(self) -> list[str]:
+        return []
+
+    def __getitem__(self, _: str) -> Any:
+        raise KeyError
+
+
+class _StubMessages:
+    def __init__(self) -> None:
+        self.last_kwargs: dict[str, Any] = {}
+
+    def create(self, **kwargs: Any) -> _StubResponse:
+        self.last_kwargs = kwargs
+        return _StubResponse()
+
+
+class _StubClient:
+    def __init__(self) -> None:
+        self.messages = _StubMessages()
+
+
+@pytest.fixture
+def stub_claude_driver(monkeypatch: pytest.MonkeyPatch):
+    """Yield a ``ClaudeDriver`` whose ``anthropic.Anthropic`` client is stubbed."""
+    from prompture.drivers import claude_driver as cd
+
+    stub_client = _StubClient()
+
+    class _StubAnthropic:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        def __new__(cls, *_: Any, **__: Any) -> _StubClient:  # type: ignore[misc]
+            return stub_client
+
+    # Patch the module-level ``anthropic.Anthropic`` constructor.
+    monkeypatch.setattr(cd, "anthropic", type("M", (), {"Anthropic": _StubAnthropic}))
+    driver = cd.ClaudeDriver(api_key="test-key", model="claude-sonnet-4-6")
+    return driver, stub_client
+
+
+class TestClaudeDriverRequestShape:
+    def test_short_system_passes_string(self, stub_claude_driver) -> None:
+        driver, client = stub_claude_driver
+        driver.generate_messages(
+            [{"role": "system", "content": "short"}, {"role": "user", "content": "hi"}],
+            options={},
+        )
+        kw = client.messages.last_kwargs
+        # System must be a plain string when below the threshold.
+        assert isinstance(kw["system"], str)
+        assert kw["system"] == "short"
+
+    def test_long_system_passes_list_with_cache_control(self, stub_claude_driver) -> None:
+        driver, client = stub_claude_driver
+        long_sys = "x" * (CACHE_PROMPT_MIN_CHARS + 100)
+        driver.generate_messages(
+            [{"role": "system", "content": long_sys}, {"role": "user", "content": "hi"}],
+            options={},
+        )
+        kw = client.messages.last_kwargs
+        assert isinstance(kw["system"], list)
+        assert kw["system"][0]["cache_control"] == {"type": "ephemeral"}
+        assert kw["system"][0]["text"] == long_sys
+
+    def test_cache_prompt_false_disables_caching(self, stub_claude_driver) -> None:
+        driver, client = stub_claude_driver
+        long_sys = "x" * (CACHE_PROMPT_MIN_CHARS + 100)
+        driver.generate_messages(
+            [{"role": "system", "content": long_sys}, {"role": "user", "content": "hi"}],
+            options={"cache_prompt": False},
+        )
+        kw = client.messages.last_kwargs
+        # Plain string, no list wrapping when caching is disabled.
+        assert isinstance(kw["system"], str)
+
+    def test_long_tools_get_cache_control_on_last(self, stub_claude_driver) -> None:
+        driver, client = stub_claude_driver
+        big_tool_desc = "y" * (CACHE_PROMPT_MIN_CHARS + 100)
+        tools = [
+            {
+                "type": "function",
+                "function": {"name": "t1", "description": big_tool_desc, "parameters": {"type": "object"}},
+            },
+            {
+                "type": "function",
+                "function": {"name": "t2", "description": "small", "parameters": {"type": "object"}},
+            },
+        ]
+        driver.generate_messages_with_tools(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=tools,
+            options={},
+        )
+        kw = client.messages.last_kwargs
+        sent_tools = kw["tools"]
+        assert len(sent_tools) == 2
+        assert "cache_control" not in sent_tools[0]
+        assert sent_tools[1]["cache_control"] == {"type": "ephemeral"}
+
+    def test_json_mode_schema_tool_can_be_cached(self, stub_claude_driver) -> None:
+        driver, client = stub_claude_driver
+        # Build a large schema to push the single inline tool over the threshold.
+        big_schema = {
+            "type": "object",
+            "properties": {f"field_{i}": {"type": "string", "description": "x" * 100} for i in range(50)},
+        }
+        driver.generate_messages(
+            [{"role": "user", "content": "extract"}],
+            options={"json_mode": True, "json_schema": big_schema},
+        )
+        kw = client.messages.last_kwargs
+        sent_tools = kw["tools"]
+        # Single tool above threshold -> last (only) tool carries cache_control.
+        assert len(sent_tools) == 1
+        # If schema was large enough, cache_control is present; otherwise absent.
+        # Just verify the marker is correct *if* present (the threshold may
+        # be tuned later).
+        if "cache_control" in sent_tools[0]:
+            assert sent_tools[0]["cache_control"] == {"type": "ephemeral"}
+
+
+# ---------------------------------------------------------------------------
+# Live integration test — hits real Anthropic API
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_live_prompt_caching_reports_cache_read() -> None:
+    """End-to-end: two identical calls should show cache write then cache read.
+
+    Requires ``CLAUDE_API_KEY`` and the ``anthropic`` package. Skips otherwise.
+    """
+    if not os.getenv("CLAUDE_API_KEY"):
+        pytest.skip("CLAUDE_API_KEY not set")
+    try:
+        import anthropic  # noqa: F401
+    except ImportError:
+        pytest.skip("anthropic SDK not installed")
+
+    from prompture.drivers.claude_driver import ClaudeDriver
+
+    # Build a system prompt definitely large enough to be cacheable
+    # (Sonnet 4.6 min: 1024 tokens ≈ 4000 chars; we use ~6000 to be safe).
+    big_system = (
+        "You are a careful research assistant. "
+        "Always cite sources. Refuse to invent facts. "
+        "Reply with exactly one sentence. "
+    ) * 100  # ~5500 chars, well over the 4000 threshold
+
+    driver = ClaudeDriver(model="claude-sonnet-4-6")
+    messages = [
+        {"role": "system", "content": big_system},
+        {"role": "user", "content": "Say 'cached'."},
+    ]
+
+    # First call -> cache creation
+    r1 = driver.generate_messages(messages, options={"max_tokens": 16})
+    cache_create_1 = r1["meta"]["cache_creation_tokens"]
+    cache_read_1 = r1["meta"]["cached_prompt_tokens"]
+    assert cache_create_1 > 0, (
+        f"Expected cache_creation_tokens > 0 on first call; "
+        f"got cache_create={cache_create_1}, cache_read={cache_read_1}. "
+        f"Either the system prompt is too short or cache_control is not being sent."
+    )
+
+    # Second call -> cache read (within 5min TTL)
+    r2 = driver.generate_messages(messages, options={"max_tokens": 16})
+    cache_read_2 = r2["meta"]["cached_prompt_tokens"]
+    assert cache_read_2 > 0, (
+        f"Expected cache_read_input_tokens > 0 on second call; got {cache_read_2}. "
+        f"Cache may have expired or cache_control may not be propagating."
+    )

--- a/tests/test_enhanced_extraction.py
+++ b/tests/test_enhanced_extraction.py
@@ -5,7 +5,6 @@ This module tests the enhanced stepwise extraction with field definitions
 support, default value handling, and graceful failure management.
 """
 
-from typing import Optional
 from unittest.mock import patch
 
 import pytest
@@ -19,8 +18,8 @@ from prompture.extraction.fields import FIELD_DEFINITIONS
 class PersonModel(BaseModel):
     name: str = Field(description="Full name of the person")
     age: int = Field(description="Age in years")
-    email: Optional[str] = Field(None, description="Email address")
-    occupation: Optional[str] = Field(None, description="Job title")
+    email: str | None = Field(None, description="Email address")
+    occupation: str | None = Field(None, description="Job title")
 
 
 class SimpleModel(BaseModel):
@@ -31,10 +30,10 @@ class SimpleModel(BaseModel):
 class ComplexModel(BaseModel):
     name: str = Field(description="Person's name")
     age: int = Field(description="Person's age")
-    email: Optional[str] = Field(None, description="Email address")
-    phone: Optional[str] = Field(None, description="Phone number")
-    occupation: Optional[str] = Field(None, description="Job title")
-    experience_years: Optional[int] = Field(None, description="Years of experience")
+    email: str | None = Field(None, description="Email address")
+    phone: str | None = Field(None, description="Phone number")
+    occupation: str | None = Field(None, description="Job title")
+    experience_years: int | None = Field(None, description="Years of experience")
 
 
 class TestStepwiseExtractionBasic:

--- a/tests/test_json_encoder.py
+++ b/tests/test_json_encoder.py
@@ -1,0 +1,127 @@
+"""Tests for the shared PromptureJSONEncoder.
+
+Added in Phase 0 — replaces the ``json.dumps(..., default=str)`` pattern that
+was duplicated across 15+ call sites. Verifies the encoder handles every
+common Python type Prompture emits while preserving the legacy fallback
+behaviour for unknown objects.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
+from enum import Enum
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+from pydantic import BaseModel
+
+from prompture._internal.json_encoder import PromptureJSONEncoder, dumps
+
+
+class _Color(Enum):
+    RED = "red"
+    BLUE = "blue"
+
+
+class _Person(BaseModel):
+    name: str
+    age: int
+
+
+class TestPromptureJSONEncoder:
+    def _encode(self, payload):
+        return json.loads(dumps(payload))
+
+    def test_datetime_serialises_to_iso8601(self) -> None:
+        out = self._encode({"when": datetime(2025, 1, 2, 3, 4, 5)})
+        assert out["when"] == "2025-01-02T03:04:05"
+
+    def test_date_serialises_to_iso8601(self) -> None:
+        out = self._encode({"day": date(2025, 1, 2)})
+        assert out["day"] == "2025-01-02"
+
+    def test_time_serialises_to_iso8601(self) -> None:
+        out = self._encode({"t": time(3, 4, 5)})
+        assert out["t"] == "03:04:05"
+
+    def test_timedelta_serialises_to_total_seconds(self) -> None:
+        out = self._encode({"span": timedelta(seconds=90)})
+        assert out["span"] == 90.0
+
+    def test_decimal_preserves_precision(self) -> None:
+        out = self._encode({"x": Decimal("3.14159265358979323846")})
+        assert out["x"] == "3.14159265358979323846"
+
+    def test_uuid_serialises_to_string(self) -> None:
+        out = self._encode({"id": UUID("00000000-0000-4000-8000-000000000000")})
+        assert out["id"] == "00000000-0000-4000-8000-000000000000"
+
+    def test_enum_serialises_to_value(self) -> None:
+        out = self._encode({"c": _Color.RED})
+        assert out["c"] == "red"
+
+    def test_path_serialises_to_string(self) -> None:
+        out = self._encode({"p": Path("foo") / "bar"})
+        assert "bar" in out["p"]
+
+    def test_pydantic_model_serialises_via_model_dump(self) -> None:
+        out = self._encode({"who": _Person(name="A", age=1)})
+        assert out["who"] == {"name": "A", "age": 1}
+
+    def test_set_is_serialised_deterministically(self) -> None:
+        # str-comparable items -> sorted
+        out = self._encode({"s": {"b", "a"}})
+        assert out["s"] == ["a", "b"]
+
+    def test_set_of_enums_falls_back_to_str_key_sort(self) -> None:
+        # Enum members aren't directly comparable; encoder should still emit
+        # them deterministically by stringifying the comparison key.
+        out_a = self._encode({"s": {_Color.RED, _Color.BLUE}})
+        out_b = self._encode({"s": {_Color.RED, _Color.BLUE}})
+        # Each call independently produces the same ordering.
+        assert out_a == out_b
+        # And the values are the enum .value strings.
+        assert set(out_a["s"]) == {"red", "blue"}
+
+    def test_bytes_printable_ascii_round_trips(self) -> None:
+        out = self._encode({"b": b"hello"})
+        assert out["b"] == "hello"
+
+    def test_bytes_binary_is_base64(self) -> None:
+        import base64
+
+        out = self._encode({"b": b"\x00\x01\x02"})
+        assert out["b"] == base64.b64encode(b"\x00\x01\x02").decode()
+
+    def test_unknown_object_falls_back_to_str(self) -> None:
+        text = dumps({"o": object()})
+        assert "object" in text
+
+    def test_explicit_encoder_class_works(self) -> None:
+        text = json.dumps({"d": date(2025, 1, 1)}, cls=PromptureJSONEncoder)
+        assert json.loads(text)["d"] == "2025-01-01"
+
+    def test_kwargs_are_forwarded(self) -> None:
+        text = dumps({"a": 1, "b": 2}, sort_keys=True, indent=2)
+        assert text.startswith("{\n  ")
+        assert "\"a\": 1" in text and "\"b\": 2" in text
+
+    def test_ensure_ascii_defaults_off(self) -> None:
+        # The legacy call sites used ``ensure_ascii=False``; dumps() preserves it.
+        text = dumps({"name": "Ańa"})
+        assert "Ańa" in text
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"nested": {"when": datetime(2025, 1, 1), "id": UUID(int=0)}},
+            [datetime(2025, 1, 1), Decimal("1.5"), _Color.BLUE],
+        ],
+    )
+    def test_recursive_structures(self, payload) -> None:
+        # Should not raise; recursion goes through default() for each leaf.
+        text = dumps(payload)
+        json.loads(text)

--- a/tests/test_kg.py
+++ b/tests/test_kg.py
@@ -1,0 +1,252 @@
+"""Tests for prompture.kg."""
+
+from __future__ import annotations
+
+from prompture.kg import (
+    Entity,
+    InMemoryEntityStore,
+    KnowledgeGraph,
+    Mention,
+    Relation,
+    SQLiteEntityStore,
+)
+
+# ----------------------------------------------------------------------
+# Type round trips
+# ----------------------------------------------------------------------
+
+
+class TestTypes:
+    def test_entity_round_trip(self) -> None:
+        e = Entity(
+            id="person:alice",
+            name="Alice",
+            type="person",
+            aliases=("Al", "A. Smith"),
+            attributes={"age": 30},
+        )
+        d = e.to_dict()
+        assert Entity.from_dict(d).aliases == ("Al", "A. Smith")
+
+    def test_entity_make_id(self) -> None:
+        assert Entity.make_id("Sam Altman", "person") == "person:sam_altman"
+        assert Entity.make_id("OpenAI") == "openai"
+
+    def test_relation_default_id(self) -> None:
+        r1 = Relation(subject_id="a", predicate="p", object_id="b")
+        r2 = Relation(subject_id="a", predicate="p", object_id="b")
+        assert r1.id != r2.id
+
+    def test_mention_round_trip(self) -> None:
+        m = Mention(entity_id="e", text="Alice", source="doc.txt", start=10, end=15)
+        m2 = Mention.from_dict(m.to_dict())
+        assert m2.entity_id == "e"
+        assert m2.start == 10
+
+
+# ----------------------------------------------------------------------
+# InMemoryEntityStore
+# ----------------------------------------------------------------------
+
+
+class TestInMemoryStore:
+    def test_upsert_get(self) -> None:
+        store = InMemoryEntityStore()
+        e = Entity(id="e1", name="Alice", type="person")
+        store.upsert_entity(e)
+        assert store.get_entity("e1").name == "Alice"
+
+    def test_find_by_name(self) -> None:
+        store = InMemoryEntityStore()
+        store.upsert_entity(Entity(id="e1", name="Alice"))
+        store.upsert_entity(Entity(id="e2", name="Bob"))
+        out = store.find_entities(name="alice")
+        assert [e.id for e in out] == ["e1"]
+
+    def test_find_by_alias(self) -> None:
+        store = InMemoryEntityStore()
+        store.upsert_entity(Entity(id="e1", name="Alice", aliases=("Al",)))
+        out = store.find_entities(name="Al")
+        assert out and out[0].id == "e1"
+
+    def test_find_by_type(self) -> None:
+        store = InMemoryEntityStore()
+        store.upsert_entity(Entity(id="e1", name="Alice", type="person"))
+        store.upsert_entity(Entity(id="e2", name="OpenAI", type="organization"))
+        people = store.find_entities(type="person")
+        assert [e.id for e in people] == ["e1"]
+
+    def test_upsert_reindexes_aliases(self) -> None:
+        store = InMemoryEntityStore()
+        store.upsert_entity(Entity(id="e1", name="Alice", aliases=("Al",)))
+        # Drop the alias on a re-upsert
+        store.upsert_entity(Entity(id="e1", name="Alice", aliases=()))
+        assert store.find_entities(name="Al") == []
+
+    def test_delete_cascades_relations(self) -> None:
+        store = InMemoryEntityStore()
+        store.upsert_entity(Entity(id="a", name="A"))
+        store.upsert_entity(Entity(id="b", name="B"))
+        rel = Relation(subject_id="a", predicate="knows", object_id="b")
+        store.add_relation(rel)
+        store.delete_entity("a")
+        assert store.relations_for("b") == []
+
+    def test_relations_direction(self) -> None:
+        store = InMemoryEntityStore()
+        store.upsert_entity(Entity(id="a", name="A"))
+        store.upsert_entity(Entity(id="b", name="B"))
+        r = Relation(subject_id="a", predicate="knows", object_id="b")
+        store.add_relation(r)
+        assert len(store.relations_for("a", as_object=False)) == 1
+        assert store.relations_for("a", as_subject=False) == []
+        assert len(store.relations_for("b", as_subject=False)) == 1
+
+    def test_relations_predicate_filter(self) -> None:
+        store = InMemoryEntityStore()
+        store.upsert_entity(Entity(id="a", name="A"))
+        store.upsert_entity(Entity(id="b", name="B"))
+        store.add_relation(Relation(subject_id="a", predicate="knows", object_id="b"))
+        store.add_relation(Relation(subject_id="a", predicate="works_with", object_id="b"))
+        knows = store.relations_for("a", predicate="knows")
+        assert len(knows) == 1
+        assert knows[0].predicate == "knows"
+
+    def test_mentions(self) -> None:
+        store = InMemoryEntityStore()
+        store.upsert_entity(Entity(id="e1", name="Alice"))
+        store.add_mention(Mention(entity_id="e1", text="Alice"))
+        store.add_mention(Mention(entity_id="e1", text="Al"))
+        out = store.mentions_for("e1")
+        assert {m.text for m in out} == {"Alice", "Al"}
+
+
+# ----------------------------------------------------------------------
+# SQLiteEntityStore
+# ----------------------------------------------------------------------
+
+
+class TestSQLiteStore:
+    def test_upsert_get(self, tmp_path) -> None:
+        store = SQLiteEntityStore(db_path=tmp_path / "kg.db")
+        store.upsert_entity(Entity(id="e1", name="Alice", type="person"))
+        assert store.get_entity("e1").type == "person"
+
+    def test_find_by_name_and_alias(self, tmp_path) -> None:
+        store = SQLiteEntityStore(db_path=tmp_path / "kg.db")
+        store.upsert_entity(Entity(id="e1", name="Alice", aliases=("Al",)))
+        store.upsert_entity(Entity(id="e2", name="Bob"))
+        assert [e.id for e in store.find_entities(name="alice")] == ["e1"]
+        # Alias search via LIKE
+        alias_hits = store.find_entities(name="Al")
+        assert any(e.id == "e1" for e in alias_hits)
+
+    def test_persistence_across_instances(self, tmp_path) -> None:
+        path = tmp_path / "kg.db"
+        SQLiteEntityStore(db_path=path).upsert_entity(Entity(id="e1", name="Alice"))
+        loaded = SQLiteEntityStore(db_path=path).get_entity("e1")
+        assert loaded is not None
+        assert loaded.name == "Alice"
+
+    def test_cascade_delete(self, tmp_path) -> None:
+        store = SQLiteEntityStore(db_path=tmp_path / "kg.db")
+        store.upsert_entity(Entity(id="a", name="A"))
+        store.upsert_entity(Entity(id="b", name="B"))
+        store.add_relation(Relation(subject_id="a", predicate="p", object_id="b"))
+        store.delete_entity("a")
+        assert store.relations_for("b") == []
+
+    def test_mentions(self, tmp_path) -> None:
+        store = SQLiteEntityStore(db_path=tmp_path / "kg.db")
+        store.upsert_entity(Entity(id="e1", name="Alice"))
+        store.add_mention(Mention(entity_id="e1", text="Alice", source="doc1.txt"))
+        out = store.mentions_for("e1")
+        assert len(out) == 1
+        assert out[0].source == "doc1.txt"
+
+
+# ----------------------------------------------------------------------
+# KnowledgeGraph
+# ----------------------------------------------------------------------
+
+
+class TestKnowledgeGraph:
+    def test_upsert_entity_by_name(self) -> None:
+        kg = KnowledgeGraph()
+        e = kg.upsert_entity("Sam Altman", type="person")
+        assert e.id == "person:sam_altman"
+        assert e.type == "person"
+
+    def test_upsert_merges_aliases_and_attrs(self) -> None:
+        kg = KnowledgeGraph()
+        kg.upsert_entity("OpenAI", type="organization", aliases=("OAI",), attributes={"hq": "SF"})
+        merged = kg.upsert_entity(
+            "OpenAI",
+            type="organization",
+            aliases=("Open AI",),
+            attributes={"hq": "San Francisco", "founded": 2015},
+        )
+        # Aliases merge, hq is overwritten, founded is added
+        assert set(merged.aliases) == {"OAI", "Open AI"}
+        assert merged.attributes["hq"] == "San Francisco"
+        assert merged.attributes["founded"] == 2015
+
+    def test_add_relation_resolves_strings(self) -> None:
+        kg = KnowledgeGraph()
+        sam = kg.upsert_entity("Sam Altman", type="person")
+        rel = kg.add_relation(sam, "works_at", "OpenAI")
+        oai = kg.resolve("OpenAI")
+        assert oai is not None
+        assert rel.subject_id == sam.id
+        assert rel.object_id == oai.id
+
+    def test_neighbors_directional(self) -> None:
+        kg = KnowledgeGraph()
+        sam = kg.upsert_entity("Sam", type="person")
+        oai = kg.upsert_entity("OpenAI", type="organization")
+        kg.add_relation(sam, "works_at", oai)
+        out_rels = kg.neighbors(sam, direction="out")
+        in_rels = kg.neighbors(oai, direction="in")
+        assert len(out_rels) == 1
+        assert len(in_rels) == 1
+        assert kg.neighbors(sam, direction="in") == []
+
+    def test_neighbors_predicate_filter(self) -> None:
+        kg = KnowledgeGraph()
+        a = kg.upsert_entity("A")
+        b = kg.upsert_entity("B")
+        kg.add_relation(a, "knows", b)
+        kg.add_relation(a, "founded", b)
+        knows = kg.neighbors(a, predicate="knows")
+        assert len(knows) == 1
+        assert knows[0].predicate == "knows"
+
+    def test_mention_with_string_creates_entity(self) -> None:
+        kg = KnowledgeGraph()
+        m = kg.mention("Paris", "Paris", source="doc1")
+        assert kg.resolve("Paris") is not None
+        assert m.source == "doc1"
+
+    def test_resolve_returns_none_when_missing(self) -> None:
+        kg = KnowledgeGraph()
+        assert kg.resolve("Nobody") is None
+
+    def test_resolve_filters_by_type(self) -> None:
+        kg = KnowledgeGraph()
+        kg.upsert_entity("Paris", type="location")
+        kg.upsert_entity("Paris", type="person")
+        loc = kg.resolve("Paris", type="location")
+        assert loc is not None
+        assert loc.type == "location"
+
+    def test_full_round_trip_with_sqlite(self, tmp_path) -> None:
+        store = SQLiteEntityStore(db_path=tmp_path / "kg.db")
+        kg = KnowledgeGraph(store)
+        sam = kg.upsert_entity("Sam", type="person")
+        kg.add_relation(sam, "works_at", "OpenAI")
+
+        # Re-open
+        kg2 = KnowledgeGraph(SQLiteEntityStore(db_path=tmp_path / "kg.db"))
+        sam2 = kg2.resolve("Sam")
+        assert sam2 is not None
+        assert len(kg2.neighbors(sam2)) == 1

--- a/tests/test_live_events.py
+++ b/tests/test_live_events.py
@@ -1,0 +1,437 @@
+"""Tests for the live event stream (interleaved tool calling)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from prompture.agents.agent import Agent
+from prompture.agents.conversation import Conversation
+from prompture.agents.live_events import (
+    AssistantTurnStart,
+    LiveEvent,
+    MessageStop,
+    TextDelta,
+    ThinkingDelta,
+    ToolInputDelta,
+    ToolResult,
+    ToolUseStart,
+    ToolUseStop,
+    TurnComplete,
+)
+from prompture.agents.tools_schema import ToolRegistry
+from prompture.drivers.base import Driver
+
+
+# ---------------------------------------------------------------------------
+# Mock drivers
+# ---------------------------------------------------------------------------
+
+
+class BufferedToolDriver(Driver):
+    """Driver that only implements the buffered (non-streaming) tool method.
+
+    Exercises the base class default ``generate_messages_with_tools_stream``
+    fallback that wraps buffered responses into synthetic events.
+    """
+
+    supports_messages = True
+    supports_tool_use = True
+    supports_streaming = False
+    supports_streaming_tool_use = False
+
+    def __init__(self, responses: list[dict[str, Any]]):
+        self._responses = list(responses)
+        self._idx = 0
+        self.model = "mock-buffered"
+
+    def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        return self._next()
+
+    def generate_messages(self, messages: list[dict[str, Any]], options: dict[str, Any]) -> dict[str, Any]:
+        return self._next()
+
+    def generate_messages_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> dict[str, Any]:
+        return self._next()
+
+    def _next(self) -> dict[str, Any]:
+        r = self._responses[min(self._idx, len(self._responses) - 1)]
+        self._idx += 1
+        return r
+
+
+class NativeStreamingDriver(Driver):
+    """Driver that natively emits LiveEvent sequences per turn.
+
+    Used to verify the conversation layer correctly forwards events,
+    executes tools, and loops until ``MessageStop`` reports no pending
+    tool calls.
+    """
+
+    supports_messages = True
+    supports_tool_use = True
+    supports_streaming = True
+    supports_streaming_tool_use = True
+
+    def __init__(self, turn_event_sequences: list[list[LiveEvent]]):
+        self._turns = list(turn_event_sequences)
+        self._idx = 0
+        self.model = "mock-native-stream"
+
+    def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        return {"text": "n/a", "meta": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "cost": 0.0}}
+
+    def generate_messages(self, messages: list[dict[str, Any]], options: dict[str, Any]) -> dict[str, Any]:
+        return self.generate("", options)
+
+    def generate_messages_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> dict[str, Any]:
+        raise AssertionError("ask_live should call generate_messages_with_tools_stream, not the buffered method")
+
+    def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> Iterator[LiveEvent]:
+        events = self._turns[min(self._idx, len(self._turns) - 1)]
+        self._idx += 1
+        yield from events
+
+
+# ---------------------------------------------------------------------------
+# Default-impl fallback tests (base class wraps buffered)
+# ---------------------------------------------------------------------------
+
+
+def lookup_population(city: str) -> str:
+    """Return population for a city."""
+    return {"Tokyo": "13960000", "Paris": "2161000"}.get(city, "Unknown")
+
+
+class TestBufferedFallback:
+    def test_buffered_driver_wrapped_into_event_sequence(self):
+        driver = BufferedToolDriver(
+            [
+                {
+                    "text": "Looking up Tokyo.",
+                    "tool_calls": [{"id": "call_1", "name": "lookup_population", "arguments": {"city": "Tokyo"}}],
+                    "meta": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15, "cost": 0.001},
+                    "stop_reason": "tool_use",
+                },
+                {
+                    "text": "Tokyo has 13,960,000 people.",
+                    "tool_calls": [],
+                    "meta": {"prompt_tokens": 20, "completion_tokens": 8, "total_tokens": 28, "cost": 0.002},
+                    "stop_reason": "end_turn",
+                },
+            ]
+        )
+        conv = Conversation(driver=driver, tools=self._tools())
+
+        events = list(conv.ask_live("How many people live in Tokyo?"))
+
+        kinds = [e.event_type for e in events]
+        # Two turns expected: turn 1 has tool call, turn 2 is the final answer.
+        assert kinds.count("assistant_turn_start") == 2
+        assert kinds.count("tool_use_start") == 1
+        assert kinds.count("tool_use_stop") == 1
+        assert kinds.count("tool_result") == 1
+        assert kinds.count("turn_complete") == 1
+
+        # The tool result must be emitted between the two assistant turns.
+        tool_result_idx = next(i for i, e in enumerate(events) if e.event_type == "tool_result")
+        turn_starts = [i for i, e in enumerate(events) if e.event_type == "assistant_turn_start"]
+        assert turn_starts[0] < tool_result_idx < turn_starts[1]
+
+        # Tool result content must include the looked-up population.
+        tool_result = next(e for e in events if isinstance(e, ToolResult))
+        assert "13960000" in tool_result.output
+        assert tool_result.is_error is False
+
+    def test_buffered_driver_emits_text_before_tool_use_start(self):
+        """In the fallback wrapper, narration text is emitted before the
+        synthesized ToolUseStart so the consumer's UI still shows context
+        before each tool fires."""
+        driver = BufferedToolDriver(
+            [
+                {
+                    "text": "Let me check.",
+                    "tool_calls": [{"id": "c", "name": "lookup_population", "arguments": {"city": "Paris"}}],
+                    "meta": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8, "cost": 0.0},
+                    "stop_reason": "tool_use",
+                },
+                {
+                    "text": "Done.",
+                    "tool_calls": [],
+                    "meta": {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12, "cost": 0.0},
+                    "stop_reason": "end_turn",
+                },
+            ]
+        )
+        conv = Conversation(driver=driver, tools=self._tools())
+        events = list(conv.ask_live("Paris?"))
+
+        # First TextDelta must come before the first ToolUseStart.
+        text_idx = next(i for i, e in enumerate(events) if isinstance(e, TextDelta))
+        tool_idx = next(i for i, e in enumerate(events) if isinstance(e, ToolUseStart))
+        assert text_idx < tool_idx
+        assert events[text_idx].text == "Let me check."
+
+    def _tools(self) -> ToolRegistry:
+        reg = ToolRegistry()
+        reg.register(lookup_population)
+        return reg
+
+
+# ---------------------------------------------------------------------------
+# Native-streaming conversation tests
+# ---------------------------------------------------------------------------
+
+
+class TestNativeStreaming:
+    def test_interleaved_text_and_tool_in_one_turn(self):
+        """A driver that streams `text → tool_use → text → tool_use → message_stop`
+        within ONE turn should flow through ask_live untouched, with the
+        conversation layer inserting one ToolResult after each tool_use_stop."""
+        turn1 = [
+            AssistantTurnStart(turn_index=0),
+            TextDelta(text="Looking up "),
+            TextDelta(text="Tokyo..."),
+            ToolUseStart(id="t1", name="lookup_population"),
+            ToolInputDelta(id="t1", fragment='{"city"'),
+            ToolInputDelta(id="t1", fragment=': "Tokyo"}'),
+            ToolUseStop(id="t1", name="lookup_population", input={"city": "Tokyo"}),
+            TextDelta(text=" Now Paris..."),
+            ToolUseStart(id="t2", name="lookup_population"),
+            ToolUseStop(id="t2", name="lookup_population", input={"city": "Paris"}),
+            MessageStop(
+                stop_reason="tool_use",
+                usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15, "cost": 0.001},
+            ),
+        ]
+        turn2 = [
+            AssistantTurnStart(turn_index=1),
+            TextDelta(text="Tokyo has more people than Paris."),
+            MessageStop(
+                stop_reason="end_turn",
+                usage={"prompt_tokens": 20, "completion_tokens": 8, "total_tokens": 28, "cost": 0.002},
+            ),
+        ]
+        driver = NativeStreamingDriver([turn1, turn2])
+        reg = ToolRegistry()
+        reg.register(lookup_population)
+        conv = Conversation(driver=driver, tools=reg)
+
+        events = list(conv.ask_live("Compare Tokyo and Paris."))
+        kinds = [e.event_type for e in events]
+
+        # Both tool_uses must be followed by a tool_result (in order).
+        assert kinds.count("tool_use_stop") == 2
+        assert kinds.count("tool_result") == 2
+
+        # Both tool_results carry the looked-up populations.
+        tool_results = [e for e in events if isinstance(e, ToolResult)]
+        outputs = [r.output for r in tool_results]
+        assert "13960000" in outputs[0]
+        assert "2161000" in outputs[1]
+
+        # Interleaved text BEFORE tools and BETWEEN tools is preserved.
+        text_chunks = [e.text for e in events if isinstance(e, TextDelta)]
+        joined_first_turn = "".join(text_chunks[:3])
+        assert "Looking up Tokyo..." in joined_first_turn
+        assert any("Now Paris" in t for t in text_chunks)
+
+        # TurnComplete is fired exactly once at the end.
+        assert kinds.count("turn_complete") == 1
+        assert kinds[-1] == "turn_complete"
+
+    def test_tool_input_deltas_forwarded(self):
+        """Input-JSON fragments should reach the consumer in order so a UI
+        can render the tool's arguments as they're generated."""
+        turn1 = [
+            AssistantTurnStart(turn_index=0),
+            ToolUseStart(id="x", name="lookup_population"),
+            ToolInputDelta(id="x", fragment='{"cit'),
+            ToolInputDelta(id="x", fragment='y": "Paris"}'),
+            ToolUseStop(id="x", name="lookup_population", input={"city": "Paris"}),
+            MessageStop(stop_reason="tool_use", usage={"total_tokens": 5, "cost": 0.0}),
+        ]
+        turn2 = [
+            AssistantTurnStart(turn_index=1),
+            TextDelta(text="Paris has 2,161,000."),
+            MessageStop(stop_reason="end_turn", usage={"total_tokens": 6, "cost": 0.0}),
+        ]
+        driver = NativeStreamingDriver([turn1, turn2])
+        reg = ToolRegistry()
+        reg.register(lookup_population)
+        conv = Conversation(driver=driver, tools=reg)
+
+        events = list(conv.ask_live("Paris?"))
+        fragments = [e.fragment for e in events if isinstance(e, ToolInputDelta)]
+        assert fragments == ['{"cit', 'y": "Paris"}']
+        assert "".join(fragments) == '{"city": "Paris"}'
+
+    def test_tool_error_marks_is_error(self):
+        def broken(_x: str) -> str:
+            """Always raises."""
+            raise RuntimeError("kaboom")
+
+        turn1 = [
+            AssistantTurnStart(turn_index=0),
+            ToolUseStart(id="b", name="broken"),
+            ToolUseStop(id="b", name="broken", input={"_x": "foo"}),
+            MessageStop(stop_reason="tool_use", usage={"total_tokens": 3, "cost": 0.0}),
+        ]
+        turn2 = [
+            AssistantTurnStart(turn_index=1),
+            TextDelta(text="Sorry, that tool failed."),
+            MessageStop(stop_reason="end_turn", usage={"total_tokens": 4, "cost": 0.0}),
+        ]
+        driver = NativeStreamingDriver([turn1, turn2])
+        reg = ToolRegistry()
+        reg.register(broken)
+        conv = Conversation(driver=driver, tools=reg)
+
+        events = list(conv.ask_live("Try the broken tool."))
+        tool_results = [e for e in events if isinstance(e, ToolResult)]
+        assert len(tool_results) == 1
+        assert tool_results[0].is_error is True
+        assert "kaboom" in tool_results[0].output
+
+    def test_no_tools_path_emits_text_only(self):
+        """When the conversation has no tools registered, ask_live should
+        delegate to streaming text and finish with TurnComplete."""
+
+        class _TextStreamDriver(Driver):
+            supports_messages = True
+            supports_streaming = True
+            model = "mock-text"
+
+            def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+                return {
+                    "text": "hello",
+                    "meta": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2, "cost": 0.0},
+                }
+
+            def generate_messages(self, messages, options):
+                return self.generate("", options)
+
+            def generate_messages_stream(self, messages, options):
+                yield {"type": "delta", "text": "hello "}
+                yield {"type": "delta", "text": "world"}
+                yield {
+                    "type": "done",
+                    "text": "hello world",
+                    "meta": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 2,
+                        "total_tokens": 3,
+                        "cost": 0.0,
+                    },
+                }
+
+        conv = Conversation(driver=_TextStreamDriver())
+        events = list(conv.ask_live("hi"))
+        kinds = [e.event_type for e in events]
+        assert kinds[0] == "text_delta"
+        assert kinds[-1] == "turn_complete"
+        joined = "".join(e.text for e in events if isinstance(e, TextDelta))
+        assert joined == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# Agent.run_live tests
+# ---------------------------------------------------------------------------
+
+
+class TestAgentRunLive:
+    def test_run_live_yields_events_and_returns_agent_result(self):
+        turn1 = [
+            AssistantTurnStart(turn_index=0),
+            TextDelta(text="Checking."),
+            ToolUseStart(id="a", name="lookup_population"),
+            ToolUseStop(id="a", name="lookup_population", input={"city": "Tokyo"}),
+            MessageStop(stop_reason="tool_use", usage={"total_tokens": 5, "cost": 0.001}),
+        ]
+        turn2 = [
+            AssistantTurnStart(turn_index=1),
+            TextDelta(text="Tokyo: 13,960,000."),
+            MessageStop(stop_reason="end_turn", usage={"total_tokens": 6, "cost": 0.001}),
+        ]
+        driver = NativeStreamingDriver([turn1, turn2])
+        agent = Agent("mock/mock", driver=driver, tools=[lookup_population])
+
+        streamed = agent.run_live("Tokyo?")
+        events = list(streamed)
+        kinds = [e.event_type for e in events]
+        assert kinds.count("text_delta") >= 2
+        assert kinds.count("tool_use_stop") == 1
+        assert kinds.count("tool_result") == 1
+        assert kinds[-1] == "turn_complete"
+
+        result = streamed.result
+        assert result is not None
+        # The final assistant turn's text becomes output_text.
+        assert "Tokyo" in result.output_text
+
+    def test_run_live_without_tools_works(self):
+        class _Stream(Driver):
+            supports_messages = True
+            supports_streaming = True
+            model = "mock-text"
+
+            def generate(self, prompt, options):
+                return {"text": "ok", "meta": {"total_tokens": 1, "cost": 0.0}}
+
+            def generate_messages(self, messages, options):
+                return self.generate("", options)
+
+            def generate_messages_stream(self, messages, options):
+                for piece in ("hel", "lo"):
+                    yield {"type": "delta", "text": piece}
+                yield {"type": "done", "text": "hello", "meta": {"total_tokens": 2, "cost": 0.0}}
+
+        agent = Agent("mock/mock", driver=_Stream())
+        events = list(agent.run_live("hi"))
+        text = "".join(e.text for e in events if isinstance(e, TextDelta))
+        assert text == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Smoke tests for event types
+# ---------------------------------------------------------------------------
+
+
+class TestEventTypes:
+    def test_event_types_have_stable_discriminator(self):
+        cases: list[tuple[type, str]] = [
+            (AssistantTurnStart, "assistant_turn_start"),
+            (TextDelta, "text_delta"),
+            (ThinkingDelta, "thinking_delta"),
+            (ToolUseStart, "tool_use_start"),
+            (ToolInputDelta, "tool_input_delta"),
+            (ToolUseStop, "tool_use_stop"),
+            (ToolResult, "tool_result"),
+            (MessageStop, "message_stop"),
+            (TurnComplete, "turn_complete"),
+        ]
+        for cls, expected in cases:
+            # All events carry their discriminator as a class default field.
+            assert getattr(cls, "__dataclass_fields__")["event_type"].default == expected
+
+    def test_event_types_are_frozen(self):
+        e = TextDelta(text="x")
+        with pytest.raises(Exception):  # noqa: B017 — frozen dataclass raises FrozenInstanceError
+            e.text = "y"  # type: ignore[misc]

--- a/tests/test_live_events.py
+++ b/tests/test_live_events.py
@@ -27,7 +27,6 @@ from prompture.agents.tools_schema import ToolRegistry
 from prompture.drivers.async_base import AsyncDriver
 from prompture.drivers.base import Driver
 
-
 # ---------------------------------------------------------------------------
 # Mock drivers
 # ---------------------------------------------------------------------------
@@ -432,7 +431,7 @@ class TestEventTypes:
         ]
         for cls, expected in cases:
             # All events carry their discriminator as a class default field.
-            assert getattr(cls, "__dataclass_fields__")["event_type"].default == expected
+            assert cls.__dataclass_fields__["event_type"].default == expected
 
     def test_event_types_are_frozen(self):
         e = TextDelta(text="x")
@@ -684,8 +683,7 @@ class _FakeStreamResponse:
         return None
 
     def iter_lines(self, decode_unicode: bool = True):
-        for line in self._lines:
-            yield line
+        yield from self._lines
 
 
 class _FakeRawHttpDriver:
@@ -727,20 +725,8 @@ class TestRawHttpHelper:
         from prompture.drivers import _openai_compat_stream
 
         sse_lines = [
-            _sse(
-                {
-                    "choices": [
-                        {"index": 0, "delta": {"content": "Looking up "}, "finish_reason": None}
-                    ]
-                }
-            ),
-            _sse(
-                {
-                    "choices": [
-                        {"index": 0, "delta": {"content": "Tokyo..."}, "finish_reason": None}
-                    ]
-                }
-            ),
+            _sse({"choices": [{"index": 0, "delta": {"content": "Looking up "}, "finish_reason": None}]}),
+            _sse({"choices": [{"index": 0, "delta": {"content": "Tokyo..."}, "finish_reason": None}]}),
             _sse(
                 {
                     "choices": [
@@ -765,11 +751,7 @@ class TestRawHttpHelper:
                     "choices": [
                         {
                             "index": 0,
-                            "delta": {
-                                "tool_calls": [
-                                    {"index": 0, "function": {"arguments": '{"cit'}}
-                                ]
-                            },
+                            "delta": {"tool_calls": [{"index": 0, "function": {"arguments": '{"cit'}}]},
                             "finish_reason": None,
                         }
                     ]
@@ -780,11 +762,7 @@ class TestRawHttpHelper:
                     "choices": [
                         {
                             "index": 0,
-                            "delta": {
-                                "tool_calls": [
-                                    {"index": 0, "function": {"arguments": 'y": "Tokyo"}'}}
-                                ]
-                            },
+                            "delta": {"tool_calls": [{"index": 0, "function": {"arguments": 'y": "Tokyo"}'}}]},
                             "finish_reason": "tool_calls",
                         }
                     ]

--- a/tests/test_live_events.py
+++ b/tests/test_live_events.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import AsyncIterator, Iterator
 from typing import Any
 
 import pytest
 
 from prompture.agents.agent import Agent
+from prompture.agents.async_agent import AsyncAgent
+from prompture.agents.async_conversation import AsyncConversation
 from prompture.agents.conversation import Conversation
 from prompture.agents.live_events import (
     AssistantTurnStart,
@@ -22,6 +24,7 @@ from prompture.agents.live_events import (
     TurnComplete,
 )
 from prompture.agents.tools_schema import ToolRegistry
+from prompture.drivers.async_base import AsyncDriver
 from prompture.drivers.base import Driver
 
 
@@ -435,3 +438,226 @@ class TestEventTypes:
         e = TextDelta(text="x")
         with pytest.raises(Exception):  # noqa: B017 — frozen dataclass raises FrozenInstanceError
             e.text = "y"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Async mocks
+# ---------------------------------------------------------------------------
+
+
+class AsyncBufferedToolDriver(AsyncDriver):
+    """Async driver implementing only the buffered tool method, exercising
+    the AsyncDriver base-class default that wraps it into synthetic events."""
+
+    supports_messages = True
+    supports_tool_use = True
+    supports_streaming = False
+    supports_streaming_tool_use = False
+
+    def __init__(self, responses: list[dict[str, Any]]):
+        self._responses = list(responses)
+        self._idx = 0
+        self.model = "mock-async-buffered"
+
+    async def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        return self._next()
+
+    async def generate_messages(self, messages: list[dict[str, Any]], options: dict[str, Any]) -> dict[str, Any]:
+        return self._next()
+
+    async def generate_messages_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> dict[str, Any]:
+        return self._next()
+
+    def _next(self) -> dict[str, Any]:
+        r = self._responses[min(self._idx, len(self._responses) - 1)]
+        self._idx += 1
+        return r
+
+
+class AsyncNativeStreamingDriver(AsyncDriver):
+    """Async driver that natively emits a fixed LiveEvent sequence per turn."""
+
+    supports_messages = True
+    supports_tool_use = True
+    supports_streaming = True
+    supports_streaming_tool_use = True
+
+    def __init__(self, turn_event_sequences: list[list[LiveEvent]]):
+        self._turns = list(turn_event_sequences)
+        self._idx = 0
+        self.model = "mock-async-native"
+
+    async def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        return {"text": "n/a", "meta": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "cost": 0.0}}
+
+    async def generate_messages(self, messages: list[dict[str, Any]], options: dict[str, Any]) -> dict[str, Any]:
+        return await self.generate("", options)
+
+    async def generate_messages_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> dict[str, Any]:
+        raise AssertionError("ask_live should use generate_messages_with_tools_stream, not the buffered method")
+
+    async def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> AsyncIterator[LiveEvent]:
+        events = self._turns[min(self._idx, len(self._turns) - 1)]
+        self._idx += 1
+        for ev in events:
+            yield ev
+
+
+# ---------------------------------------------------------------------------
+# Async ask_live tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncAskLive:
+    @pytest.mark.asyncio
+    async def test_async_buffered_fallback_yields_event_sequence(self):
+        driver = AsyncBufferedToolDriver(
+            [
+                {
+                    "text": "Looking up Tokyo.",
+                    "tool_calls": [{"id": "call_1", "name": "lookup_population", "arguments": {"city": "Tokyo"}}],
+                    "meta": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15, "cost": 0.001},
+                    "stop_reason": "tool_use",
+                },
+                {
+                    "text": "Tokyo has 13,960,000 people.",
+                    "tool_calls": [],
+                    "meta": {"prompt_tokens": 20, "completion_tokens": 8, "total_tokens": 28, "cost": 0.002},
+                    "stop_reason": "end_turn",
+                },
+            ]
+        )
+        reg = ToolRegistry()
+        reg.register(lookup_population)
+        conv = AsyncConversation(driver=driver, tools=reg)
+
+        events = [ev async for ev in conv.ask_live("Tokyo?")]
+        kinds = [e.event_type for e in events]
+        assert kinds.count("assistant_turn_start") == 2
+        assert kinds.count("tool_use_start") == 1
+        assert kinds.count("tool_use_stop") == 1
+        assert kinds.count("tool_result") == 1
+        assert kinds[-1] == "turn_complete"
+        tool_result = next(e for e in events if isinstance(e, ToolResult))
+        assert "13960000" in tool_result.output
+
+    @pytest.mark.asyncio
+    async def test_async_native_interleaved_streaming(self):
+        turn1 = [
+            AssistantTurnStart(turn_index=0),
+            TextDelta(text="Looking up "),
+            TextDelta(text="Tokyo..."),
+            ToolUseStart(id="t1", name="lookup_population"),
+            ToolInputDelta(id="t1", fragment='{"city"'),
+            ToolInputDelta(id="t1", fragment=': "Tokyo"}'),
+            ToolUseStop(id="t1", name="lookup_population", input={"city": "Tokyo"}),
+            TextDelta(text=" Now Paris..."),
+            ToolUseStart(id="t2", name="lookup_population"),
+            ToolUseStop(id="t2", name="lookup_population", input={"city": "Paris"}),
+            MessageStop(
+                stop_reason="tool_use",
+                usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15, "cost": 0.001},
+            ),
+        ]
+        turn2 = [
+            AssistantTurnStart(turn_index=1),
+            TextDelta(text="Tokyo has more people than Paris."),
+            MessageStop(
+                stop_reason="end_turn",
+                usage={"prompt_tokens": 20, "completion_tokens": 8, "total_tokens": 28, "cost": 0.002},
+            ),
+        ]
+        driver = AsyncNativeStreamingDriver([turn1, turn2])
+        reg = ToolRegistry()
+        reg.register(lookup_population)
+        conv = AsyncConversation(driver=driver, tools=reg)
+
+        events = [ev async for ev in conv.ask_live("Compare Tokyo and Paris.")]
+        kinds = [e.event_type for e in events]
+        assert kinds.count("tool_use_stop") == 2
+        assert kinds.count("tool_result") == 2
+        assert kinds[-1] == "turn_complete"
+
+        tool_results = [e for e in events if isinstance(e, ToolResult)]
+        outputs = [r.output for r in tool_results]
+        assert "13960000" in outputs[0]
+        assert "2161000" in outputs[1]
+
+
+# ---------------------------------------------------------------------------
+# AsyncAgent.run_live tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncAgentRunLive:
+    @pytest.mark.asyncio
+    async def test_async_run_live_yields_events_and_returns_result(self):
+        turn1 = [
+            AssistantTurnStart(turn_index=0),
+            TextDelta(text="Checking."),
+            ToolUseStart(id="a", name="lookup_population"),
+            ToolUseStop(id="a", name="lookup_population", input={"city": "Tokyo"}),
+            MessageStop(stop_reason="tool_use", usage={"total_tokens": 5, "cost": 0.001}),
+        ]
+        turn2 = [
+            AssistantTurnStart(turn_index=1),
+            TextDelta(text="Tokyo: 13,960,000."),
+            MessageStop(stop_reason="end_turn", usage={"total_tokens": 6, "cost": 0.001}),
+        ]
+        driver = AsyncNativeStreamingDriver([turn1, turn2])
+        agent = AsyncAgent("mock/mock", driver=driver, tools=[lookup_population])
+
+        streamed = agent.run_live("Tokyo?")
+        collected: list[Any] = []
+        async for ev in streamed:
+            collected.append(ev)
+
+        kinds = [e.event_type for e in collected]
+        assert kinds.count("text_delta") >= 2
+        assert kinds.count("tool_use_stop") == 1
+        assert kinds.count("tool_result") == 1
+        assert kinds[-1] == "turn_complete"
+
+        result = streamed.result
+        assert result is not None
+        assert "Tokyo" in result.output_text
+
+    @pytest.mark.asyncio
+    async def test_async_run_live_without_tools(self):
+        class _AsyncTextStream(AsyncDriver):
+            supports_messages = True
+            supports_streaming = True
+            model = "mock-text-async"
+
+            async def generate(self, prompt, options):
+                return {"text": "ok", "meta": {"total_tokens": 1, "cost": 0.0}}
+
+            async def generate_messages(self, messages, options):
+                return await self.generate("", options)
+
+            async def generate_messages_stream(self, messages, options):
+                for piece in ("hel", "lo"):
+                    yield {"type": "delta", "text": piece}
+                yield {"type": "done", "text": "hello", "meta": {"total_tokens": 2, "cost": 0.0}}
+
+        agent = AsyncAgent("mock/mock", driver=_AsyncTextStream())
+        events: list[Any] = []
+        async for ev in agent.run_live("hi"):
+            events.append(ev)
+        text = "".join(e.text for e in events if isinstance(e, TextDelta))
+        assert text == "hello"

--- a/tests/test_live_events.py
+++ b/tests/test_live_events.py
@@ -661,3 +661,211 @@ class TestAsyncAgentRunLive:
             events.append(ev)
         text = "".join(e.text for e in events if isinstance(e, TextDelta))
         assert text == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Raw-HTTP SSE helper tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeStreamResponse:
+    """Minimal stand-in for the requests streaming response object."""
+
+    def __init__(self, lines: list[str]):
+        self._lines = lines
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def raise_for_status(self):
+        return None
+
+    def iter_lines(self, decode_unicode: bool = True):
+        for line in self._lines:
+            yield line
+
+
+class _FakeRawHttpDriver:
+    """Driver stub satisfying the raw-HTTP helper's contract.
+
+    Exposes ``api_base``, ``api_key``, ``model``, ``_get_model_config``, and
+    ``_calculate_cost`` — no real network or SDK involved.
+    """
+
+    api_base = "https://example.invalid/v1"
+    api_key = "test-key"
+    model = "test-model"
+
+    def _get_model_config(self, provider: str, model: str) -> dict[str, Any]:
+        return {"tokens_param": "max_tokens", "supports_temperature": True}
+
+    def _calculate_cost(
+        self,
+        provider: str,
+        model: str,
+        prompt_tokens: int,
+        completion_tokens: int,
+        cached_tokens: int = 0,
+    ) -> float:
+        return 0.0001 * prompt_tokens + 0.0005 * completion_tokens
+
+
+def _sse(payload: dict[str, Any]) -> str:
+    import json as _json
+
+    return "data: " + _json.dumps(payload)
+
+
+class TestRawHttpHelper:
+    def test_raw_http_stream_yields_interleaved_events(self, monkeypatch):
+        """Helper should parse SSE deltas the same way as the SDK helper:
+        text deltas before tool_calls, JSON fragments accumulated, ToolUseStop
+        emitted with the parsed input, MessageStop with cost at the end."""
+        from prompture.drivers import _openai_compat_stream
+
+        sse_lines = [
+            _sse(
+                {
+                    "choices": [
+                        {"index": 0, "delta": {"content": "Looking up "}, "finish_reason": None}
+                    ]
+                }
+            ),
+            _sse(
+                {
+                    "choices": [
+                        {"index": 0, "delta": {"content": "Tokyo..."}, "finish_reason": None}
+                    ]
+                }
+            ),
+            _sse(
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "call_a",
+                                        "function": {"name": "lookup_population", "arguments": ""},
+                                    }
+                                ]
+                            },
+                            "finish_reason": None,
+                        }
+                    ]
+                }
+            ),
+            _sse(
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {"index": 0, "function": {"arguments": '{"cit'}}
+                                ]
+                            },
+                            "finish_reason": None,
+                        }
+                    ]
+                }
+            ),
+            _sse(
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {"index": 0, "function": {"arguments": 'y": "Tokyo"}'}}
+                                ]
+                            },
+                            "finish_reason": "tool_calls",
+                        }
+                    ]
+                }
+            ),
+            _sse(
+                {
+                    "choices": [],
+                    "usage": {
+                        "prompt_tokens": 12,
+                        "completion_tokens": 9,
+                        "prompt_tokens_details": {"cached_tokens": 0},
+                    },
+                }
+            ),
+            "data: [DONE]",
+        ]
+
+        def fake_post(url, headers, json, stream, timeout):
+            return _FakeStreamResponse(sse_lines)
+
+        monkeypatch.setattr("requests.post", fake_post)
+
+        driver = _FakeRawHttpDriver()
+        events = list(
+            _openai_compat_stream.stream_raw_http_compat_tool_call(
+                driver,
+                messages=[{"role": "user", "content": "Tokyo?"}],
+                tools=[{"type": "function", "function": {"name": "lookup_population"}}],
+                options={},
+                provider="grok",
+            )
+        )
+        kinds = [e.event_type for e in events]
+        assert kinds.count("text_delta") == 2
+        assert kinds.count("tool_use_start") == 1
+        assert kinds.count("tool_input_delta") == 2
+        assert kinds.count("tool_use_stop") == 1
+        assert kinds[-1] == "message_stop"
+
+        tool_stop = next(e for e in events if e.event_type == "tool_use_stop")
+        assert tool_stop.id == "call_a"
+        assert tool_stop.name == "lookup_population"
+        assert tool_stop.input == {"city": "Tokyo"}
+
+        message_stop = events[-1]
+        assert message_stop.stop_reason == "tool_calls"
+        assert message_stop.usage["prompt_tokens"] == 12
+        assert message_stop.usage["completion_tokens"] == 9
+        # Cost = 0.0001 * 12 + 0.0005 * 9 = 0.0012 + 0.0045 = 0.0057
+        assert message_stop.usage["cost"] == pytest.approx(0.0057, abs=1e-6)
+
+    def test_raw_http_stream_handles_done_and_blank_lines(self, monkeypatch):
+        from prompture.drivers import _openai_compat_stream
+
+        sse_lines = [
+            "",  # blank
+            "event: ping",  # non-data line
+            _sse({"choices": [{"index": 0, "delta": {"content": "hi"}, "finish_reason": None}]}),
+            "",
+            _sse({"choices": [], "usage": {"prompt_tokens": 1, "completion_tokens": 1}}),
+            "data: [DONE]",
+            # Anything after [DONE] must not be processed.
+            _sse({"choices": [{"index": 0, "delta": {"content": "GHOST"}}]}),
+        ]
+
+        def fake_post(url, headers, json, stream, timeout):
+            return _FakeStreamResponse(sse_lines)
+
+        monkeypatch.setattr("requests.post", fake_post)
+
+        driver = _FakeRawHttpDriver()
+        events = list(
+            _openai_compat_stream.stream_raw_http_compat_tool_call(
+                driver,
+                messages=[],
+                tools=[],
+                options={},
+                provider="grok",
+            )
+        )
+        text = "".join(e.text for e in events if e.event_type == "text_delta")
+        assert text == "hi"
+        assert "GHOST" not in text

--- a/tests/test_phase2_rerank_and_ollama_schema.py
+++ b/tests/test_phase2_rerank_and_ollama_schema.py
@@ -1,0 +1,287 @@
+"""Phase 2: RAGPipeline reranker string resolution + Ollama JSON schema wire format.
+
+Two independent feature areas covered:
+
+1. ``RAGPipeline(reranker="provider/model")`` resolves the string via
+   :func:`prompture.drivers.rerank_registry.get_rerank_driver_for_model`.
+2. ``OllamaDriver`` / ``AsyncOllamaDriver`` pass ``json_schema`` directly to
+   Ollama's ``format`` parameter, supporting native constrained decoding
+   without falling back to prompted repair.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# 1. Reranker string resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveReranker:
+    def _import(self):
+        from prompture.rag.pipeline import _resolve_reranker
+
+        return _resolve_reranker
+
+    def test_none_passes_through(self) -> None:
+        assert self._import()(None, prefer_async=False) is None
+
+    def test_already_instantiated_driver_passes_through(self) -> None:
+        fake_driver = object()
+        out = self._import()(fake_driver, prefer_async=False)
+        assert out is fake_driver
+
+    def test_malformed_string_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="provider/model"):
+            self._import()("cohere", prefer_async=False)
+
+    def test_provider_model_string_calls_sync_registry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Stub the sync registry. Verifies we go through it, not directly to a provider SDK.
+        from prompture.drivers import rerank_registry
+
+        sentinel = MagicMock(name="sync_driver")
+        monkeypatch.setattr(
+            rerank_registry,
+            "get_rerank_driver_for_model",
+            lambda s: sentinel if s == "cohere/rerank-v3.5" else None,
+        )
+        out = self._import()("cohere/rerank-v3.5", prefer_async=False)
+        assert out is sentinel
+
+    def test_prefer_async_tries_async_then_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Async registry raises -> sync registry must be used.
+        from prompture.drivers import rerank_registry
+
+        sync_sentinel = MagicMock(name="sync_driver")
+        monkeypatch.setattr(
+            rerank_registry,
+            "get_async_rerank_driver_for_model",
+            MagicMock(side_effect=RuntimeError("no async driver")),
+        )
+        monkeypatch.setattr(
+            rerank_registry,
+            "get_rerank_driver_for_model",
+            lambda s: sync_sentinel,
+        )
+        out = self._import()("voyage/rerank-2.5", prefer_async=True)
+        assert out is sync_sentinel
+
+    def test_prefer_async_uses_async_when_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from prompture.drivers import rerank_registry
+
+        async_sentinel = MagicMock(name="async_driver")
+        sync_sentinel = MagicMock(name="sync_driver")
+        monkeypatch.setattr(
+            rerank_registry,
+            "get_async_rerank_driver_for_model",
+            lambda s: async_sentinel,
+        )
+        monkeypatch.setattr(
+            rerank_registry,
+            "get_rerank_driver_for_model",
+            lambda s: sync_sentinel,
+        )
+        out = self._import()("cohere/rerank-v3.5", prefer_async=True)
+        assert out is async_sentinel
+
+
+class TestRAGPipelineRerankerWiring:
+    def test_pipeline_resolves_string_in_constructor(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from prompture.drivers import rerank_registry
+        from prompture.rag import RAGPipeline
+
+        fake = MagicMock(name="resolved_reranker")
+        monkeypatch.setattr(
+            rerank_registry,
+            "get_rerank_driver_for_model",
+            lambda s: fake,
+        )
+        # Minimal stub retriever / llm.
+        retriever = MagicMock(name="retriever")
+        retriever.retrieve = MagicMock(return_value=[])
+        llm = MagicMock(name="llm", model="fake/model", model_name="fake/model")
+
+        pipeline = RAGPipeline(retriever=retriever, llm=llm, reranker="cohere/rerank-v3.5")
+        assert pipeline.reranker is fake
+
+    def test_pipeline_rejects_bad_string(self) -> None:
+        from prompture.rag import RAGPipeline
+
+        retriever = MagicMock(name="retriever")
+        llm = MagicMock(name="llm")
+        with pytest.raises(ValueError, match="provider/model"):
+            RAGPipeline(retriever=retriever, llm=llm, reranker="cohere")  # missing /model
+
+    def test_async_pipeline_resolves_string_too(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from prompture.drivers import rerank_registry
+        from prompture.rag import AsyncRAGPipeline
+
+        async_fake = MagicMock(name="async_reranker")
+        monkeypatch.setattr(
+            rerank_registry,
+            "get_async_rerank_driver_for_model",
+            lambda s: async_fake,
+        )
+        retriever = MagicMock(name="retriever")
+        llm = MagicMock(name="llm")
+        pipeline = AsyncRAGPipeline(retriever=retriever, llm=llm, reranker="cohere/rerank-v3.5")
+        assert pipeline.reranker is async_fake
+
+
+# ---------------------------------------------------------------------------
+# 2. Ollama native JSON schema wire format
+# ---------------------------------------------------------------------------
+
+
+class _StubResponse:
+    """Stand-in for requests.Response from Ollama."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+def _ollama_chat_response() -> dict[str, Any]:
+    return {
+        "message": {"role": "assistant", "content": '{"x":1}'},
+        "prompt_eval_count": 10,
+        "eval_count": 5,
+        "done": True,
+        "done_reason": "stop",
+    }
+
+
+@pytest.fixture
+def ollama_driver_with_capture(monkeypatch: pytest.MonkeyPatch):
+    """Yield (driver, captured_payloads_list)."""
+    from prompture.drivers import ollama_driver as od
+
+    # Skip the health check probe.
+    monkeypatch.setattr(od.OllamaDriver, "_validate_connection", lambda self: None)
+
+    captured: list[dict[str, Any]] = []
+
+    def _stub_post(url: str, *, json: dict[str, Any], **kw: Any) -> _StubResponse:
+        captured.append({"url": url, "payload": json})
+        return _StubResponse(_ollama_chat_response())
+
+    monkeypatch.setattr(od.requests, "post", _stub_post)
+
+    driver = od.OllamaDriver(endpoint="http://localhost:11434/api/generate", model="llama3.1:8b")
+    return driver, captured
+
+
+class TestOllamaJsonSchema:
+    SCHEMA = {
+        "type": "object",
+        "properties": {"x": {"type": "integer"}},
+        "required": ["x"],
+    }
+
+    def test_capability_flag_set(self) -> None:
+        from prompture.drivers.ollama_driver import OllamaDriver
+
+        assert OllamaDriver.supports_json_schema is True
+        assert OllamaDriver.supports_json_mode is True
+
+    def test_json_schema_passes_into_format(self, ollama_driver_with_capture) -> None:
+        driver, captured = ollama_driver_with_capture
+        driver.generate_messages(
+            [{"role": "user", "content": "give me x"}],
+            options={"json_mode": True, "json_schema": self.SCHEMA},
+        )
+        assert len(captured) == 1
+        payload = captured[0]["payload"]
+        assert payload["format"] == self.SCHEMA, (
+            f"Expected the JSON schema to be sent verbatim as `format`; got {payload.get('format')!r}"
+        )
+
+    def test_schema_alone_implies_json_mode(self, ollama_driver_with_capture) -> None:
+        # New behaviour: passing json_schema without an explicit json_mode flag
+        # should still enable structured output (schema implies JSON mode).
+        driver, captured = ollama_driver_with_capture
+        driver.generate_messages(
+            [{"role": "user", "content": "give me x"}],
+            options={"json_schema": self.SCHEMA},
+        )
+        payload = captured[0]["payload"]
+        assert payload["format"] == self.SCHEMA
+
+    def test_json_mode_without_schema_uses_loose_grammar(self, ollama_driver_with_capture) -> None:
+        # Backwards-compat: json_mode=True with no schema -> "json" sentinel.
+        driver, captured = ollama_driver_with_capture
+        driver.generate_messages(
+            [{"role": "user", "content": "anything"}],
+            options={"json_mode": True},
+        )
+        payload = captured[0]["payload"]
+        assert payload["format"] == "json"
+
+    def test_no_json_mode_omits_format(self, ollama_driver_with_capture) -> None:
+        driver, captured = ollama_driver_with_capture
+        driver.generate_messages(
+            [{"role": "user", "content": "anything"}],
+            options={},
+        )
+        payload = captured[0]["payload"]
+        assert "format" not in payload
+
+    def test_uses_chat_endpoint_not_generate(self, ollama_driver_with_capture) -> None:
+        driver, captured = ollama_driver_with_capture
+        driver.generate_messages(
+            [{"role": "user", "content": "x"}],
+            options={"json_schema": self.SCHEMA},
+        )
+        assert captured[0]["url"].endswith("/api/chat")
+
+
+class TestAsyncOllamaJsonSchema:
+    SCHEMA = {"type": "object", "properties": {"x": {"type": "integer"}}}
+
+    @pytest.mark.asyncio
+    async def test_async_driver_passes_schema_through_format(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from prompture.drivers import async_ollama_driver as aod
+
+        captured: list[dict[str, Any]] = []
+
+        class _StubResp:
+            def raise_for_status(self) -> None:
+                pass
+
+            def json(self) -> dict[str, Any]:
+                return _ollama_chat_response()
+
+        class _StubAsyncClient:
+            def __init__(self, *a: Any, **kw: Any) -> None:
+                pass
+
+            async def __aenter__(self) -> _StubAsyncClient:
+                return self
+
+            async def __aexit__(self, *a: Any) -> None:
+                return None
+
+            async def post(self, url: str, *, json: dict[str, Any], **kw: Any) -> _StubResp:
+                captured.append({"url": url, "payload": json})
+                return _StubResp()
+
+        monkeypatch.setattr(aod.httpx, "AsyncClient", _StubAsyncClient)
+
+        driver = aod.AsyncOllamaDriver(endpoint="http://localhost:11434/api/generate", model="llama3.1:8b")
+        await driver.generate_messages(
+            [{"role": "user", "content": "x"}],
+            options={"json_schema": self.SCHEMA},
+        )
+        assert captured[0]["payload"]["format"] == self.SCHEMA

--- a/tests/test_phase3_query_side_retrievers.py
+++ b/tests/test_phase3_query_side_retrievers.py
@@ -1,0 +1,385 @@
+"""Phase 3: HyDE, MultiQuery, StepBack retrievers + the shared fusion helper.
+
+Every test stubs both the LLM and the base retriever so the suite never
+hits any provider. The point is to verify that:
+
+* The query the LLM sees matches our documented prompt contract.
+* The query (or queries) the base retriever sees matches what the
+  technique requires.
+* Results are RRF-fused (Multi-Query / Step-Back) or passed through
+  (HyDE).
+* Failure modes degrade gracefully — a broken LLM never makes the
+  retriever worse than the baseline.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from prompture.rag.documents import Document
+from prompture.rag.retrievers._fusion import _document_id, fuse_search_results
+from prompture.rag.retrievers.base import Retriever
+from prompture.rag.retrievers.hyde import HyDERetriever
+from prompture.rag.retrievers.multi_query import MultiQueryRetriever, _parse_alternatives
+from prompture.rag.retrievers.step_back import StepBackRetriever
+from prompture.rag.vectorstores.base import VectorSearchResult
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedLLM:
+    """LLM stub that returns canned responses in order. Records every prompt."""
+
+    def __init__(self, texts: list[str]) -> None:
+        self._texts = list(texts)
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append((prompt, options))
+        text = self._texts.pop(0) if self._texts else ""
+        return {"text": text, "meta": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "cost": 0.0}}
+
+
+class _RaisingLLM:
+    def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("boom")
+
+
+class _RecordingRetriever(Retriever):
+    """Base retriever stub that records every query and returns canned hits.
+
+    ``answers`` maps query strings (substring match) to result lists. A
+    catch-all default list is returned for unrecognised queries.
+    """
+
+    def __init__(
+        self,
+        answers: dict[str, list[VectorSearchResult]] | None = None,
+        default: list[VectorSearchResult] | None = None,
+    ) -> None:
+        self.answers = answers or {}
+        self.default = default or []
+        self.calls: list[tuple[str, int]] = []
+
+    def retrieve(
+        self,
+        query: str,
+        k: int = 4,
+        filter: dict | None = None,
+        **options: Any,
+    ) -> list[VectorSearchResult]:
+        self.calls.append((query, k))
+        for key, results in self.answers.items():
+            if key.casefold() in query.casefold():
+                return results[:k]
+        return self.default[:k]
+
+
+def _result(content: str, score: float, doc_id: str | None = None) -> VectorSearchResult:
+    md: dict[str, Any] = {}
+    if doc_id is not None:
+        md["id"] = doc_id
+    return VectorSearchResult(document=Document(content=content, metadata=md), score=score)
+
+
+# ---------------------------------------------------------------------------
+# Fusion helper
+# ---------------------------------------------------------------------------
+
+
+class TestFusionHelper:
+    def test_document_id_uses_metadata_id_when_present(self) -> None:
+        r = _result("foo", 0.9, doc_id="explicit-1")
+        assert _document_id(r) == "explicit-1"
+
+    def test_document_id_falls_back_to_content_hash(self) -> None:
+        r = _result("foo", 0.9)
+        rid = _document_id(r)
+        assert rid.startswith("sha1:")
+        # Same content -> same id, deterministic across calls.
+        assert _document_id(_result("foo", 0.1)) == rid
+
+    def test_fuse_returns_empty_for_no_inputs(self) -> None:
+        assert fuse_search_results([], top_n=4) == []
+        assert fuse_search_results([[], []], top_n=4) == []
+
+    def test_fuse_keeps_best_score_per_doc(self) -> None:
+        a = _result("doc-a", 0.3, doc_id="a")
+        a_hi = _result("doc-a", 0.9, doc_id="a")
+        out = fuse_search_results([[a], [a_hi]], top_n=2)
+        assert len(out) == 1
+        # The single surviving result carries the *better* upstream score.
+        assert out[0].score == 0.9
+
+    def test_fuse_ranks_by_rrf(self) -> None:
+        # doc-a appears first in both lists -> higher fused score than doc-b
+        # which is rank 1 only in the second list.
+        a = _result("doc-a", 0.5, doc_id="a")
+        b = _result("doc-b", 0.5, doc_id="b")
+        out = fuse_search_results([[a, b], [a, b]], top_n=2)
+        assert [r.document.metadata["id"] for r in out] == ["a", "b"]
+
+    def test_fuse_top_n_caps_output(self) -> None:
+        rs = [_result(f"d{i}", 1.0 - i * 0.1, doc_id=str(i)) for i in range(5)]
+        out = fuse_search_results([rs], top_n=2)
+        assert len(out) == 2
+
+
+# ---------------------------------------------------------------------------
+# HyDE
+# ---------------------------------------------------------------------------
+
+
+class TestHyDERetriever:
+    def test_query_swap_passes_hypothetical_to_base(self) -> None:
+        llm = _ScriptedLLM(["Paris is the capital of France."])
+        base = _RecordingRetriever(default=[_result("doc1", 1.0)])
+        ret = HyDERetriever(base=base, llm=llm)
+
+        ret.retrieve("What is the capital of France?", k=2)
+
+        # LLM saw the rendered template, base retriever saw the hypothetical answer.
+        assert "What is the capital of France?" in llm.calls[0][0]
+        assert base.calls == [("Paris is the capital of France.", 2)]
+
+    def test_empty_llm_response_falls_back_to_original_query(self) -> None:
+        llm = _ScriptedLLM([""])
+        base = _RecordingRetriever(default=[_result("doc1", 1.0)])
+        ret = HyDERetriever(base=base, llm=llm)
+
+        ret.retrieve("Original?", k=3)
+        assert base.calls == [("Original?", 3)]
+
+    def test_llm_failure_falls_back_to_original_query(self) -> None:
+        base = _RecordingRetriever(default=[_result("doc1", 1.0)])
+        ret = HyDERetriever(base=base, llm=_RaisingLLM())
+        out = ret.retrieve("Original?", k=2)
+        assert base.calls == [("Original?", 2)]
+        assert len(out) == 1
+
+    def test_long_response_is_truncated(self) -> None:
+        # Hypothetical is far over the 2000-char cap.
+        big = "x" * 5000
+        llm = _ScriptedLLM([big])
+        base = _RecordingRetriever(default=[_result("doc1", 1.0)])
+        ret = HyDERetriever(base=base, llm=llm, max_hypothetical_chars=200)
+        ret.retrieve("q", k=1)
+        sent_query, _ = base.calls[0]
+        assert len(sent_query) == 200
+
+    def test_prompt_must_include_query_placeholder(self) -> None:
+        with pytest.raises(ValueError, match="\\{query\\}"):
+            HyDERetriever(base=_RecordingRetriever(), llm=_ScriptedLLM([]), prompt="no placeholder here")
+
+    def test_filter_and_options_forwarded_to_base(self) -> None:
+        llm = _ScriptedLLM(["hypo"])
+        base = _RecordingRetriever(default=[])
+
+        captured: dict[str, Any] = {}
+
+        def _patched(query: str, k: int = 4, filter: dict | None = None, **opts: Any) -> list[VectorSearchResult]:
+            captured["query"] = query
+            captured["filter"] = filter
+            captured["opts"] = opts
+            return []
+
+        base.retrieve = _patched  # type: ignore[method-assign]
+        ret = HyDERetriever(base=base, llm=llm)
+        ret.retrieve("q", k=3, filter={"category": "history"}, foo="bar")
+        assert captured["filter"] == {"category": "history"}
+        assert captured["opts"] == {"foo": "bar"}
+
+
+# ---------------------------------------------------------------------------
+# MultiQuery
+# ---------------------------------------------------------------------------
+
+
+class TestParseAlternatives:
+    def test_plain_lines(self) -> None:
+        raw = "Foo bar?\nBaz qux?\nQuux quuux?\n"
+        assert _parse_alternatives(raw, max_count=5) == ["Foo bar?", "Baz qux?", "Quux quuux?"]
+
+    def test_numbered_lines(self) -> None:
+        raw = "1. Foo?\n2) Bar?\n- Baz?\n* Qux?"
+        assert _parse_alternatives(raw, max_count=5) == ["Foo?", "Bar?", "Baz?", "Qux?"]
+
+    def test_dedupes_case_insensitive(self) -> None:
+        raw = "Foo?\nFOO?\nfoo?\nBar?"
+        assert _parse_alternatives(raw, max_count=5) == ["Foo?", "Bar?"]
+
+    def test_caps_at_max_count(self) -> None:
+        raw = "\n".join(f"Q{i}?" for i in range(10))
+        assert len(_parse_alternatives(raw, max_count=3)) == 3
+
+    def test_strips_quotes(self) -> None:
+        raw = '"Foo?"\n\'Bar?\''
+        assert _parse_alternatives(raw, max_count=5) == ["Foo?", "Bar?"]
+
+
+class TestMultiQueryRetriever:
+    def test_runs_base_per_variant_including_original(self) -> None:
+        llm = _ScriptedLLM(["Alt one?\nAlt two?\nAlt three?"])
+        base = _RecordingRetriever(default=[_result("doc1", 1.0)])
+        ret = MultiQueryRetriever(base=base, llm=llm, n_queries=3)
+
+        ret.retrieve("Original?", k=2)
+
+        # 1 original + 3 alternatives = 4 base calls.
+        queries = [c[0] for c in base.calls]
+        assert queries == ["Original?", "Alt one?", "Alt two?", "Alt three?"]
+
+    def test_skips_original_when_disabled(self) -> None:
+        llm = _ScriptedLLM(["Alt one?\nAlt two?"])
+        base = _RecordingRetriever(default=[_result("doc1", 1.0)])
+        ret = MultiQueryRetriever(base=base, llm=llm, n_queries=2, include_original=False)
+
+        ret.retrieve("Original?", k=2)
+        queries = [c[0] for c in base.calls]
+        assert "Original?" not in queries
+        assert queries == ["Alt one?", "Alt two?"]
+
+    def test_drops_alternative_equal_to_original(self) -> None:
+        llm = _ScriptedLLM(["Original?\nAlt two?"])  # first alt is a dupe of input
+        base = _RecordingRetriever(default=[_result("doc1", 1.0)])
+        ret = MultiQueryRetriever(base=base, llm=llm, n_queries=2)
+
+        ret.retrieve("Original?", k=2)
+        queries = [c[0] for c in base.calls]
+        # Original + the one non-dupe alternative.
+        assert queries == ["Original?", "Alt two?"]
+
+    def test_llm_failure_still_runs_original(self) -> None:
+        base = _RecordingRetriever(default=[_result("doc1", 1.0)])
+        ret = MultiQueryRetriever(base=base, llm=_RaisingLLM(), n_queries=3)
+
+        out = ret.retrieve("Original?", k=2)
+        # Falls back to just the original query.
+        assert base.calls == [("Original?", 2)]
+        assert len(out) == 1
+
+    def test_fuses_results_across_variants(self) -> None:
+        # Two variants produce overlapping ranked lists; RRF should rank
+        # the doc seen by both higher than docs seen by only one.
+        shared = _result("shared", 0.5, doc_id="shared")
+        unique_a = _result("unique-a", 0.5, doc_id="ua")
+        unique_b = _result("unique-b", 0.5, doc_id="ub")
+
+        answers = {
+            "Original?": [shared, unique_a],
+            "Alt?": [shared, unique_b],
+        }
+        base = _RecordingRetriever(answers=answers)
+        llm = _ScriptedLLM(["Alt?"])  # one reformulation
+        ret = MultiQueryRetriever(base=base, llm=llm, n_queries=1)
+
+        out = ret.retrieve("Original?", k=3)
+        ids = [r.document.metadata.get("id") or r.document.content for r in out]
+        # Shared doc fuses to the top.
+        assert ids[0] == "shared"
+        # And both unique docs are kept (order between them is implementation-defined).
+        assert set(ids[1:]) == {"ua", "ub"}
+
+    def test_prompt_must_include_query_and_n_placeholders(self) -> None:
+        with pytest.raises(ValueError, match="\\{query\\}"):
+            MultiQueryRetriever(
+                base=_RecordingRetriever(), llm=_ScriptedLLM([]), prompt="no placeholders"
+            )
+
+    def test_invalid_n_queries_raises(self) -> None:
+        with pytest.raises(ValueError, match="n_queries"):
+            MultiQueryRetriever(base=_RecordingRetriever(), llm=_ScriptedLLM([]), n_queries=0)
+
+
+# ---------------------------------------------------------------------------
+# StepBack
+# ---------------------------------------------------------------------------
+
+
+class TestStepBackRetriever:
+    def test_runs_original_and_broader(self) -> None:
+        llm = _ScriptedLLM(["What are the major European capitals?"])
+        base = _RecordingRetriever(default=[_result("doc1", 1.0)])
+        ret = StepBackRetriever(base=base, llm=llm)
+
+        ret.retrieve("What is the capital of France?", k=2)
+
+        queries = [c[0] for c in base.calls]
+        assert queries == [
+            "What is the capital of France?",
+            "What are the major European capitals?",
+        ]
+
+    def test_llm_failure_still_returns_original_results(self) -> None:
+        base = _RecordingRetriever(default=[_result("doc1", 1.0)])
+        ret = StepBackRetriever(base=base, llm=_RaisingLLM())
+
+        out = ret.retrieve("Q?", k=2)
+        assert base.calls == [("Q?", 2)]
+        assert len(out) == 1
+
+    def test_broader_identical_to_original_is_skipped(self) -> None:
+        llm = _ScriptedLLM(["Q?"])  # broader == original
+        base = _RecordingRetriever(default=[_result("doc1", 1.0)])
+        ret = StepBackRetriever(base=base, llm=llm)
+
+        ret.retrieve("Q?", k=2)
+        assert base.calls == [("Q?", 2)]
+
+    def test_strips_leading_label_and_quotes(self) -> None:
+        llm = _ScriptedLLM(['"What are European capitals?"'])
+        base = _RecordingRetriever(default=[_result("doc1", 1.0)])
+        ret = StepBackRetriever(base=base, llm=llm)
+
+        ret.retrieve("Capital of France?", k=1)
+        # Quotes stripped; first non-empty line used.
+        assert base.calls[1][0] == "What are European capitals?"
+
+    def test_fuses_two_ranked_lists(self) -> None:
+        shared = _result("shared", 0.5, doc_id="shared")
+        narrow = _result("narrow", 0.5, doc_id="narrow")
+        broad = _result("broad", 0.5, doc_id="broad")
+
+        answers = {
+            "Narrow?": [shared, narrow],
+            "Broader?": [shared, broad],
+        }
+        base = _RecordingRetriever(answers=answers)
+        llm = _ScriptedLLM(["Broader?"])
+        ret = StepBackRetriever(base=base, llm=llm)
+
+        out = ret.retrieve("Narrow?", k=3)
+        ids = [r.document.metadata["id"] for r in out]
+        assert ids[0] == "shared"
+        assert set(ids[1:]) == {"narrow", "broad"}
+
+    def test_prompt_must_include_query_placeholder(self) -> None:
+        with pytest.raises(ValueError, match="\\{query\\}"):
+            StepBackRetriever(
+                base=_RecordingRetriever(), llm=_ScriptedLLM([]), prompt="no placeholder"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring
+# ---------------------------------------------------------------------------
+
+
+class TestRetrieverRegistry:
+    def test_new_retrievers_registered(self) -> None:
+        from prompture.rag.retrievers import RETRIEVER_REGISTRY, get_retriever
+
+        for name in ("hyde", "multi_query", "multi-query", "step_back", "step-back"):
+            assert name in RETRIEVER_REGISTRY, f"missing registry entry for {name}"
+
+        # Factory call works for one to prove the wire is hot.
+        ret = get_retriever(
+            "hyde",
+            base=_RecordingRetriever(default=[_result("doc1", 1.0)]),
+            llm=_ScriptedLLM(["hypo"]),
+        )
+        assert isinstance(ret, HyDERetriever)

--- a/tests/test_phase4_contextual_and_fewshot.py
+++ b/tests/test_phase4_contextual_and_fewshot.py
@@ -1,0 +1,554 @@
+"""Phase 4: ContextualChunker + FewShotExampleStore + extract_with_model wiring.
+
+Three independent feature areas:
+
+1. ``ContextualChunker`` — wraps a base chunker and prepends per-chunk
+   LLM-generated context. Uses the system-role path when the driver
+   exposes ``generate_messages`` so Anthropic prompt caching kicks in.
+2. ``FewShotExampleStore`` — embedding-backed example bank with
+   ``add`` / ``add_many`` / ``select``.
+3. Wiring — ``extract_with_model(examples_store=...)`` retrieves
+   top-K examples and prepends them to the instruction. Tests use a
+   recording driver to verify what reaches the LLM.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from pydantic import BaseModel
+
+from prompture.extraction.few_shot import (
+    Example,
+    FewShotExampleStore,
+    _NgramEmbedder,
+    format_examples_for_prompt,
+)
+from prompture.rag.chunkers.base import TextChunker
+from prompture.rag.chunkers.contextual import (
+    DEFAULT_CONTEXTUAL_PROMPT,
+    ContextualChunker,
+)
+from prompture.rag.documents import Document
+
+# ---------------------------------------------------------------------------
+# Shared LLM stubs
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedLLM:
+    """Returns canned text in order, optionally distinguishing path used."""
+
+    def __init__(self, texts: list[str], *, has_generate_messages: bool = True) -> None:
+        self._texts = list(texts)
+        self.calls: list[tuple[str, str, Any]] = []  # (path, payload, options)
+        if not has_generate_messages:
+            # Hide generate_messages so ContextualChunker falls back to generate().
+            self.generate_messages = None  # type: ignore[assignment]
+
+    def _pop(self) -> str:
+        return self._texts.pop(0) if self._texts else ""
+
+    def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append(("generate", prompt, options))
+        return {"text": self._pop()}
+
+    def generate_messages(self, messages: list[dict[str, Any]], options: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append(("generate_messages", messages, options))
+        return {"text": self._pop()}
+
+
+class _RaisingLLM:
+    def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("boom")
+
+    def generate_messages(self, messages: list[dict[str, Any]], options: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("boom")
+
+
+class _FixedSplitChunker(TextChunker):
+    """Splits on '|' so test inputs can exercise exact chunk counts deterministically."""
+
+    def __init__(self, chunk_size: int = 1000, chunk_overlap: int = 0) -> None:
+        super().__init__(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+
+    def split_text(self, text: str) -> list[str]:
+        return [p.strip() for p in text.split("|") if p.strip()]
+
+
+# ---------------------------------------------------------------------------
+# 1. ContextualChunker
+# ---------------------------------------------------------------------------
+
+
+class TestContextualChunkerSplitPath:
+    def test_prompt_must_have_chunk_placeholder(self) -> None:
+        with pytest.raises(ValueError, match="\\{chunk\\}"):
+            ContextualChunker(
+                base=_FixedSplitChunker(),
+                driver=_ScriptedLLM([]),
+                prompt="no placeholder",
+            )
+
+    def test_split_text_delegates_to_base_uncontextualised(self) -> None:
+        chunker = ContextualChunker(base=_FixedSplitChunker(), driver=_ScriptedLLM([]))
+        # split_text never calls the LLM — it operates on raw text without doc context.
+        assert chunker.split_text("a|b|c") == ["a", "b", "c"]
+
+    def test_split_documents_prepends_context_to_each_chunk(self) -> None:
+        llm = _ScriptedLLM(["context for A", "context for B", "context for C"])
+        chunker = ContextualChunker(base=_FixedSplitChunker(), driver=llm)
+        doc = Document(content="A|B|C", metadata={"source": "doc1"})
+        out = chunker.split_documents([doc])
+
+        assert [d.content for d in out] == [
+            "context for A\n\nA",
+            "context for B\n\nB",
+            "context for C\n\nC",
+        ]
+        # Each chunk gets its context stamped in metadata for transparency.
+        for i, d in enumerate(out):
+            assert d.metadata["chunk_index"] == i
+            assert d.metadata["chunk_count"] == 3
+            assert d.metadata["parent_source"] == "doc1"
+            assert "context for" in d.metadata["contextual_context"]
+
+    def test_single_chunk_document_skipped_by_default(self) -> None:
+        # When the base only produces one chunk, contextualisation is a no-op
+        # (no LLM call) unless the user explicitly opts in.
+        llm = _ScriptedLLM(["should not be used"])
+        chunker = ContextualChunker(base=_FixedSplitChunker(), driver=llm)
+        out = chunker.split_documents([Document(content="just one")])
+
+        assert llm.calls == []
+        assert out[0].content == "just one"
+        assert "contextual_context" not in out[0].metadata
+
+    def test_single_chunk_contextualised_when_opted_in(self) -> None:
+        llm = _ScriptedLLM(["single-chunk context"])
+        chunker = ContextualChunker(
+            base=_FixedSplitChunker(),
+            driver=llm,
+            skip_if_only_one_chunk=False,
+        )
+        out = chunker.split_documents([Document(content="just one")])
+        assert out[0].content == "single-chunk context\n\njust one"
+
+
+class TestContextualChunkerLLMPath:
+    def test_uses_generate_messages_with_system_role_when_available(self) -> None:
+        llm = _ScriptedLLM(["context A", "context B"])
+        chunker = ContextualChunker(base=_FixedSplitChunker(), driver=llm)
+        chunker.split_documents([Document(content="A|B")])
+
+        # Both calls went through generate_messages.
+        assert all(c[0] == "generate_messages" for c in llm.calls)
+        # System role carries the full document; user role carries the chunk prompt.
+        first_messages = llm.calls[0][1]
+        assert first_messages[0]["role"] == "system"
+        assert first_messages[0]["content"] == "A|B"  # full doc, not just the chunk
+        assert first_messages[1]["role"] == "user"
+        assert "<chunk>\nA\n</chunk>" in first_messages[1]["content"]
+
+    def test_fallback_to_generate_when_no_generate_messages(self) -> None:
+        llm = _ScriptedLLM(["ctx A", "ctx B"], has_generate_messages=False)
+        chunker = ContextualChunker(base=_FixedSplitChunker(), driver=llm)
+        chunker.split_documents([Document(content="A|B")])
+
+        # Both calls landed on generate() (the messages path was unavailable).
+        assert all(c[0] == "generate" for c in llm.calls)
+        # The fallback combined prompt includes the document.
+        assert "<document>\nA|B\n</document>" in llm.calls[0][1]
+
+    def test_document_truncated_for_llm_call(self) -> None:
+        # Document is enormous; the LLM should see at most max_document_chars.
+        big = "X" * 5000
+        doc = Document(content=f"{big}|Y")
+        llm = _ScriptedLLM(["ctx 1", "ctx 2"])
+        chunker = ContextualChunker(
+            base=_FixedSplitChunker(),
+            driver=llm,
+            max_document_chars=100,
+        )
+        chunker.split_documents([doc])
+
+        first_messages = llm.calls[0][1]
+        assert len(first_messages[0]["content"]) == 100
+
+    def test_long_context_is_truncated(self) -> None:
+        long_ctx = "Y" * 1000
+        llm = _ScriptedLLM([long_ctx, long_ctx])
+        chunker = ContextualChunker(
+            base=_FixedSplitChunker(),
+            driver=llm,
+            max_context_chars=50,
+        )
+        out = chunker.split_documents([Document(content="A|B")])
+        # Context capped to 50 chars, then "\n\n" + chunk.
+        for d in out:
+            assert d.metadata["contextual_context"].startswith("YYY")
+            assert len(d.metadata["contextual_context"]) <= 50
+
+    def test_strips_label_prefixes_from_llm_output(self) -> None:
+        llm = _ScriptedLLM(["Context: this is the situating context"])
+        chunker = ContextualChunker(base=_FixedSplitChunker(), driver=llm)
+        out = chunker.split_documents([Document(content="A|B")])
+        # The "Context:" prefix was stripped.
+        assert out[0].metadata["contextual_context"] == "this is the situating context"
+
+    def test_fail_open_emits_empty_context_on_llm_failure(self) -> None:
+        chunker = ContextualChunker(
+            base=_FixedSplitChunker(),
+            driver=_RaisingLLM(),
+            fail_open=True,
+        )
+        out = chunker.split_documents([Document(content="A|B")])
+        # Failure -> empty context, chunk content unmodified.
+        assert [d.content for d in out] == ["A", "B"]
+        for d in out:
+            assert "contextual_context" not in d.metadata
+
+    def test_fail_closed_propagates_error(self) -> None:
+        # When both generate_messages and generate fail, fail_open=False re-raises.
+        chunker = ContextualChunker(
+            base=_FixedSplitChunker(),
+            driver=_RaisingLLM(),
+            fail_open=False,
+        )
+        with pytest.raises(RuntimeError, match="boom"):
+            chunker.split_documents([Document(content="A|B")])
+
+
+class TestContextualChunkerRegistry:
+    def test_registered_factory(self) -> None:
+        from prompture.rag.chunkers import CHUNKER_REGISTRY, get_chunker
+
+        assert "contextual" in CHUNKER_REGISTRY
+        ck = get_chunker(
+            "contextual",
+            base=_FixedSplitChunker(),
+            driver=_ScriptedLLM(["ctx"]),
+        )
+        assert isinstance(ck, ContextualChunker)
+
+
+class TestDefaultPrompt:
+    def test_default_prompt_contains_chunk_placeholder(self) -> None:
+        assert "{chunk}" in DEFAULT_CONTEXTUAL_PROMPT
+        # The default prompt is *also* a self-contained instruction.
+        assert "retrieval" in DEFAULT_CONTEXTUAL_PROMPT.lower()
+
+
+# ---------------------------------------------------------------------------
+# 2. FewShotExampleStore
+# ---------------------------------------------------------------------------
+
+
+class TestNgramEmbedderFallback:
+    def test_consistent_dimensions(self) -> None:
+        emb = _NgramEmbedder(dimensions=64)
+        out = emb.embed(["foo bar", "baz qux"], {})
+        assert "embeddings" in out
+        assert len(out["embeddings"]) == 2
+        assert all(len(v) == 64 for v in out["embeddings"])
+
+    def test_similar_inputs_have_higher_similarity(self) -> None:
+        # Same string should embed identically -> cosine 1.0.
+        emb = _NgramEmbedder(dimensions=256)
+        out = emb.embed(["hello world", "hello world", "totally different content here"], {})
+        a, b, c = out["embeddings"]
+        from prompture.extraction.few_shot import _cosine
+
+        assert _cosine(a, b) > 0.99
+        assert _cosine(a, c) < _cosine(a, b)
+
+
+class TestFewShotExampleStore:
+    def test_add_and_len(self) -> None:
+        store = FewShotExampleStore()
+        store.add("Maria, 32, developer", {"name": "Maria", "age": 32})
+        store.add("Bob, 47, accountant", {"name": "Bob", "age": 47})
+        assert len(store) == 2
+
+    def test_add_many_batches_embedder(self) -> None:
+        class _CountingEmbedder:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def embed(self, texts: list[str], options: dict[str, Any]) -> dict[str, Any]:
+                self.calls += 1
+                return {"embeddings": [[float(len(t)), 0.0] for t in texts]}
+
+        emb = _CountingEmbedder()
+        store = FewShotExampleStore(embedder=emb)
+        store.add_many([("a", 1), ("ab", 2), ("abc", 3)])
+        # One batched call instead of three single-text calls.
+        assert emb.calls == 1
+        assert len(store) == 3
+
+    def test_select_returns_top_k_by_similarity(self) -> None:
+        # Use a controllable embedder: each example gets an explicit vector so
+        # we can verify the ranking logic without relying on the n-gram hash
+        # collisions of the fallback embedder.
+        class _ManualEmbedder:
+            """Returns the per-text vector configured at construction."""
+
+            def __init__(self, by_text: dict[str, list[float]]) -> None:
+                self._by_text = by_text
+
+            def embed(self, texts: list[str], options: dict[str, Any]) -> dict[str, Any]:
+                return {"embeddings": [self._by_text[t] for t in texts]}
+
+        emb = _ManualEmbedder(
+            {
+                "ex1": [1.0, 0.0],   # close to query
+                "ex2": [0.9, 0.1],   # also close
+                "ex3": [0.0, 1.0],   # orthogonal — should NOT make the top 2
+                "query": [1.0, 0.0],
+            }
+        )
+        store = FewShotExampleStore(embedder=emb)
+        store.add("ex1", {"id": 1})
+        store.add("ex2", {"id": 2})
+        store.add("ex3", {"id": 3})
+
+        hits = store.select("query", k=2)
+        ids = [h.expected_output["id"] for h in hits]
+        assert ids == [1, 2]
+
+    def test_select_uses_ngram_fallback_for_obvious_overlap(self) -> None:
+        """Smoke test using the default n-gram embedder.
+
+        With the default fallback embedder, we don't promise textbook
+        recall — only that *very* obvious overlaps rank above unrelated
+        content. The closest input wins.
+        """
+        store = FewShotExampleStore()
+        store.add("Alice is a software engineer in LA.", {"closest": True})
+        store.add("Completely unrelated: nuclear physics formulas.", {"closest": False})
+        hits = store.select("Alice is a software engineer in LA.", k=1)
+        assert hits[0].expected_output == {"closest": True}
+
+    def test_select_respects_k(self) -> None:
+        store = FewShotExampleStore()
+        for i in range(5):
+            store.add(f"input {i}", {"i": i})
+        assert len(store.select("query", k=0)) == 0
+        assert len(store.select("query", k=2)) == 2
+        # k larger than store size is clamped, not an error.
+        assert len(store.select("query", k=99)) == 5
+
+    def test_select_empty_store_returns_empty(self) -> None:
+        store = FewShotExampleStore()
+        assert store.select("anything", k=3) == []
+
+    def test_clear(self) -> None:
+        store = FewShotExampleStore()
+        store.add("x", 1)
+        store.add("y", 2)
+        store.clear()
+        assert len(store) == 0
+
+    def test_embedder_returning_wrong_count_raises(self) -> None:
+        class _BadEmbedder:
+            def embed(self, texts: list[str], options: dict[str, Any]) -> dict[str, Any]:
+                return {"embeddings": [[0.0]] * (len(texts) - 1)}  # one short
+
+        store = FewShotExampleStore(embedder=_BadEmbedder())
+        with pytest.raises(ValueError, match="vectors for"):
+            store.add_many([("a", 1), ("b", 2)])
+
+    def test_embedder_returning_bad_shape_raises(self) -> None:
+        class _BadShape:
+            def embed(self, texts: list[str], options: dict[str, Any]) -> dict[str, Any]:
+                return ["not", "a", "dict"]  # type: ignore[return-value]
+
+        store = FewShotExampleStore(embedder=_BadShape())
+        with pytest.raises(ValueError, match="unexpected shape"):
+            store.add("anything", 1)
+
+
+# ---------------------------------------------------------------------------
+# 3. format_examples_for_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestFormatExamplesForPrompt:
+    def test_empty_returns_empty_string(self) -> None:
+        assert format_examples_for_prompt([]) == ""
+
+    def test_renders_inputs_and_outputs(self) -> None:
+        ex1 = Example(input_text="Maria, 32, dev", expected_output={"name": "Maria", "age": 32})
+        ex2 = Example(input_text="Bob, 47, acct", expected_output={"name": "Bob", "age": 47})
+        text = format_examples_for_prompt([ex1, ex2])
+        assert "Maria, 32, dev" in text
+        assert "Bob, 47, acct" in text
+        # Outputs serialised as indented JSON.
+        assert '"name": "Maria"' in text
+        assert '"age": 32' in text
+
+    def test_pydantic_model_output_is_dumped(self) -> None:
+        class Person(BaseModel):
+            name: str
+            age: int
+
+        ex = Example(input_text="x", expected_output=Person(name="A", age=1))
+        text = format_examples_for_prompt([ex])
+        assert '"name": "A"' in text
+        assert '"age": 1' in text
+
+    def test_string_output_passes_through(self) -> None:
+        ex = Example(input_text="x", expected_output="literal answer")
+        text = format_examples_for_prompt([ex])
+        assert "literal answer" in text
+
+    def test_uses_custom_header_and_footer(self) -> None:
+        ex = Example(input_text="x", expected_output=1)
+        text = format_examples_for_prompt(
+            [ex],
+            header="CUSTOM HEAD",
+            footer="CUSTOM FOOT",
+        )
+        assert "CUSTOM HEAD" in text
+        assert "CUSTOM FOOT" in text
+
+
+# ---------------------------------------------------------------------------
+# 4. extract_with_model + examples_store wiring
+# ---------------------------------------------------------------------------
+
+
+class _PersonForExtract(BaseModel):
+    name: str
+    age: int
+
+
+class TestExtractWithModelFewShotWiring:
+    def _build_store(self) -> FewShotExampleStore:
+        store = FewShotExampleStore()
+        store.add("Maria is 32, a developer in NYC.", {"name": "Maria", "age": 32})
+        store.add("Bob, 47, accountant.", {"name": "Bob", "age": 47})
+        store.add("The forecast says rain tomorrow.", {"unrelated": True})
+        return store
+
+    def test_examples_block_prepended_to_instruction(self) -> None:
+        """The selected examples should appear in the prompt sent to the driver."""
+        store = self._build_store()
+
+        captured_prompts: list[str] = []
+
+        def _fake_extract_and_jsonify(*, text, instruction_template, **kw):
+            captured_prompts.append(instruction_template)
+            return {
+                "json_string": '{"name": "Alice", "age": 25}',
+                "json_object": {"name": "Alice", "age": 25},
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "cost": 0.0},
+            }
+
+        with patch("prompture.extraction.core.extract_and_jsonify", _fake_extract_and_jsonify):
+            from prompture.extraction.core import extract_with_model
+
+            result = extract_with_model(
+                _PersonForExtract,
+                "Alice is 25, a designer in LA.",
+                model_name="fake/model",
+                examples_store=store,
+                examples_k=2,
+            )
+
+        assert captured_prompts, "extract_and_jsonify was not called"
+        prompt = captured_prompts[0]
+        # The instruction now starts with the examples block.
+        assert "Input:" in prompt
+        assert "Output:" in prompt
+        # The 2 person examples beat the unrelated weather sentence.
+        assert "Maria" in prompt or "Bob" in prompt
+        # The store metadata is surfaced on the result for transparency.
+        assert "few_shot" in result["usage"]
+        assert result["usage"]["few_shot"]["count"] == 2
+        assert result["usage"]["few_shot"]["k_requested"] == 2
+
+    def test_no_examples_store_means_no_block(self) -> None:
+        """Without examples_store the instruction template is unchanged."""
+        captured: list[str] = []
+
+        def _fake_extract_and_jsonify(*, text, instruction_template, **kw):
+            captured.append(instruction_template)
+            return {
+                "json_string": '{"name": "Alice", "age": 25}',
+                "json_object": {"name": "Alice", "age": 25},
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "cost": 0.0},
+            }
+
+        with patch("prompture.extraction.core.extract_and_jsonify", _fake_extract_and_jsonify):
+            from prompture.extraction.core import extract_with_model
+
+            extract_with_model(
+                _PersonForExtract,
+                "Alice is 25, a designer in LA.",
+                model_name="fake/model",
+            )
+
+        assert "Input:" not in captured[0]
+        assert "Output:" not in captured[0]
+
+    def test_examples_k_zero_disables_injection(self) -> None:
+        store = self._build_store()
+        captured: list[str] = []
+
+        def _fake_extract_and_jsonify(*, text, instruction_template, **kw):
+            captured.append(instruction_template)
+            return {
+                "json_string": '{"name": "Alice", "age": 25}',
+                "json_object": {"name": "Alice", "age": 25},
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "cost": 0.0},
+            }
+
+        with patch("prompture.extraction.core.extract_and_jsonify", _fake_extract_and_jsonify):
+            from prompture.extraction.core import extract_with_model
+
+            result = extract_with_model(
+                _PersonForExtract,
+                "Alice is 25.",
+                model_name="fake/model",
+                examples_store=store,
+                examples_k=0,
+            )
+
+        assert "Input:" not in captured[0]
+        assert "few_shot" not in result["usage"]
+
+    def test_failed_select_continues_extraction(self) -> None:
+        """If the store's select() blows up, extraction still runs without examples."""
+
+        class _BadStore:
+            def select(self, query: str, k: int = 3):
+                raise RuntimeError("store on fire")
+
+        captured: list[str] = []
+
+        def _fake_extract_and_jsonify(*, text, instruction_template, **kw):
+            captured.append(instruction_template)
+            return {
+                "json_string": '{"name": "Alice", "age": 25}',
+                "json_object": {"name": "Alice", "age": 25},
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "cost": 0.0},
+            }
+
+        with patch("prompture.extraction.core.extract_and_jsonify", _fake_extract_and_jsonify):
+            from prompture.extraction.core import extract_with_model
+
+            result = extract_with_model(
+                _PersonForExtract,
+                "Alice is 25.",
+                model_name="fake/model",
+                examples_store=_BadStore(),
+                examples_k=2,
+            )
+
+        # Extraction succeeded with no examples injected.
+        assert "Input:" not in captured[0]
+        assert "few_shot" not in result["usage"]
+        assert result["json_object"]["name"] == "Alice"

--- a/tests/test_phase5_schema_feedback_and_streaming.py
+++ b/tests/test_phase5_schema_feedback_and_streaming.py
@@ -1,0 +1,486 @@
+"""Phase 5: schema-tightening retry feedback + partial-JSON streaming.
+
+Two independent feature areas:
+
+1. ``tighten_schema_from_validation_errors()`` walks Pydantic
+   validation errors and appends short retry hints to the
+   corresponding field's ``description`` in a deep-copied schema. The
+   retry loop in ``extract_with_model`` now uses the tightened schema
+   on subsequent attempts.
+2. ``parse_partial_json`` + ``stream_extract`` produce a progression
+   of partial Pydantic instances as a streaming driver emits delta
+   chunks; the last yield is a fully-validated instance when the
+   final JSON parses.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from prompture.extraction.core import (
+    _format_validation_hint,
+    _walk_schema_to_field,
+    tighten_schema_from_validation_errors,
+)
+from prompture.extraction.streaming import (
+    _build_partial_model,
+    parse_partial_json,
+    stream_extract,
+)
+
+# ---------------------------------------------------------------------------
+# Test models
+# ---------------------------------------------------------------------------
+
+
+class _Person(BaseModel):
+    name: str
+    age: int
+    profession: str | None = None
+
+
+class _Address(BaseModel):
+    street: str
+    zip: int
+
+
+class _PersonWithAddress(BaseModel):
+    name: str
+    age: int
+    address: _Address
+
+
+# ---------------------------------------------------------------------------
+# Schema-tightening helper unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestWalkSchemaToField:
+    def test_top_level_property(self) -> None:
+        schema = _Person.model_json_schema()
+        node = _walk_schema_to_field(schema, ("age",))
+        assert isinstance(node, dict)
+        assert node.get("type") in {"integer", "number"} or "type" in node
+
+    def test_missing_field_returns_none(self) -> None:
+        schema = _Person.model_json_schema()
+        assert _walk_schema_to_field(schema, ("not_a_field",)) is None
+
+    def test_empty_loc_returns_none(self) -> None:
+        assert _walk_schema_to_field({}, ()) is None
+
+    def test_nested_field_resolves(self) -> None:
+        # Pydantic resolves $refs lazily; for nested models the path may differ,
+        # so we just verify the helper doesn't crash and gives None when the
+        # ref path isn't directly walkable.
+        schema = _PersonWithAddress.model_json_schema()
+        # Top-level "address" should resolve; deeper may not without $ref.
+        addr_node = _walk_schema_to_field(schema, ("address",))
+        assert addr_node is None or isinstance(addr_node, dict)
+
+
+class TestFormatValidationHint:
+    def test_includes_msg(self) -> None:
+        hint = _format_validation_hint(
+            {"type": "int_parsing", "loc": ("age",), "msg": "Input should be a valid integer", "input": "thirty"}
+        )
+        assert "VALIDATION:" in hint
+        assert "integer" in hint.lower()
+        assert "thirty" in hint
+
+    def test_truncates_huge_input(self) -> None:
+        huge = "x" * 1000
+        hint = _format_validation_hint(
+            {"type": "x", "loc": ("name",), "msg": "bad value", "input": huge}
+        )
+        # Inputs over 80 chars get ellipsised.
+        assert len(hint) < 250
+        assert "..." in hint
+
+    def test_handles_missing_input(self) -> None:
+        hint = _format_validation_hint({"loc": ("name",), "msg": "missing"})
+        assert "VALIDATION" in hint
+
+
+class TestTightenSchema:
+    def test_no_errors_returns_input(self) -> None:
+        schema = _Person.model_json_schema()
+        out = tighten_schema_from_validation_errors(schema, [])
+        # No deep-copy when there's nothing to do — same identity.
+        assert out is schema
+
+    def test_unresolvable_locs_return_input(self) -> None:
+        schema = _Person.model_json_schema()
+        out = tighten_schema_from_validation_errors(
+            schema,
+            [{"loc": ("does_not_exist",), "msg": "x", "type": "x", "input": "x"}],
+        )
+        assert out is schema
+
+    def test_appends_hint_to_failing_field(self) -> None:
+        schema = _Person.model_json_schema()
+        original_desc = schema["properties"]["age"].get("description", "")
+        out = tighten_schema_from_validation_errors(
+            schema,
+            [{"loc": ("age",), "msg": "Input should be a valid integer", "type": "int_parsing", "input": "thirty"}],
+        )
+        # Deep copy — input untouched.
+        assert schema["properties"]["age"].get("description", "") == original_desc
+        # Output has the hint appended.
+        new_desc = out["properties"]["age"]["description"]
+        assert "VALIDATION" in new_desc
+        assert "integer" in new_desc.lower()
+        assert "thirty" in new_desc
+
+    def test_appending_twice_dedupes(self) -> None:
+        schema = _Person.model_json_schema()
+        err = {"loc": ("age",), "msg": "Input should be a valid integer", "type": "int_parsing", "input": "thirty"}
+        once = tighten_schema_from_validation_errors(schema, [err])
+        twice = tighten_schema_from_validation_errors(once, [err])
+        # The hint appears only once.
+        assert twice["properties"]["age"]["description"].count("VALIDATION") == 1
+
+    def test_creates_description_when_missing(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"x": {"type": "integer"}},  # no description
+        }
+        out = tighten_schema_from_validation_errors(
+            schema,
+            [{"loc": ("x",), "msg": "must be integer", "type": "int_parsing", "input": "a"}],
+        )
+        assert "VALIDATION" in out["properties"]["x"]["description"]
+
+
+# ---------------------------------------------------------------------------
+# extract_with_model retry-loop integration
+# ---------------------------------------------------------------------------
+
+
+class TestRetryLoopUsesTightenedSchema:
+    """Use a constrained model so normalize_field_value can't paper over the bug.
+
+    The retry loop only fires when ``actual_cls(**json_object)`` raises a
+    Pydantic ValidationError. ``_Person.age=int`` is silently normalised
+    by ``normalize_field_value`` (string -> 0 default), so we use a
+    constrained ``Field(gt=0)`` here — negative values survive
+    normalization and *do* fail Pydantic.
+    """
+
+    def test_second_attempt_receives_tightened_schema(self) -> None:
+        """The schema sent on retry must carry the corrective hint."""
+        from pydantic import Field
+
+        from prompture.extraction.core import extract_with_model
+
+        class _ConstrainedPerson(BaseModel):
+            name: str
+            age: int = Field(..., gt=0, description="Positive integer")
+
+        # Track every schema sent to extract_and_jsonify.
+        sent_schemas: list[dict[str, Any]] = []
+        call_count = {"n": 0}
+
+        def _fake_extract_and_jsonify(*, text, json_schema, instruction_template, **kw):
+            sent_schemas.append(json_schema)
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # First call: -5 survives normalisation but fails Field(gt=0).
+                return {
+                    "json_string": '{"name": "Maria", "age": -5}',
+                    "json_object": {"name": "Maria", "age": -5},
+                    "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "cost": 0.0},
+                }
+            # Second call: return a valid positive value.
+            return {
+                "json_string": '{"name": "Maria", "age": 30}',
+                "json_object": {"name": "Maria", "age": 30},
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "cost": 0.0},
+            }
+
+        with patch("prompture.extraction.core.extract_and_jsonify", _fake_extract_and_jsonify):
+            result = extract_with_model(
+                _ConstrainedPerson,
+                "Maria is -5",
+                model_name="fake/model",
+                max_retries=2,
+            )
+
+        # Second attempt happened with a tightened schema.
+        assert len(sent_schemas) == 2, f"expected 2 attempts, got {len(sent_schemas)}"
+        first_age = sent_schemas[0]["properties"]["age"].get("description", "")
+        second_age = sent_schemas[1]["properties"]["age"]["description"]
+        assert "VALIDATION" not in first_age
+        assert "VALIDATION" in second_age
+        # The corrective hint references the bad input ('-5') or the constraint.
+        assert "-5" in second_age or "greater than" in second_age.lower()
+        # Result is the validated model from attempt 2.
+        assert result["json_object"]["age"] == 30
+
+    def test_no_retries_no_tightening(self) -> None:
+        """max_retries=1 means one attempt; no schema tightening happens."""
+        from prompture.extraction.core import extract_with_model
+
+        sent_schemas: list[dict[str, Any]] = []
+
+        def _fake(*, text, json_schema, instruction_template, **kw):
+            sent_schemas.append(json_schema)
+            return {
+                "json_string": '{"name": "Maria", "age": 30}',
+                "json_object": {"name": "Maria", "age": 30},
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "cost": 0.0},
+            }
+
+        with patch("prompture.extraction.core.extract_and_jsonify", _fake):
+            extract_with_model(_Person, "Maria is 30", model_name="fake/model")
+
+        assert len(sent_schemas) == 1
+        # No corrective hint was added.
+        desc = sent_schemas[0]["properties"]["age"].get("description", "")
+        assert "VALIDATION" not in desc
+
+
+# ---------------------------------------------------------------------------
+# Partial-JSON parser unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestParsePartialJSON:
+    def test_empty_returns_none(self) -> None:
+        assert parse_partial_json("") is None
+        assert parse_partial_json("   ") is None
+
+    def test_complete_object_parses(self) -> None:
+        assert parse_partial_json('{"a": 1}') == {"a": 1}
+
+    def test_truncated_string_value(self) -> None:
+        # Mid-string at end: complete by appending the closing quote + brace.
+        out = parse_partial_json('{"name": "Alic')
+        assert out == {"name": "Alic"}
+
+    def test_missing_closing_brace(self) -> None:
+        out = parse_partial_json('{"a": 1, "b": 2')
+        # The trailing "2" is complete; just need to close the brace.
+        assert out == {"a": 1, "b": 2}
+
+    def test_partial_number_drops_to_last_complete_value(self) -> None:
+        # Mid-number — fallback cuts back to the comma, leaving {"a": 1}.
+        out = parse_partial_json('{"a": 1, "b": 23')
+        # Either {"a": 1, "b": 23} (we treat 23 as complete) or {"a": 1}
+        # are acceptable. Verify it's one of those.
+        assert out in ({"a": 1, "b": 23}, {"a": 1})
+
+    def test_partial_key_drops_pair(self) -> None:
+        # Mid-key after a comma — fallback cuts back, returning {"a": 1}.
+        out = parse_partial_json('{"a": 1, "n')
+        assert out == {"a": 1}
+
+    def test_partial_array(self) -> None:
+        out = parse_partial_json('{"items": [1, 2, 3')
+        # Should complete to {"items": [1, 2, 3]} or earlier truncation.
+        assert isinstance(out, dict)
+        assert isinstance(out.get("items"), list)
+        assert out["items"][:3] == [1, 2, 3] or out["items"][:2] == [1, 2]
+
+    def test_nested_object(self) -> None:
+        out = parse_partial_json('{"a": {"b": {"c": 1')
+        # Should fill closing braces — exact innermost may be partial.
+        assert isinstance(out, dict)
+        # The "a" key should at least be present.
+        assert "a" in out
+
+    def test_unrecoverable_imbalanced(self) -> None:
+        # More closes than opens — unrecoverable.
+        assert parse_partial_json("{}}") is None or parse_partial_json("{}}") == {}
+
+    def test_trailing_escape_dropped(self) -> None:
+        # Mid-escape — the trailing backslash should be dropped, not crash.
+        out = parse_partial_json('{"name": "foo\\')
+        # Should produce {"name": "foo"} or similar; not None on a normal case.
+        # If the parser can't recover, None is acceptable.
+        assert out is None or "name" in out
+
+
+# ---------------------------------------------------------------------------
+# stream_extract integration
+# ---------------------------------------------------------------------------
+
+
+class _StreamingDriver:
+    """Driver stub that emits ``chunks`` as delta dicts then a done chunk."""
+
+    supports_json_schema = True
+
+    def __init__(self, chunks: list[str], final_text: str | None = None) -> None:
+        self.chunks = chunks
+        self.final_text = final_text
+        self.last_messages: list[dict[str, Any]] | None = None
+        self.last_options: dict[str, Any] | None = None
+
+    def generate_messages_stream(
+        self, messages: list[dict[str, Any]], options: dict[str, Any]
+    ) -> Iterator[dict[str, Any]]:
+        self.last_messages = messages
+        self.last_options = options
+        for c in self.chunks:
+            yield {"type": "delta", "text": c}
+        yield {
+            "type": "done",
+            "text": self.final_text if self.final_text is not None else "".join(self.chunks),
+        }
+
+
+class _NonStreamingDriver:
+    """Driver with no generate_messages_stream."""
+
+    def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        return {"text": "{}", "meta": {}}
+
+
+class TestBuildPartialModel:
+    def test_skips_non_dict(self) -> None:
+        assert _build_partial_model(_Person, [1, 2]) is None
+
+    def test_filters_unknown_keys(self) -> None:
+        out = _build_partial_model(_Person, {"name": "A", "junk_key": 1})
+        assert out is not None
+        assert out.name == "A"
+        assert not hasattr(out, "junk_key")
+
+    def test_missing_fields_left_unset(self) -> None:
+        out = _build_partial_model(_Person, {"name": "A"})
+        assert out is not None
+        # model_construct doesn't enforce required fields; age is unset.
+        assert out.name == "A"
+
+
+class TestStreamExtract:
+    def test_yields_progressive_partials(self) -> None:
+        # Chunks split mid-key, mid-value, then complete.
+        chunks = ['{"na', 'me": "Mar', 'ia", "ag', 'e": 32', "}"]
+        driver = _StreamingDriver(chunks)
+        outputs = list(stream_extract(driver, "extract", _Person))
+        # At least 2 progressive partials before the final.
+        assert len(outputs) >= 2
+        # Final yield is a fully-validated model with all required fields.
+        final = outputs[-1]
+        assert final.name == "Maria"
+        assert final.age == 32
+
+    def test_emits_unchanged_when_requested(self) -> None:
+        # Same parseable state across two chunks (whitespace) — without
+        # emit_unchanged we should only see 1 emit; with it, 2+.
+        chunks = ['{"name": "Maria", "age": 32}', "  ", "  "]
+        driver = _StreamingDriver(chunks, final_text='{"name": "Maria", "age": 32}')
+        compact = list(stream_extract(driver, "extract", _Person, emit_unchanged=False))
+        verbose = list(stream_extract(driver, "extract", _Person, emit_unchanged=True))
+        assert len(verbose) >= len(compact)
+
+    def test_skips_partial_arrays_as_root(self) -> None:
+        # Top-level array can't construct a Person — should not emit garbage,
+        # and the final yield must validate (which it can't here), so 0 emits.
+        chunks = ["[1, 2"]
+        driver = _StreamingDriver(chunks, final_text="[1, 2]")
+        outputs = list(stream_extract(driver, "extract", _Person))
+        assert outputs == []
+
+    def test_drops_unknown_keys(self) -> None:
+        # Model has no "garbage" field — final validates only on declared keys.
+        chunks = ['{"name": "Maria", "age": 32, "garbage": true}']
+        driver = _StreamingDriver(chunks)
+        outputs = list(stream_extract(driver, "extract", _Person))
+        final = outputs[-1]
+        assert final.name == "Maria"
+        assert final.age == 32
+
+    def test_invalid_final_keeps_last_partial(self) -> None:
+        # Final text doesn't validate (missing required field) — partials still emitted,
+        # no final-emit happens.
+        chunks = ['{"name": "Maria"']
+        driver = _StreamingDriver(chunks, final_text='{"name": "Maria"')
+        outputs = list(stream_extract(driver, "extract", _Person))
+        # At least one partial was emitted via model_construct, but no validated final.
+        assert len(outputs) >= 1
+        # The last partial has name set, age unset.
+        assert outputs[-1].name == "Maria"
+
+    def test_non_streaming_driver_raises(self) -> None:
+        with pytest.raises(AttributeError, match="generate_messages_stream"):
+            list(stream_extract(_NonStreamingDriver(), "x", _Person))
+
+    def test_system_prompt_forwarded(self) -> None:
+        driver = _StreamingDriver(['{"name": "Alice", "age": 1}'])
+        list(stream_extract(driver, "extract", _Person, system_prompt="SYS"))
+        assert driver.last_messages is not None
+        roles = [m["role"] for m in driver.last_messages]
+        assert roles[0] == "system"
+        assert driver.last_messages[0]["content"] == "SYS"
+
+
+# ---------------------------------------------------------------------------
+# Conversation.ask_stream_model integration
+# ---------------------------------------------------------------------------
+
+
+class TestAskStreamModel:
+    def test_yields_partials_via_conversation(self) -> None:
+        from prompture.agents.conversation import Conversation
+
+        driver = _StreamingDriver(['{"na', 'me": "Bob", "ag', 'e": 41}'])
+        conv = Conversation(driver=driver)
+        outputs = list(conv.ask_stream_model("Tell me about Bob", _Person))
+
+        assert any(getattr(p, "name", None) == "Bob" for p in outputs)
+        final = outputs[-1]
+        assert final.age == 41
+        # History records user content and the final JSON string.
+        assert any(m["role"] == "user" and m["content"] == "Tell me about Bob" for m in conv._messages)
+
+    def test_schema_propagated_to_driver(self) -> None:
+        from prompture.agents.conversation import Conversation
+
+        driver = _StreamingDriver(['{"name": "Bob", "age": 41}'])
+        conv = Conversation(driver=driver)
+        list(conv.ask_stream_model("Tell me about Bob", _Person))
+
+        # driver.supports_json_schema = True (set on stub), so json_schema should be
+        # forwarded in options.
+        assert driver.last_options is not None
+        assert driver.last_options.get("json_mode") is True
+        assert driver.last_options.get("json_schema") is not None
+        assert driver.last_options["json_schema"]["properties"].get("name") is not None
+
+    def test_history_excludes_schema_text(self) -> None:
+        from prompture.agents.conversation import Conversation
+
+        driver = _StreamingDriver(['{"name": "Bob", "age": 41}'])
+        conv = Conversation(driver=driver)
+        list(conv.ask_stream_model("ASK", _Person))
+
+        # The user history entry is the plain prompt, NOT the schema-augmented one.
+        user_msgs = [m for m in conv._messages if m["role"] == "user"]
+        assert user_msgs[-1]["content"] == "ASK"
+        # No "JSON object" instruction in stored history.
+        assert "MUST respond" not in user_msgs[-1]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Smoke: ValidationError shape we depend on
+# ---------------------------------------------------------------------------
+
+
+class TestValidationErrorContract:
+    def test_pydantic_validation_error_shape(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            _Person(name="A", age="not an int")
+        errs = exc_info.value.errors()
+        assert isinstance(errs, list)
+        assert errs
+        assert "loc" in errs[0]
+        assert "msg" in errs[0]
+        assert "type" in errs[0]

--- a/tests/test_phase6_eval_framework.py
+++ b/tests/test_phase6_eval_framework.py
@@ -1,0 +1,548 @@
+"""Phase 6: LLM-as-judge evaluation primitives.
+
+Covers four orthogonal evaluators:
+
+* :class:`LLMJudge` — single-output rubric scoring
+* :class:`PairwiseJudge` — A/B preference with position-bias correction
+* :class:`SelfConsistencyEvaluator` — N-sample majority vote
+* :class:`FaithfulnessEvaluator` — claim-by-claim RAG grounding
+
+Every test stubs the LLM driver so the suite never touches a provider.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from prompture.eval import (
+    EvalError,
+    FaithfulnessEvaluator,
+    FaithfulnessResult,
+    JudgeResult,
+    LLMJudge,
+    PairwiseJudge,
+    PairwiseResult,
+    SelfConsistencyEvaluator,
+    SelfConsistencyResult,
+)
+from prompture.eval.judge import _criteria_block, _criterion_keys
+from prompture.eval.pairwise import _parse_choice
+from prompture.eval.self_consistency import _default_normalize
+
+# ---------------------------------------------------------------------------
+# Shared driver stubs
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedDriver:
+    """Returns canned texts in order; records every prompt."""
+
+    def __init__(self, texts: list[str], *, with_meta: bool = True) -> None:
+        self._texts = list(texts)
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self._with_meta = with_meta
+
+    def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append((prompt, options))
+        text = self._texts.pop(0) if self._texts else ""
+        meta = (
+            {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15, "cost": 0.001}
+            if self._with_meta
+            else {}
+        )
+        return {"text": text, "meta": meta}
+
+
+class _RaisingDriver:
+    def generate(self, prompt: str, options: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("driver-fail")
+
+
+# ---------------------------------------------------------------------------
+# LLMJudge
+# ---------------------------------------------------------------------------
+
+
+class TestLLMJudgeHelpers:
+    def test_criteria_block_handles_colon_split(self) -> None:
+        block = _criteria_block(["clarity", "factuality: claims must match the reference"])
+        assert "clarity" in block
+        assert "factuality" in block
+        assert "claims must match the reference" in block
+
+    def test_criterion_keys_strip_descriptions(self) -> None:
+        assert _criterion_keys(["clarity", "factuality: details"]) == ["clarity", "factuality"]
+
+    def test_criteria_block_skips_blank(self) -> None:
+        block = _criteria_block(["", "  ", "factuality"])
+        # No empty bullets emitted.
+        assert "- \n" not in block
+        assert "factuality" in block
+
+
+class TestLLMJudgeInit:
+    def test_rejects_empty_criteria(self) -> None:
+        with pytest.raises(EvalError, match="at least one criterion"):
+            LLMJudge(driver=_ScriptedDriver([]), criteria=[])
+
+    def test_rejects_small_scale(self) -> None:
+        with pytest.raises(EvalError, match="scale"):
+            LLMJudge(driver=_ScriptedDriver([]), scale=1)
+
+    def test_rejects_prompt_missing_placeholder(self) -> None:
+        with pytest.raises(EvalError, match="placeholder"):
+            LLMJudge(driver=_ScriptedDriver([]), prompt="missing all placeholders")
+
+
+class TestLLMJudgeEvaluate:
+    def _judge(self, response_text: str, **kw: Any) -> tuple[LLMJudge, _ScriptedDriver]:
+        driver = _ScriptedDriver([response_text])
+        judge = LLMJudge(
+            driver=driver,
+            criteria=["factuality: claims must match the reference", "brevity"],
+            scale=5,
+            **kw,
+        )
+        return judge, driver
+
+    def test_clean_json_response(self) -> None:
+        judge, driver = self._judge(
+            '{"score": 4, "reasoning": "Mostly factual, a bit long.", '
+            '"per_criterion": {"factuality": 5, "brevity": 3}}'
+        )
+        result = judge.evaluate("What is X?", "X is Y", reference="X is Y")
+        assert isinstance(result, JudgeResult)
+        assert result.score == 4
+        assert result.reasoning.startswith("Mostly factual")
+        assert result.per_criterion == {"factuality": 5, "brevity": 3}
+        # Reference block appears in the rendered prompt.
+        assert "REFERENCE ANSWER" in driver.calls[0][0]
+        # Meta was forwarded.
+        assert result.meta.get("calls") == 1
+        assert result.meta.get("total_tokens") == 15
+
+    def test_no_reference_omits_reference_block(self) -> None:
+        judge, driver = self._judge(
+            '{"score": 3, "per_criterion": {"factuality": 3, "brevity": 3}, "reasoning": "OK"}'
+        )
+        judge.evaluate("input", "output")
+        assert "REFERENCE ANSWER" not in driver.calls[0][0]
+
+    def test_fenced_json_response(self) -> None:
+        judge, _ = self._judge(
+            'Here is the rubric scoring:\n```json\n'
+            '{"score": 2, "per_criterion": {"factuality": 2, "brevity": 2}, "reasoning": "Weak"}\n```'
+        )
+        result = judge.evaluate("i", "o")
+        assert result.score == 2
+
+    def test_embedded_json_in_prose(self) -> None:
+        judge, _ = self._judge(
+            'Sure. {"score": 5, "per_criterion": {"factuality": 5, "brevity": 5}, "reasoning": "Great"} hope that helps.'
+        )
+        result = judge.evaluate("i", "o")
+        assert result.score == 5
+
+    def test_score_clamped_to_scale(self) -> None:
+        judge, _ = self._judge(
+            '{"score": 999, "per_criterion": {"factuality": 50, "brevity": -3}, "reasoning": "x"}'
+        )
+        result = judge.evaluate("i", "o")
+        assert result.score == 5  # max(1, min(5, 999))
+        assert result.per_criterion["factuality"] == 5
+        # -3 clamps up to 1.
+        assert result.per_criterion["brevity"] == 1
+
+    def test_score_string_fraction(self) -> None:
+        judge, _ = self._judge(
+            '{"score": "4/5", "per_criterion": {"factuality": "5", "brevity": "3"}, "reasoning": "x"}'
+        )
+        result = judge.evaluate("i", "o")
+        assert result.score == 4
+
+    def test_case_insensitive_criterion_keys(self) -> None:
+        judge, _ = self._judge(
+            '{"score": 4, "per_criterion": {"FACTUALITY": 4, "Brevity": 3}, "reasoning": "x"}'
+        )
+        result = judge.evaluate("i", "o")
+        assert result.per_criterion == {"factuality": 4, "brevity": 3}
+
+    def test_pass_threshold(self) -> None:
+        judge_passes, _ = self._judge(
+            '{"score": 4, "per_criterion": {"factuality": 4, "brevity": 4}, "reasoning": "x"}',
+            pass_threshold=3,
+        )
+        assert judge_passes.evaluate("i", "o").passed is True
+        judge_fails, _ = self._judge(
+            '{"score": 2, "per_criterion": {"factuality": 2, "brevity": 2}, "reasoning": "x"}',
+            pass_threshold=3,
+        )
+        assert judge_fails.evaluate("i", "o").passed is False
+
+    def test_missing_score_raises(self) -> None:
+        judge, _ = self._judge('{"reasoning": "no score field"}')
+        with pytest.raises(EvalError, match="score"):
+            judge.evaluate("i", "o")
+
+    def test_unparseable_response_raises(self) -> None:
+        judge, _ = self._judge("the model said hello and produced no JSON")
+        with pytest.raises(EvalError):
+            judge.evaluate("i", "o")
+
+    def test_driver_failure_raises_eval_error(self) -> None:
+        judge = LLMJudge(driver=_RaisingDriver(), criteria=["clarity"])
+        with pytest.raises(EvalError, match="driver call failed"):
+            judge.evaluate("i", "o")
+
+
+# ---------------------------------------------------------------------------
+# PairwiseJudge
+# ---------------------------------------------------------------------------
+
+
+class TestParseChoice:
+    def test_choice_a(self) -> None:
+        assert _parse_choice("CHOICE: A\nREASON: A is more concise.") == ("A", "A is more concise.")
+
+    def test_choice_b(self) -> None:
+        assert _parse_choice("Choice = B\nReason: B has more detail.") == ("B", "B has more detail.")
+
+    def test_response_a_fallback(self) -> None:
+        choice, _ = _parse_choice("I think Response A is clearly better.")
+        assert choice == "A"
+
+    def test_single_letter_first_line(self) -> None:
+        assert _parse_choice("A")[0] == "A"
+
+    def test_empty_returns_none(self) -> None:
+        assert _parse_choice("") == (None, "")
+
+
+class TestPairwiseJudge:
+    def test_both_passes_agree(self) -> None:
+        # First pass picks A, second pass picks B (B presented first → remapped to A).
+        driver = _ScriptedDriver(
+            [
+                "CHOICE: A\nREASON: A is better.",  # A first
+                "CHOICE: B\nREASON: A is better.",  # B first, B==original A
+            ]
+        )
+        judge = PairwiseJudge(driver=driver)
+        result = judge.compare("input", "candidate A", "candidate B")
+        assert isinstance(result, PairwiseResult)
+        assert result.winner == "A"
+        assert result.confidence == 1.0
+        assert result.votes == {"A_first": "A", "B_first": "A"}
+
+    def test_passes_disagree_yields_tie(self) -> None:
+        # First pass: A. Second pass: B (B presented first → remapped → A).
+        # Wait — for a TIE we need them to disagree at the original-frame level:
+        # A_first: A and B_first: B (so the LLM kept picking the FIRST-presented one — pure position bias).
+        driver = _ScriptedDriver(
+            [
+                "CHOICE: A\nREASON: position bias.",  # A first → A
+                "CHOICE: A\nREASON: position bias.",  # B first → A→B in original frame
+            ]
+        )
+        judge = PairwiseJudge(driver=driver)
+        result = judge.compare("input", "x", "y")
+        assert result.winner == "tie"
+        assert result.confidence == 0.5
+        assert result.votes == {"A_first": "A", "B_first": "B"}
+
+    def test_no_swap_mode(self) -> None:
+        driver = _ScriptedDriver(["CHOICE: B\nREASON: better."])
+        judge = PairwiseJudge(driver=driver, swap_positions=False)
+        result = judge.compare("input", "x", "y")
+        assert result.winner == "B"
+        assert result.confidence == 1.0
+        assert len(driver.calls) == 1  # only one judge call
+
+    def test_invalid_response_no_swap_raises(self) -> None:
+        driver = _ScriptedDriver(["garbage output"])
+        judge = PairwiseJudge(driver=driver, swap_positions=False)
+        with pytest.raises(EvalError, match="no parseable choice"):
+            judge.compare("i", "x", "y")
+
+    def test_swap_one_invalid_one_valid_falls_through(self) -> None:
+        # First pass invalid, second pass picks A (in B-first frame → B-first's A == original B).
+        driver = _ScriptedDriver(
+            [
+                "no clear choice here",
+                "CHOICE: A\nREASON: A is better.",
+            ]
+        )
+        judge = PairwiseJudge(driver=driver)
+        result = judge.compare("i", "x", "y")
+        # Only the valid pass counts.
+        assert result.winner == "B"
+        assert result.confidence == 1.0
+
+    def test_driver_failure(self) -> None:
+        with pytest.raises(EvalError, match="driver call failed"):
+            PairwiseJudge(driver=_RaisingDriver()).compare("i", "x", "y")
+
+    def test_prompt_missing_placeholder(self) -> None:
+        with pytest.raises(EvalError, match="placeholder"):
+            PairwiseJudge(driver=_ScriptedDriver([]), prompt="no placeholders")
+
+
+# ---------------------------------------------------------------------------
+# SelfConsistencyEvaluator
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultNormalize:
+    def test_strips_and_lowercases(self) -> None:
+        assert _default_normalize("  Hello World  ") == "hello world"
+
+    def test_strips_trailing_punctuation(self) -> None:
+        assert _default_normalize("42.") == "42"
+        assert _default_normalize("Yes!") == "yes"
+
+    def test_collapses_whitespace(self) -> None:
+        assert _default_normalize("a  b\nc") == "a b c"
+
+
+class TestSelfConsistency:
+    def test_majority_consensus(self) -> None:
+        driver = _ScriptedDriver(["42", "42", "42", "43", "42"])
+        ev = SelfConsistencyEvaluator(driver=driver, n_samples=5)
+        result = ev.evaluate("What is 6*7?")
+        assert isinstance(result, SelfConsistencyResult)
+        assert result.consensus == "42"
+        assert result.agreement == 0.8
+        assert result.counts == {"42": 4, "43": 1}
+        # Meta accumulated across all 5 calls.
+        assert result.meta["calls"] == 5
+
+    def test_tied_majority_picks_one(self) -> None:
+        driver = _ScriptedDriver(["A", "B", "A", "B"])
+        ev = SelfConsistencyEvaluator(driver=driver, n_samples=4)
+        result = ev.evaluate("question")
+        # most_common returns insertion-order ties — either is acceptable.
+        assert result.consensus in {"a", "b"}
+        assert result.agreement == 0.5
+
+    def test_empty_text_skipped(self) -> None:
+        driver = _ScriptedDriver(["", "42", "  "])
+        ev = SelfConsistencyEvaluator(driver=driver, n_samples=3)
+        result = ev.evaluate("q")
+        assert result.consensus == "42"
+        # Only 1 non-empty sample.
+        assert len(result.samples) == 1
+
+    def test_all_empty_raises(self) -> None:
+        driver = _ScriptedDriver(["", "", ""])
+        ev = SelfConsistencyEvaluator(driver=driver, n_samples=3)
+        with pytest.raises(EvalError, match="empty"):
+            ev.evaluate("q")
+
+    def test_custom_normalize(self) -> None:
+        driver = _ScriptedDriver(["Yes.", "yes", "YES!"])
+        ev = SelfConsistencyEvaluator(
+            driver=driver,
+            n_samples=3,
+            normalize=lambda s: s.lower().rstrip(".!?"),
+        )
+        result = ev.evaluate("?")
+        assert result.consensus == "yes"
+        assert result.agreement == 1.0
+
+    def test_custom_sampler(self) -> None:
+        # No driver needed when sampler= is supplied.
+        outputs = iter(["X", "X", "Y"])
+        ev = SelfConsistencyEvaluator(sampler=lambda: next(outputs), n_samples=3)
+        result = ev.evaluate("ignored")
+        assert result.consensus == "x"
+        assert result.agreement > 0.6
+
+    def test_temperature_default_routes_into_options(self) -> None:
+        driver = _ScriptedDriver(["x"])
+        ev = SelfConsistencyEvaluator(driver=driver, n_samples=1, temperature=0.9)
+        ev.evaluate("q")
+        assert driver.calls[0][1].get("temperature") == 0.9
+
+    def test_invalid_n_samples_raises(self) -> None:
+        with pytest.raises(EvalError, match="n_samples"):
+            SelfConsistencyEvaluator(driver=_ScriptedDriver([]), n_samples=0)
+
+    def test_missing_driver_and_sampler(self) -> None:
+        with pytest.raises(EvalError, match="driver"):
+            SelfConsistencyEvaluator()  # no driver, no sampler
+
+    def test_empty_prompt_for_driver_path(self) -> None:
+        ev = SelfConsistencyEvaluator(driver=_ScriptedDriver(["x"]), n_samples=1)
+        with pytest.raises(EvalError, match="prompt is required"):
+            ev.evaluate("")
+
+
+# ---------------------------------------------------------------------------
+# FaithfulnessEvaluator
+# ---------------------------------------------------------------------------
+
+
+class TestFaithfulnessEvaluator:
+    def _make(self, responses: list[str]) -> tuple[FaithfulnessEvaluator, _ScriptedDriver]:
+        driver = _ScriptedDriver(responses)
+        return FaithfulnessEvaluator(driver=driver), driver
+
+    def test_all_supported_score_1(self) -> None:
+        ev, _driver = self._make(
+            [
+                '["Paris is the capital of France.", "The Eiffel Tower is in Paris."]',
+                "SUPPORTED",
+                "SUPPORTED",
+            ]
+        )
+        result = ev.evaluate(
+            answer="Paris is the capital of France. The Eiffel Tower is in Paris.",
+            evidence=[
+                "Paris is the capital of France.",
+                "The Eiffel Tower stands in central Paris.",
+            ],
+        )
+        assert isinstance(result, FaithfulnessResult)
+        assert result.score == 1.0
+        assert len(result.supported) == 2
+        assert result.unsupported == []
+        assert result.contradicted == []
+
+    def test_partial_support(self) -> None:
+        ev, _ = self._make(
+            [
+                '["A", "B", "C"]',
+                "SUPPORTED",
+                "SILENT",
+                "CONTRADICTED",
+            ]
+        )
+        result = ev.evaluate(answer="A. B. C.", evidence=["e1", "e2"])
+        # default treat_silent_as='unsupported': silent + contradicted both count against.
+        assert pytest.approx(result.score) == 1 / 3
+        assert result.supported == ["A"]
+        assert set(result.unsupported) == {"B", "C"}
+        assert result.contradicted == ["C"]
+
+    def test_silent_as_neutral_excludes_silent(self) -> None:
+        driver = _ScriptedDriver(
+            [
+                '["A", "B", "C"]',
+                "SUPPORTED",
+                "SILENT",
+                "SUPPORTED",
+            ]
+        )
+        ev = FaithfulnessEvaluator(driver=driver, treat_silent_as="neutral")
+        result = ev.evaluate(answer="A. B. C.", evidence=["e"])
+        # B is excluded from denominator entirely → 2/2 = 1.0
+        assert result.score == 1.0
+
+    def test_decomposition_returns_no_claims_raises(self) -> None:
+        _ev, _ = self._make(["plain prose, no list"])
+        # The bullet/numbered fallback will catch the prose as a single line,
+        # so we need a truly empty decomposition.
+        ev2, _ = self._make([""])
+        with pytest.raises(EvalError, match="no claims"):
+            ev2.evaluate(answer="x", evidence=["y"])
+
+    def test_unparseable_verdict_treated_as_silent(self) -> None:
+        ev, _ = self._make(
+            [
+                '["claim 1"]',
+                "the model rambled and didn't pick a label",  # no verdict word
+            ]
+        )
+        result = ev.evaluate(answer="claim 1.", evidence=["e"])
+        # Defaults to SILENT → unsupported (under default treat_silent_as).
+        assert result.score == 0.0
+        assert result.unsupported == ["claim 1"]
+        assert result.contradicted == []
+
+    def test_fenced_json_decomposition(self) -> None:
+        ev, _ = self._make(
+            [
+                '```json\n["claim a", "claim b"]\n```',
+                "SUPPORTED",
+                "SUPPORTED",
+            ]
+        )
+        result = ev.evaluate("claim a. claim b.", evidence=["e"])
+        assert result.score == 1.0
+        assert len(result.supported) == 2
+
+    def test_bullet_list_decomposition_fallback(self) -> None:
+        ev, _ = self._make(
+            [
+                "- claim x\n- claim y\n- claim z",
+                "SUPPORTED",
+                "SUPPORTED",
+                "SUPPORTED",
+            ]
+        )
+        result = ev.evaluate("any answer", evidence=["e"])
+        assert result.score == 1.0
+        assert len(result.supported) == 3
+
+    def test_evidence_text_assembled_with_indices(self) -> None:
+        ev, driver = self._make(['["X"]', "SUPPORTED"])
+        ev.evaluate("X.", evidence=["chunk one", "chunk two"])
+        # The second call is the verification — evidence appears in its prompt.
+        verify_prompt = driver.calls[1][0]
+        assert "[1] chunk one" in verify_prompt
+        assert "[2] chunk two" in verify_prompt
+
+    def test_invalid_treat_silent_as(self) -> None:
+        with pytest.raises(EvalError, match="treat_silent_as"):
+            FaithfulnessEvaluator(driver=_ScriptedDriver([]), treat_silent_as="bogus")
+
+    def test_prompt_missing_placeholder_raises(self) -> None:
+        with pytest.raises(EvalError, match="answer"):
+            FaithfulnessEvaluator(driver=_ScriptedDriver([]), decomposition_prompt="no placeholders")
+        with pytest.raises(EvalError, match="claim"):
+            FaithfulnessEvaluator(
+                driver=_ScriptedDriver([]),
+                verification_prompt="missing {evidence} but no claim",
+            )
+
+    def test_meta_accumulates_across_all_calls(self) -> None:
+        ev, _ = self._make(
+            [
+                '["a", "b"]',
+                "SUPPORTED",
+                "CONTRADICTED",
+            ]
+        )
+        result = ev.evaluate("a. b.", evidence=["e"])
+        # 1 decomposition + 2 verifications = 3 calls.
+        assert result.meta["calls"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Package exports
+# ---------------------------------------------------------------------------
+
+
+class TestEvalExports:
+    def test_all_evaluators_importable(self) -> None:
+        from prompture.eval import (  # noqa: F401
+            EvalDriver,
+            EvalError,
+            FaithfulnessEvaluator,
+            FaithfulnessResult,
+            JudgeResult,
+            LLMJudge,
+            PairwiseJudge,
+            PairwiseResult,
+            SelfConsistencyEvaluator,
+            SelfConsistencyResult,
+        )
+
+    def test_result_to_dict_round_trip(self) -> None:
+        r = JudgeResult(score=4, reasoning="ok", per_criterion={"a": 4}, passed=True, meta={"x": 1})
+        d = r.to_dict()
+        assert d["score"] == 4
+        assert d["per_criterion"] == {"a": 4}
+        assert d["passed"] is True

--- a/tests/test_phase8a_constrained_decoding.py
+++ b/tests/test_phase8a_constrained_decoding.py
@@ -1,0 +1,403 @@
+"""Phase 8A-lite: vLLM-style ``guided_json`` + ``extra_body`` pass-through.
+
+Two layers:
+
+1. **Helper unit tests** — exercise
+   ``prompture.drivers._openai_compat`` directly. Stdlib-only, fast.
+2. **Driver wire-format tests** — stub the HTTP layer and assert that
+   ``guided_json`` / ``guided_decoding_backend`` / extra-body fields
+   land in the request payload in the right places for every
+   OpenAI-compatible driver pair (sync + async).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from prompture.drivers._openai_compat import (
+    apply_guided_decoding,
+    apply_structured_output,
+    build_response_format,
+    merge_extra_body,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+SCHEMA = {"type": "object", "properties": {"x": {"type": "integer"}}, "required": ["x"]}
+
+
+def _empty() -> dict[str, Any]:
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildResponseFormat:
+    def test_shape(self) -> None:
+        rf = build_response_format(SCHEMA)
+        assert rf["type"] == "json_schema"
+        assert rf["json_schema"]["name"] == "extraction"
+        assert rf["json_schema"]["strict"] is True
+        # The schema must round-trip the user input (post-strict-patching).
+        assert "properties" in rf["json_schema"]["schema"]
+
+
+class TestApplyGuidedDecoding:
+    def test_off_is_noop(self) -> None:
+        payload = _empty()
+        apply_guided_decoding(payload, json_schema=SCHEMA, guided_decoding=False)
+        assert payload == {}
+
+    def test_no_schema_is_noop(self) -> None:
+        payload = _empty()
+        apply_guided_decoding(payload, json_schema=None, guided_decoding=True)
+        assert payload == {}
+
+    def test_true_writes_guided_json_without_backend(self) -> None:
+        payload = _empty()
+        apply_guided_decoding(payload, json_schema=SCHEMA, guided_decoding=True)
+        assert payload == {"guided_json": SCHEMA}
+
+    def test_outlines_string_writes_backend(self) -> None:
+        payload = _empty()
+        apply_guided_decoding(payload, json_schema=SCHEMA, guided_decoding="outlines")
+        assert payload["guided_json"] == SCHEMA
+        assert payload["guided_decoding_backend"] == "outlines"
+
+    def test_xgrammar_backend(self) -> None:
+        payload = _empty()
+        apply_guided_decoding(payload, json_schema=SCHEMA, guided_decoding="xgrammar")
+        assert payload["guided_decoding_backend"] == "xgrammar"
+
+    def test_unknown_backend_passes_through(self) -> None:
+        # Don't reject — vLLM ships new backends sometimes.
+        payload = _empty()
+        apply_guided_decoding(payload, json_schema=SCHEMA, guided_decoding="future-backend")
+        assert payload["guided_decoding_backend"] == "future-backend"
+
+
+class TestMergeExtraBody:
+    def test_no_extra_is_noop(self) -> None:
+        payload = {"a": 1}
+        merge_extra_body(payload, {})
+        assert payload == {"a": 1}
+
+    def test_non_dict_extra_ignored(self) -> None:
+        payload = {"a": 1}
+        merge_extra_body(payload, {"extra_body": "not-a-dict"})
+        assert payload == {"a": 1}
+
+    def test_extra_keys_overwrite(self) -> None:
+        payload = {"a": 1, "model": "default"}
+        merge_extra_body(payload, {"extra_body": {"a": 2, "min_p": 0.1}})
+        # User extras WIN — that's the whole point of the escape hatch.
+        assert payload["a"] == 2
+        assert payload["min_p"] == 0.1
+        assert payload["model"] == "default"
+
+
+class TestApplyStructuredOutput:
+    def test_full_pipeline(self) -> None:
+        payload = {"model": "fake", "messages": []}
+        apply_structured_output(
+            payload,
+            options={
+                "json_mode": True,
+                "json_schema": SCHEMA,
+                "guided_decoding": "outlines",
+                "extra_body": {"min_p": 0.05},
+            },
+        )
+        assert payload["response_format"]["type"] == "json_schema"
+        assert payload["guided_json"] == SCHEMA
+        assert payload["guided_decoding_backend"] == "outlines"
+        assert payload["min_p"] == 0.05
+
+    def test_loose_json_mode_without_schema(self) -> None:
+        payload = {"model": "fake"}
+        apply_structured_output(payload, options={"json_mode": True})
+        assert payload["response_format"] == {"type": "json_object"}
+        # No guided_json without a schema.
+        assert "guided_json" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Driver wire-format tests
+# ---------------------------------------------------------------------------
+
+
+class _StubResponse:
+    """Minimal requests-Response stand-in."""
+
+    def __init__(self, payload: dict[str, Any], status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+        self.text = ""
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+def _stub_chat_response() -> dict[str, Any]:
+    return {
+        "id": "stub",
+        "model": "test",
+        "choices": [{"message": {"role": "assistant", "content": '{"x": 1}'}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+
+class TestOpenAICompatibleWireFormat:
+    """Sync OpenAICompatibleDriver."""
+
+    def _driver(self, monkeypatch: pytest.MonkeyPatch):
+        from prompture.drivers import openai_compatible_driver as ocd
+
+        captured: list[dict[str, Any]] = []
+
+        def _post(url: str, *, headers: Any = None, json: dict[str, Any], **kw: Any) -> _StubResponse:
+            captured.append(json)
+            return _StubResponse(_stub_chat_response())
+
+        monkeypatch.setattr(ocd.requests, "post", _post)
+        driver = ocd.OpenAICompatibleDriver(
+            endpoint="http://fake.example.com/v1",
+            api_key="test",
+            model="fake-model",
+        )
+        return driver, captured
+
+    def test_guided_decoding_writes_vllm_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        driver, captured = self._driver(monkeypatch)
+        driver.generate(
+            "anything",
+            options={
+                "json_mode": True,
+                "json_schema": SCHEMA,
+                "guided_decoding": "outlines",
+            },
+        )
+        body = captured[0]
+        assert body["guided_json"] == SCHEMA
+        assert body["guided_decoding_backend"] == "outlines"
+        assert body["response_format"]["type"] == "json_schema"
+
+    def test_extra_body_overrides(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        driver, captured = self._driver(monkeypatch)
+        driver.generate(
+            "anything",
+            options={
+                "json_mode": True,
+                "json_schema": SCHEMA,
+                "extra_body": {"min_p": 0.1, "guided_grammar": "S -> 'yes'"},
+            },
+        )
+        body = captured[0]
+        assert body["min_p"] == 0.1
+        assert body["guided_grammar"] == "S -> 'yes'"
+
+    def test_off_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        driver, captured = self._driver(monkeypatch)
+        driver.generate(
+            "anything",
+            options={"json_mode": True, "json_schema": SCHEMA},
+        )
+        # No guided_decoding flag → no vLLM fields.
+        body = captured[0]
+        assert "guided_json" not in body
+        assert "guided_decoding_backend" not in body
+
+
+class TestOpenRouterWireFormat:
+    def _driver(self, monkeypatch: pytest.MonkeyPatch):
+        import os
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+        from prompture.drivers import openrouter_driver as ord_
+
+        captured: list[dict[str, Any]] = []
+
+        def _post(url: str, *, headers: Any = None, json: dict[str, Any], **kw: Any) -> _StubResponse:
+            captured.append(json)
+            return _StubResponse(_stub_chat_response())
+
+        monkeypatch.setattr(ord_.requests, "post", _post)
+        driver = ord_.OpenRouterDriver(model="meta-llama/llama-3-8b-instruct")
+        # Defensive: zero out os.getenv side-effects.
+        _ = os.environ.get("OPENROUTER_API_KEY")
+        return driver, captured
+
+    def test_guided_decoding_in_payload(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        driver, captured = self._driver(monkeypatch)
+        driver.generate(
+            "anything",
+            options={
+                "json_mode": True,
+                "json_schema": SCHEMA,
+                "guided_decoding": True,
+            },
+        )
+        body = captured[0]
+        assert body["guided_json"] == SCHEMA
+        # ``True`` without a backend string → no guided_decoding_backend key.
+        assert "guided_decoding_backend" not in body
+
+    def test_extra_body_passthrough(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        driver, captured = self._driver(monkeypatch)
+        driver.generate(
+            "anything",
+            options={
+                "json_mode": True,
+                "json_schema": SCHEMA,
+                "extra_body": {"provider": {"order": ["Hyperbolic", "Together"]}},
+            },
+        )
+        body = captured[0]
+        # OpenRouter-specific provider preference field rides through unmolested.
+        assert body["provider"] == {"order": ["Hyperbolic", "Together"]}
+
+
+class TestLMStudioWireFormat:
+    def _driver(self, monkeypatch: pytest.MonkeyPatch):
+        from prompture.drivers import lmstudio_driver as lmd
+
+        captured: list[dict[str, Any]] = []
+
+        def _post(url: str, *, headers: Any = None, json: dict[str, Any], **kw: Any) -> _StubResponse:
+            captured.append(json)
+            return _StubResponse(_stub_chat_response())
+
+        monkeypatch.setattr(lmd.requests, "post", _post)
+        driver = lmd.LMStudioDriver(endpoint="http://localhost:1234/v1/chat/completions")
+        return driver, captured
+
+    def test_guided_decoding(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        driver, captured = self._driver(monkeypatch)
+        driver.generate(
+            "x",
+            options={
+                "json_mode": True,
+                "json_schema": SCHEMA,
+                "guided_decoding": "lm-format-enforcer",
+            },
+        )
+        body = captured[0]
+        assert body["guided_json"] == SCHEMA
+        assert body["guided_decoding_backend"] == "lm-format-enforcer"
+
+    def test_response_format_still_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # LM Studio's native schema enforcement should still be in place
+        # alongside the vLLM-style fields.
+        driver, captured = self._driver(monkeypatch)
+        driver.generate(
+            "x",
+            options={"json_mode": True, "json_schema": SCHEMA, "guided_decoding": True},
+        )
+        body = captured[0]
+        assert body["response_format"]["type"] == "json_schema"
+        assert body["guided_json"] == SCHEMA
+
+
+# ---------------------------------------------------------------------------
+# Async sibling smoke tests
+# ---------------------------------------------------------------------------
+
+
+class _AsyncStubResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+        self.status_code = 200
+        self.text = ""
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _StubAsyncClient:
+    """Capturing httpx.AsyncClient stand-in."""
+
+    captured: list[dict[str, Any]] = []
+
+    def __init__(self, *_: Any, **__: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> _StubAsyncClient:
+        return self
+
+    async def __aexit__(self, *a: Any) -> None:
+        return None
+
+    async def post(self, url: str, *, headers: Any = None, json: dict[str, Any], **kw: Any) -> _AsyncStubResponse:
+        type(self).captured.append(json)
+        return _AsyncStubResponse(_stub_chat_response())
+
+
+class TestAsyncDriversWireFormat:
+    @pytest.mark.asyncio
+    async def test_async_openai_compatible(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from prompture.drivers import async_openai_compatible_driver as a_ocd
+
+        _StubAsyncClient.captured = []
+        monkeypatch.setattr(a_ocd.httpx, "AsyncClient", _StubAsyncClient)
+        driver = a_ocd.AsyncOpenAICompatibleDriver(
+            endpoint="http://fake/v1",
+            api_key="t",
+            model="m",
+        )
+        await driver.generate(
+            "x",
+            options={"json_mode": True, "json_schema": SCHEMA, "guided_decoding": "outlines"},
+        )
+        body = _StubAsyncClient.captured[0]
+        assert body["guided_json"] == SCHEMA
+        assert body["guided_decoding_backend"] == "outlines"
+
+    @pytest.mark.asyncio
+    async def test_async_openrouter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test")
+        from prompture.drivers import async_openrouter_driver as a_ord
+
+        _StubAsyncClient.captured = []
+        monkeypatch.setattr(a_ord.httpx, "AsyncClient", _StubAsyncClient)
+        driver = a_ord.AsyncOpenRouterDriver(model="meta-llama/llama-3-8b-instruct")
+        await driver.generate(
+            "x",
+            options={
+                "json_mode": True,
+                "json_schema": SCHEMA,
+                "guided_decoding": True,
+                "extra_body": {"provider": {"order": ["X"]}},
+            },
+        )
+        body = _StubAsyncClient.captured[0]
+        assert body["guided_json"] == SCHEMA
+        assert body["provider"] == {"order": ["X"]}
+
+    @pytest.mark.asyncio
+    async def test_async_lmstudio(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from prompture.drivers import async_lmstudio_driver as a_lmd
+
+        _StubAsyncClient.captured = []
+        monkeypatch.setattr(a_lmd.httpx, "AsyncClient", _StubAsyncClient)
+        driver = a_lmd.AsyncLMStudioDriver(endpoint="http://localhost:1234/v1/chat/completions")
+        await driver.generate(
+            "x",
+            options={"json_mode": True, "json_schema": SCHEMA, "guided_decoding": "xgrammar"},
+        )
+        body = _StubAsyncClient.captured[0]
+        assert body["guided_json"] == SCHEMA
+        assert body["guided_decoding_backend"] == "xgrammar"

--- a/tests/test_phase8c_dataset_modernization.py
+++ b/tests/test_phase8c_dataset_modernization.py
@@ -1,0 +1,614 @@
+"""Phase 8C: synthetic dataset modernisation.
+
+Covers four orthogonal feature areas:
+
+* :class:`QualityFilter` — shape / length / refusal-gating filters
+* :func:`dedup_exact` / :func:`dedup_shingle` / :func:`dedup_semantic` —
+  three dedup strategies + the unified :class:`DedupConfig` entry
+* :class:`EvolInstruct` — depth / breadth / reasoning evolution
+* :class:`SelfInstruct` — seed-based expansion
+* :func:`generate_qa_dataset` wiring — personas, quality_filter, and
+  dedup parameters
+
+Every test stubs the LLM via :func:`unittest.mock.patch` so the suite
+never touches a provider.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from prompture.dataset import (
+    DedupConfig,
+    EvolInstruct,
+    QAPair,
+    QualityFilter,
+    SelfInstruct,
+    apply_dedup,
+    dedup_exact,
+    dedup_semantic,
+    dedup_shingle,
+    generate_qa_dataset,
+    length_filter,
+    refusal_filter,
+    shape_filter,
+)
+from prompture.dataset.filters import FilterDecision
+from prompture.rag.documents import Document
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _pair(q: str, a: str) -> QAPair:
+    return QAPair(question=q, answer=a)
+
+
+class _ManualEmbedder:
+    """Returns a fixed vector per text. Used to control dedup tests."""
+
+    def __init__(self, by_text: dict[str, list[float]]) -> None:
+        self._by_text = by_text
+
+    def embed(self, texts: list[str], options: dict[str, Any]) -> dict[str, Any]:
+        return {"embeddings": [self._by_text[t] for t in texts]}
+
+
+# ---------------------------------------------------------------------------
+# QualityFilter
+# ---------------------------------------------------------------------------
+
+
+class TestShapeFilter:
+    def test_drops_empty_question(self) -> None:
+        decision = shape_filter()(_pair("", "answer"))
+        assert decision.keep is False
+        assert "empty_field" in decision.reason
+
+    def test_drops_empty_answer(self) -> None:
+        decision = shape_filter()(_pair("What?", ""))
+        assert decision.keep is False
+
+    def test_drops_identical_q_and_a(self) -> None:
+        decision = shape_filter()(_pair("Same", "Same"))
+        assert decision.keep is False
+        assert "identical" in decision.reason
+
+    def test_drops_non_question(self) -> None:
+        # No ``?``, no interrogative prefix.
+        decision = shape_filter()(_pair("This is a statement.", "Some answer."))
+        assert decision.keep is False
+        assert "not_a_question" in decision.reason
+
+    def test_keeps_interrogative_without_questionmark(self) -> None:
+        # Starts with "What" / "Why" / etc. — keep even without "?".
+        decision = shape_filter()(_pair("Define osmosis", "Osmosis is..."))
+        assert decision.keep is True
+
+    def test_keeps_normal_question(self) -> None:
+        decision = shape_filter()(_pair("What is the capital of France?", "Paris."))
+        assert decision.keep is True
+
+
+class TestLengthFilter:
+    def test_drops_short_question(self) -> None:
+        d = length_filter(min_question_chars=10)(_pair("Hi?", "answer text"))
+        assert d.keep is False
+        assert "short_question" in d.reason
+
+    def test_drops_long_answer(self) -> None:
+        d = length_filter(max_answer_chars=20)(_pair("What is X?", "y" * 1000))
+        assert d.keep is False
+        assert "long_answer" in d.reason
+
+    def test_keeps_within_bounds(self) -> None:
+        d = length_filter()(_pair("What is the capital of France?", "Paris is the capital."))
+        assert d.keep is True
+
+    def test_disabling_upper_bound(self) -> None:
+        d = length_filter(max_answer_chars=None)(
+            _pair("What is X?", "x" * 100_000)
+        )
+        assert d.keep is True
+
+
+class TestRefusalFilter:
+    def test_drops_refusal_answer(self) -> None:
+        f = refusal_filter()
+        d = f(_pair("How do I hack X?", "I'm sorry, but I can't help with that."))
+        assert d.keep is False
+        assert "refusal" in d.reason
+
+    def test_keeps_genuine_answer(self) -> None:
+        f = refusal_filter()
+        d = f(_pair("What is the capital of France?", "Paris is the capital of France."))
+        assert d.keep is True
+
+
+class TestQualityFilterPipeline:
+    def test_filter_collects_stats(self) -> None:
+        pairs = [
+            _pair("What is the capital of France?", "Paris."),
+            _pair("", "empty Q"),
+            _pair("Hi?", "y"),  # short answer (default min=1, but pass — adjust)
+            _pair("This is not a question.", "Some prose."),
+        ]
+        clean, stats = QualityFilter().filter(pairs)
+        assert stats.total_in == 4
+        assert len(clean) <= stats.total_in
+        assert stats.total_out == len(clean)
+        # At least the empty-Q and non-question rows must drop.
+        assert stats.total_in - stats.total_out >= 2
+        assert sum(stats.dropped_by_reason.values()) == stats.total_in - stats.total_out
+
+    def test_iter_yields_only_kept(self) -> None:
+        pairs = [_pair("What is the capital of France?", "Paris."), _pair("", "")]
+        out = list(QualityFilter().iter(pairs))
+        assert len(out) == 1
+
+    def test_filter_decision_helpers(self) -> None:
+        assert FilterDecision.keep_().keep
+        assert not FilterDecision.drop("x").keep
+        assert FilterDecision.drop("foo").reason == "drop:foo"
+
+    def test_first_failing_predicate_short_circuits(self) -> None:
+        calls = {"count": 0}
+
+        def _counting_filter():
+            def _p(_pair: Any) -> FilterDecision:
+                calls["count"] += 1
+                return FilterDecision.keep_()
+
+            return _p
+
+        filt = QualityFilter(predicates=[shape_filter(), _counting_filter()])
+        # Run a row that fails the first predicate.
+        filt.evaluate(_pair("", ""))
+        # The second predicate must NOT have been called.
+        assert calls["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Dedup
+# ---------------------------------------------------------------------------
+
+
+class TestDedupExact:
+    def test_drops_normalised_duplicates(self) -> None:
+        pairs = [
+            _pair("What is the Capital of France?", "Paris."),
+            _pair("what is the capital of france?", "Paris."),  # case-only dup
+            _pair("What about Germany?", "Berlin."),
+        ]
+        kept, removed = dedup_exact(pairs)
+        assert len(kept) == 2
+        assert removed == 1
+
+    def test_empty_keys_dropped(self) -> None:
+        kept, _ = dedup_exact([QAPair(question="", answer="a")])
+        assert kept == []
+
+    def test_preserves_order(self) -> None:
+        pairs = [_pair("Q1?", "A1"), _pair("Q2?", "A2"), _pair("Q3?", "A3")]
+        kept, _ = dedup_exact(pairs)
+        assert [p.question for p in kept] == ["Q1?", "Q2?", "Q3?"]
+
+
+class TestDedupShingle:
+    def test_catches_paraphrase(self) -> None:
+        pairs = [
+            _pair("What is the capital of France?", "Paris."),
+            _pair("What's the capital of France?", "Paris."),  # paraphrase
+            _pair("Describe the moon.", "It's a satellite."),
+        ]
+        kept, removed = dedup_shingle(pairs, threshold=0.55, shingle_size=4)
+        assert removed >= 1
+        # The unrelated moon question survives.
+        assert any("moon" in p.question.lower() for p in kept)
+
+    def test_high_threshold_keeps_paraphrases(self) -> None:
+        # At threshold=0.99, only carbon copies merge.
+        pairs = [
+            _pair("What is X?", "Y."),
+            _pair("What about X?", "Y."),
+        ]
+        kept, removed = dedup_shingle(pairs, threshold=0.99)
+        assert removed == 0
+        assert len(kept) == 2
+
+
+class TestDedupSemantic:
+    def test_drops_close_embeddings(self) -> None:
+        embedder = _ManualEmbedder(
+            {
+                "Q1": [1.0, 0.0],
+                "Q2": [0.99, 0.01],  # close to Q1
+                "Q3": [0.0, 1.0],  # orthogonal
+            }
+        )
+        pairs = [_pair("Q1", "A"), _pair("Q2", "A"), _pair("Q3", "A")]
+        kept, removed = dedup_semantic(pairs, embedder=embedder, threshold=0.9)
+        assert removed == 1
+        assert {p.question for p in kept} == {"Q1", "Q3"}
+
+    def test_handles_empty_keys(self) -> None:
+        embedder = _ManualEmbedder({"Q": [1.0, 0.0]})
+        pairs = [_pair("", "A"), _pair("Q", "A")]
+        kept, removed = dedup_semantic(pairs, embedder=embedder)
+        assert removed == 1  # empty-Q dropped
+        assert len(kept) == 1
+
+    def test_wrong_vector_count_raises(self) -> None:
+        class _Bad:
+            def embed(self, texts: list[str], options: dict) -> dict:
+                return {"embeddings": [[0.0]] * (len(texts) - 1)}
+
+        with pytest.raises(ValueError, match="vectors"):
+            dedup_semantic([_pair("A", "B")], embedder=_Bad())
+
+
+class TestApplyDedup:
+    def test_exact(self) -> None:
+        kept, _ = apply_dedup([_pair("A?", "x"), _pair("A?", "x")], DedupConfig(strategy="exact"))
+        assert len(kept) == 1
+
+    def test_none_passthrough(self) -> None:
+        pairs = [_pair("A?", "x"), _pair("A?", "x")]
+        kept, removed = apply_dedup(pairs, DedupConfig(strategy="none"))
+        assert kept == pairs
+        assert removed == 0
+
+    def test_semantic_requires_embedder(self) -> None:
+        with pytest.raises(ValueError, match="embedder"):
+            apply_dedup([_pair("Q", "A")], DedupConfig(strategy="semantic"))
+
+    def test_unknown_strategy_raises(self) -> None:
+        with pytest.raises(ValueError, match="strategy"):
+            apply_dedup([], DedupConfig(strategy="bogus"))
+
+
+# ---------------------------------------------------------------------------
+# EvolInstruct
+# ---------------------------------------------------------------------------
+
+
+class TestEvolInstruct:
+    def test_evolve_pair_returns_new_qapair(self) -> None:
+        def _fake_extract(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {
+                "model": QAPair(question="Evolved Q?", answer="Evolved A."),
+                "json_string": "",
+                "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15, "cost": 0.001},
+            }
+
+        with patch("prompture.dataset.evol.extract_with_model", _fake_extract):
+            evol = EvolInstruct(model="fake/model")
+            evolved, meta = evol.evolve_pair(_pair("Original Q?", "Original A."), operator="depth")
+            assert evolved is not None
+            assert evolved.question == "Evolved Q?"
+            assert meta.get("prompt_tokens") == 10
+
+    def test_evolve_pair_drops_identical_question(self) -> None:
+        identical = QAPair(question="Original?", answer="Same.")
+
+        def _fake(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {"model": identical, "json_string": "", "usage": {}}
+
+        with patch("prompture.dataset.evol.extract_with_model", _fake):
+            evol = EvolInstruct(model="fake")
+            evolved, _ = evol.evolve_pair(_pair("Original?", "Original."), operator="depth")
+            assert evolved is None
+
+    def test_evolve_pair_returns_none_on_extract_failure(self) -> None:
+        def _boom(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            raise RuntimeError("driver down")
+
+        with patch("prompture.dataset.evol.extract_with_model", _boom):
+            evol = EvolInstruct(model="fake")
+            evolved, _ = evol.evolve_pair(_pair("Q?", "A."))
+            assert evolved is None
+
+    def test_evolve_batch_runs_all_operators(self) -> None:
+        outputs = iter(["d1", "b1", "r1", "d2", "b2", "r2"])
+
+        def _fake(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            n = next(outputs)
+            return {
+                "model": QAPair(question=f"Evolved {n}?", answer=f"Answer {n}"),
+                "json_string": "",
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2, "cost": 0.0},
+            }
+
+        with patch("prompture.dataset.evol.extract_with_model", _fake):
+            evol = EvolInstruct(model="fake")
+            result = evol.evolve_batch(
+                [_pair("S1?", "a"), _pair("S2?", "b")],
+                operators=["depth", "breadth", "reasoning"],
+                rounds=1,
+            )
+            assert len(result.evolved) == 6
+            assert result.failures == 0
+            assert result.meta["calls"] == 6
+
+    def test_evolve_batch_rounds_compound(self) -> None:
+        # Two sources × one operator × two rounds = 4 evolved.
+        outputs = iter(["e1", "e2", "e3", "e4"])
+
+        def _fake(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            n = next(outputs)
+            return {
+                "model": QAPair(question=f"Q-{n}?", answer="."),
+                "json_string": "",
+                "usage": {},
+            }
+
+        with patch("prompture.dataset.evol.extract_with_model", _fake):
+            evol = EvolInstruct(model="fake")
+            result = evol.evolve_batch(
+                [_pair("S1?", "a"), _pair("S2?", "b")],
+                operators=["depth"],
+                rounds=2,
+            )
+            assert len(result.evolved) == 4
+
+    def test_init_validates_operator_prompts(self) -> None:
+        with pytest.raises(ValueError, match="depth"):
+            EvolInstruct(model="x", operator_prompts={"breadth": "{question} {answer}"})
+        with pytest.raises(ValueError, match=r"\{question\}"):
+            EvolInstruct(
+                model="x",
+                operator_prompts={
+                    "depth": "no placeholders",
+                    "breadth": "{question} {answer}",
+                    "reasoning": "{question} {answer}",
+                },
+            )
+
+    def test_invalid_operator_arg_raises(self) -> None:
+        with patch("prompture.dataset.evol.extract_with_model", lambda *a, **k: {}):
+            evol = EvolInstruct(model="x")
+            with pytest.raises(ValueError, match="Unknown operator"):
+                evol.evolve_batch([_pair("Q?", "A")], operators=["bogus"])  # type: ignore[list-item]
+
+
+# ---------------------------------------------------------------------------
+# SelfInstruct
+# ---------------------------------------------------------------------------
+
+
+class TestSelfInstruct:
+    def _fake_batch(self, pairs: list[QAPair]) -> Any:
+        from prompture.dataset.schemas import QAPairBatch
+
+        def _make(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {
+                "model": QAPairBatch(pairs=list(pairs)),
+                "json_string": "",
+                "usage": {"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10, "cost": 0.0},
+            }
+
+        return _make
+
+    def test_expand_produces_target_count(self) -> None:
+        new = [_pair(f"Q{i}?", f"A{i}") for i in range(5)]
+        with patch("prompture.dataset.seed.extract_with_model", self._fake_batch(new)):
+            si = SelfInstruct(model="fake", seed_random=__import__("random").Random(0))
+            result = si.expand(
+                [_pair("Seed?", "answer")],
+                target_count=3,
+                batch_size=5,
+            )
+            assert len(result.pairs) == 3
+            # Seeds should not appear in the result.
+            assert all(p.question != "Seed?" for p in result.pairs)
+
+    def test_seed_required(self) -> None:
+        with pytest.raises(ValueError, match="seed"):
+            SelfInstruct(model="x").expand([], target_count=5)
+
+    def test_target_count_bounds(self) -> None:
+        with pytest.raises(ValueError, match="target_count"):
+            SelfInstruct(model="x").expand([_pair("S?", "a")], target_count=0)
+
+    def test_dedup_against_seeds(self) -> None:
+        # Generated pair collides with seed -> dropped.
+        seed = _pair("Match?", "OK.")
+        with patch("prompture.dataset.seed.extract_with_model", self._fake_batch([seed])):
+            si = SelfInstruct(model="fake", seed_random=__import__("random").Random(0))
+            result = si.expand([seed], target_count=2, batch_size=2, max_rounds=2)
+            # The fake always returns the seed itself — every gen gets dropped.
+            assert result.pairs == []
+
+    def test_max_rounds_caps_loop(self) -> None:
+        # Fake returns the SAME pair every call so dedup keeps culling.
+        with patch(
+            "prompture.dataset.seed.extract_with_model",
+            self._fake_batch([_pair("Repeat?", "OK.")]),
+        ):
+            si = SelfInstruct(model="fake", seed_random=__import__("random").Random(0))
+            result = si.expand([_pair("Seed?", "a")], target_count=10, max_rounds=3)
+            # The first round produces one new pair; subsequent rounds find
+            # only duplicates of that pair. We stop at max_rounds = 3.
+            assert result.rounds_completed == 3
+            assert len(result.pairs) == 1
+
+
+# ---------------------------------------------------------------------------
+# generate_qa_dataset wiring
+# ---------------------------------------------------------------------------
+
+
+def _fake_chunker_class():
+    from prompture.rag.chunkers.base import TextChunker
+
+    class _SplitOnPipe(TextChunker):
+        def __init__(self) -> None:
+            super().__init__(chunk_size=1000, chunk_overlap=0)
+
+        def split_text(self, text: str) -> list[str]:
+            return [p.strip() for p in text.split("|") if p.strip()]
+
+    return _SplitOnPipe()
+
+
+class TestGenerateQADatasetWiring:
+    def _stub_extract(self, pairs_per_call: list[QAPair]) -> Any:
+        from prompture.dataset.schemas import QAPairBatch
+
+        def _fake(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {
+                "model": QAPairBatch(pairs=list(pairs_per_call)),
+                "json_string": "",
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "cost": 0.0},
+            }
+
+        return _fake
+
+    def test_personas_multiply_calls(self) -> None:
+        # Two personas, two chunks → 4 extract calls.
+        class _StubPersona:
+            def __init__(self, name: str, voice: str) -> None:
+                self.name = name
+                self._voice = voice
+
+            def render(self) -> str:
+                return self._voice
+
+        calls: list[str] = []
+
+        def _capture(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            from prompture.dataset.schemas import QAPairBatch
+
+            # ``text`` positional captures the rendered prompt.
+            calls.append(args[1] if len(args) > 1 else kwargs.get("text", ""))
+            return {
+                "model": QAPairBatch(pairs=[_pair("Q?", "A.")]),
+                "json_string": "",
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "cost": 0.0},
+            }
+
+        with patch("prompture.dataset.synth.extract_with_model", _capture):
+            doc = Document(content="alpha | beta")
+            pairs = generate_qa_dataset(
+                [doc],
+                model="fake/model",
+                chunker=_fake_chunker_class(),
+                personas=[_StubPersona("p1", "VOICE_ONE"), _StubPersona("p2", "VOICE_TWO")],
+            )
+        # 2 chunks * 2 personas = 4 extraction calls.
+        assert len(calls) == 4
+        # Each persona prefix appears in some prompt.
+        assert any("VOICE_ONE" in p for p in calls)
+        assert any("VOICE_TWO" in p for p in calls)
+        # All 4 pairs come back (default dedup is exact on identical "Q?"),
+        # so we expect 1 after dedup.
+        assert len(pairs) == 1
+
+    def test_quality_filter_drops_junk_pairs(self) -> None:
+        from prompture.dataset.schemas import QAPairBatch
+
+        # First call returns 2 pairs: one good, one junk.
+        def _fake(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {
+                "model": QAPairBatch(
+                    pairs=[
+                        _pair("What is the capital of France?", "Paris."),
+                        _pair("", "junk"),  # empty Q → dropped by shape_filter
+                    ]
+                ),
+                "json_string": "",
+                "usage": {},
+            }
+
+        with patch("prompture.dataset.synth.extract_with_model", _fake):
+            doc = Document(content="single chunk")
+            result, stats = generate_qa_dataset(
+                [doc],
+                model="fake",
+                chunker=_fake_chunker_class(),
+                quality_filter=QualityFilter(),
+                return_stats=True,
+            )
+        assert len(result) == 1
+        assert stats["filter"]["dropped"] == 1
+        assert stats["filter"]["total_in"] == 2
+
+    def test_dedup_config_supersedes_legacy_dedupe(self) -> None:
+        from prompture.dataset.schemas import QAPairBatch
+
+        # 3 identical pairs across one chunk.
+        def _fake(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {
+                "model": QAPairBatch(
+                    pairs=[
+                        _pair("Same Q?", "A1."),
+                        _pair("Same Q?", "A2."),
+                        _pair("Same Q?", "A3."),
+                    ]
+                ),
+                "json_string": "",
+                "usage": {},
+            }
+
+        with patch("prompture.dataset.synth.extract_with_model", _fake):
+            doc = Document(content="single chunk")
+            # dedup=None_strategy means no dedup; legacy `dedupe=True` ignored.
+            pairs = generate_qa_dataset(
+                [doc],
+                model="fake",
+                chunker=_fake_chunker_class(),
+                dedup=DedupConfig(strategy="none"),
+                dedupe=True,  # would be exact by itself; superseded
+            )
+            assert len(pairs) == 3
+
+    def test_return_stats_shape(self) -> None:
+        from prompture.dataset.schemas import QAPairBatch
+
+        def _fake(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {
+                "model": QAPairBatch(pairs=[_pair("Q?", "A.")]),
+                "json_string": "",
+                "usage": {},
+            }
+
+        with patch("prompture.dataset.synth.extract_with_model", _fake):
+            doc = Document(content="x")
+            pairs, stats = generate_qa_dataset(
+                [doc],
+                model="fake",
+                chunker=_fake_chunker_class(),
+                return_stats=True,
+            )
+            assert isinstance(pairs, list)
+            assert "raw_count" in stats
+
+
+# ---------------------------------------------------------------------------
+# Package exports
+# ---------------------------------------------------------------------------
+
+
+class TestDatasetExports:
+    def test_all_new_symbols_exported(self) -> None:
+        from prompture.dataset import (  # noqa: F401
+            DedupConfig,
+            EvolInstruct,
+            EvolResult,
+            FilterDecision,
+            FilterStats,
+            QualityFilter,
+            SelfInstruct,
+            SelfInstructResult,
+            apply_dedup,
+            dedup_exact,
+            dedup_semantic,
+            dedup_shingle,
+            length_filter,
+            refusal_filter,
+            shape_filter,
+        )

--- a/tests/test_robust_conversion.py
+++ b/tests/test_robust_conversion.py
@@ -194,10 +194,12 @@ class TestConvertValueUnionTypes:
     def test_optional_type_conversion(self):
         """Test conversion with Optional types."""
         # Optional[int] is Union[int, None]
-        result = convert_value("42", Optional[int])
+        # Note: deliberately using the legacy ``Optional`` form to verify
+        # ``convert_value`` still handles it; ``X | None`` is the modern style.
+        result = convert_value("42", Optional[int])  # noqa: UP045
         assert result == 42
 
-        result = convert_value(None, Optional[int])
+        result = convert_value(None, Optional[int])  # noqa: UP045
         assert result is None
 
 

--- a/tests/test_session_memory.py
+++ b/tests/test_session_memory.py
@@ -1,0 +1,272 @@
+"""Tests for prompture.session_memory."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from prompture.session_memory import (
+    InMemorySessionStore,
+    MemoryFact,
+    MemoryKind,
+    SessionMemory,
+    SQLiteSessionStore,
+    default_summarizer,
+)
+
+# ----------------------------------------------------------------------
+# MemoryFact
+# ----------------------------------------------------------------------
+
+
+class TestMemoryFact:
+    def test_default_ids_unique(self) -> None:
+        a = MemoryFact(user_id="u", content="x")
+        b = MemoryFact(user_id="u", content="x")
+        assert a.id != b.id
+
+    def test_round_trip_dict(self) -> None:
+        f = MemoryFact(user_id="u", content="x", kind=MemoryKind.preference.value, importance=0.9)
+        f2 = MemoryFact.from_dict(f.to_dict())
+        assert f2.id == f.id
+        assert f2.kind == MemoryKind.preference.value
+        assert f2.importance == 0.9
+
+
+# ----------------------------------------------------------------------
+# InMemorySessionStore
+# ----------------------------------------------------------------------
+
+
+class TestInMemoryStore:
+    def test_add_and_list_isolates_users(self) -> None:
+        store = InMemorySessionStore()
+        store.add(MemoryFact(user_id="alice", content="a"))
+        store.add(MemoryFact(user_id="bob", content="b"))
+        assert len(store.list("alice")) == 1
+        assert len(store.list("bob")) == 1
+        assert store.list("alice")[0].content == "a"
+
+    def test_session_filter(self) -> None:
+        store = InMemorySessionStore()
+        store.add(MemoryFact(user_id="u", session_id="s1", content="one"))
+        store.add(MemoryFact(user_id="u", session_id="s2", content="two"))
+        store.add(MemoryFact(user_id="u", content="user-wide"))
+        assert [f.content for f in store.list("u", session_id="s1")] == ["one"]
+        assert [f.content for f in store.list("u", session_id="__user__")] == ["user-wide"]
+        # session_id=None means "any" session
+        assert {f.content for f in store.list("u")} == {"one", "two", "user-wide"}
+
+    def test_kind_filter(self) -> None:
+        store = InMemorySessionStore()
+        store.add(MemoryFact(user_id="u", content="a", kind="fact"))
+        store.add(MemoryFact(user_id="u", content="b", kind="preference"))
+        out = store.list("u", kinds=("preference",))
+        assert [f.content for f in out] == ["b"]
+
+    def test_upsert_by_id(self) -> None:
+        store = InMemorySessionStore()
+        f = MemoryFact(id="fixed", user_id="u", content="old")
+        store.add(f)
+        store.add(MemoryFact(id="fixed", user_id="u", content="new"))
+        results = store.list("u")
+        assert len(results) == 1
+        assert results[0].content == "new"
+
+    def test_search_scores_overlap_and_importance(self) -> None:
+        store = InMemorySessionStore()
+        store.add(MemoryFact(user_id="u", content="paris france travel", importance=0.1))
+        store.add(MemoryFact(user_id="u", content="paris food guide", importance=0.9))
+        store.add(MemoryFact(user_id="u", content="berlin trip", importance=0.5))
+        out = store.search("u", "paris food")
+        assert out[0].content == "paris food guide"
+        assert {f.content for f in out} == {"paris food guide", "paris france travel"}
+
+    def test_search_empty_query_returns_recent(self) -> None:
+        store = InMemorySessionStore()
+        store.add(MemoryFact(user_id="u", content="a", ts=time.time() - 100))
+        store.add(MemoryFact(user_id="u", content="b", ts=time.time()))
+        out = store.search("u", "", k=5)
+        assert [f.content for f in out] == ["a", "b"]
+
+    def test_delete_by_session(self) -> None:
+        store = InMemorySessionStore()
+        store.add(MemoryFact(user_id="u", session_id="s1", content="a"))
+        store.add(MemoryFact(user_id="u", session_id="s1", content="b"))
+        store.add(MemoryFact(user_id="u", session_id="s2", content="c"))
+        removed = store.delete("u", session_id="s1")
+        assert removed == 2
+        assert [f.content for f in store.list("u")] == ["c"]
+
+    def test_delete_by_fact_id(self) -> None:
+        store = InMemorySessionStore()
+        f = MemoryFact(user_id="u", content="a")
+        store.add(f)
+        store.add(MemoryFact(user_id="u", content="b"))
+        assert store.delete("u", fact_id=f.id) == 1
+        assert [f.content for f in store.list("u")] == ["b"]
+
+    def test_delete_requires_filter(self) -> None:
+        store = InMemorySessionStore()
+        with pytest.raises(ValueError, match="Refusing"):
+            store.delete("u")
+
+
+# ----------------------------------------------------------------------
+# SQLiteSessionStore
+# ----------------------------------------------------------------------
+
+
+class TestSQLiteStore:
+    def test_add_and_list(self, tmp_path) -> None:
+        store = SQLiteSessionStore(db_path=tmp_path / "mem.db")
+        store.add(MemoryFact(user_id="alice", content="hello"))
+        out = store.list("alice")
+        assert len(out) == 1
+        assert out[0].content == "hello"
+
+    def test_persistence_across_instances(self, tmp_path) -> None:
+        path = tmp_path / "mem.db"
+        s1 = SQLiteSessionStore(db_path=path)
+        s1.add(MemoryFact(user_id="alice", content="persist me"))
+        s2 = SQLiteSessionStore(db_path=path)
+        out = s2.list("alice")
+        assert len(out) == 1
+        assert out[0].content == "persist me"
+
+    def test_search(self, tmp_path) -> None:
+        store = SQLiteSessionStore(db_path=tmp_path / "mem.db")
+        store.add(MemoryFact(user_id="u", content="weather is sunny"))
+        store.add(MemoryFact(user_id="u", content="tax is increasing"))
+        out = store.search("u", "weather")
+        assert len(out) == 1
+        assert "weather" in out[0].content
+
+    def test_delete_by_session(self, tmp_path) -> None:
+        store = SQLiteSessionStore(db_path=tmp_path / "mem.db")
+        store.add(MemoryFact(user_id="u", session_id="s1", content="a"))
+        store.add(MemoryFact(user_id="u", session_id="s2", content="b"))
+        assert store.delete("u", session_id="s1") == 1
+        remaining = [f.content for f in store.list("u")]
+        assert remaining == ["b"]
+
+    def test_metadata_round_trip(self, tmp_path) -> None:
+        store = SQLiteSessionStore(db_path=tmp_path / "mem.db")
+        store.add(MemoryFact(user_id="u", content="x", metadata={"foo": 1, "bar": [1, 2]}))
+        out = store.list("u")
+        assert out[0].metadata == {"foo": 1, "bar": [1, 2]}
+
+
+# ----------------------------------------------------------------------
+# SessionMemory high-level API
+# ----------------------------------------------------------------------
+
+
+class TestSessionMemory:
+    def test_remember_writes_user_wide_by_default(self) -> None:
+        mem = SessionMemory(user_id="alice", session_id="s1")
+        f = mem.remember("loves espresso", kind=MemoryKind.preference.value)
+        assert f.user_id == "alice"
+        assert f.session_id is None  # user-wide
+
+    def test_remember_session_scoped(self) -> None:
+        mem = SessionMemory(user_id="alice", session_id="s1")
+        f = mem.remember("booked flight to Paris", session_scoped=True)
+        assert f.session_id == "s1"
+
+    def test_recall_merges_session_and_user_wide(self) -> None:
+        store = InMemorySessionStore()
+        mem = SessionMemory(user_id="u", session_id="s1", store=store)
+        mem.remember("alice loves dark mode")  # user-wide
+        mem.remember("currently booking paris flight", session_scoped=True)
+        hits = mem.recall("paris")
+        assert any("paris" in f.content for f in hits)
+        hits2 = mem.recall("dark")
+        assert any("dark mode" in f.content for f in hits2)
+
+    def test_recall_excluding_user_wide(self) -> None:
+        store = InMemorySessionStore()
+        mem = SessionMemory(user_id="u", session_id="s1", store=store)
+        mem.remember("user-wide fact about coffee")
+        mem.remember("session note about coffee", session_scoped=True)
+        only_session = mem.recall("coffee", include_user_wide=False)
+        # All hits should belong to this session
+        assert all(f.session_id == "s1" for f in only_session)
+
+    def test_render_for_prompt_relevance(self) -> None:
+        mem = SessionMemory(user_id="u", session_id="s1")
+        mem.remember("Pref: concise answers", kind=MemoryKind.preference.value)
+        mem.remember("Pref: avoid emojis", kind=MemoryKind.preference.value)
+        text = mem.render_for_prompt("emojis")
+        assert "Long-term memory" in text
+        assert "avoid emojis" in text
+
+    def test_render_for_prompt_empty(self) -> None:
+        mem = SessionMemory(user_id="u")
+        assert mem.render_for_prompt("anything") == ""
+
+    def test_render_for_prompt_recent_when_no_query(self) -> None:
+        mem = SessionMemory(user_id="u", recall_k=2)
+        mem.remember("one")
+        mem.remember("two")
+        mem.remember("three")
+        text = mem.render_for_prompt()
+        assert "two" in text
+        assert "three" in text
+        assert "one" not in text
+
+    def test_forget(self) -> None:
+        mem = SessionMemory(user_id="u")
+        f = mem.remember("to delete")
+        assert mem.forget(f.id) is True
+        assert mem.forget("nope") is False
+
+    def test_clear_session(self) -> None:
+        mem = SessionMemory(user_id="u", session_id="s1")
+        mem.remember("user-wide")
+        mem.remember("session", session_scoped=True)
+        removed = mem.clear_session()
+        assert removed == 1
+        remaining = mem.all()
+        assert [f.content for f in remaining] == ["user-wide"]
+
+    def test_clear_session_without_session_id_clears_user_wide(self) -> None:
+        mem = SessionMemory(user_id="u")
+        mem.remember("user-wide")
+        removed = mem.clear_session()
+        assert removed == 1
+        assert mem.all() == []
+
+    def test_summarize_uses_default_summarizer(self) -> None:
+        mem = SessionMemory(user_id="u", session_id="s1")
+        msgs = [
+            {"role": "user", "content": "first message"},
+            {"role": "assistant", "content": "reply"},
+            {"role": "user", "content": "last message"},
+        ]
+        f = mem.summarize(msgs)
+        assert f is not None
+        assert f.kind == MemoryKind.summary.value
+        assert "first message" in f.content or "last message" in f.content
+        assert f.metadata["message_count"] == 3
+
+    def test_summarize_empty_returns_none(self) -> None:
+        mem = SessionMemory(user_id="u")
+        assert mem.summarize([]) is None
+
+    def test_summarize_with_custom_summarizer(self) -> None:
+        mem = SessionMemory(user_id="u")
+        f = mem.summarize(
+            [{"role": "user", "content": "hi"}],
+            summarizer=lambda msgs: f"CUSTOM:{len(msgs)}",
+        )
+        assert f is not None
+        assert f.content == "CUSTOM:1"
+
+    def test_default_summarizer_handles_no_user_messages(self) -> None:
+        assert default_summarizer([{"role": "assistant", "content": "hi"}]) == ""
+
+    def test_empty_user_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match="user_id"):
+            SessionMemory(user_id="")

--- a/tests/test_swarm.py
+++ b/tests/test_swarm.py
@@ -1,0 +1,565 @@
+"""Tests for the prompture.swarm runtime."""
+
+from __future__ import annotations
+
+import random
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from prompture.agents.types import AgentResult, AgentState
+from prompture.groups.types import ErrorPolicy
+from prompture.swarm import (
+    AllScheduler,
+    CallableScheduler,
+    Environment,
+    Event,
+    InMemoryStore,
+    PriorityScheduler,
+    RoundRobinScheduler,
+    SampleScheduler,
+    Swarm,
+    SwarmAgent,
+    SwarmCallbacks,
+)
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _mock_agent(name: str, outputs: list[str] | None = None) -> MagicMock:
+    """Create a MagicMock agent that returns successive canned outputs."""
+    outputs = outputs or [f"{name}-output"]
+    agent = MagicMock()
+    agent._counter = 0
+
+    def _run(prompt: str, **_: Any) -> AgentResult:
+        idx = min(agent._counter, len(outputs) - 1)
+        agent._counter += 1
+        text = outputs[idx]
+        return AgentResult(
+            output=text,
+            output_text=text,
+            messages=[],
+            usage={},
+            state=AgentState.idle,
+            run_usage={
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+                "total_cost": 0.001,
+            },
+        )
+
+    agent.run.side_effect = _run
+    agent.name = name
+    return agent
+
+
+def _make_swarm_agent(
+    name: str,
+    outputs: list[str] | None = None,
+    **kwargs: Any,
+) -> SwarmAgent:
+    inner = _mock_agent(name, outputs)
+    return SwarmAgent(agent=inner, name=name, **kwargs)
+
+
+# ----------------------------------------------------------------------
+# Environment
+# ----------------------------------------------------------------------
+
+
+class TestEnvironment:
+    def test_emit_and_events(self) -> None:
+        env = Environment()
+        env.advance_tick()
+        ev = env.emit("alice", "hello", kind="say")
+        assert isinstance(ev, Event)
+        assert ev.tick == 1
+        assert ev.agent_id == "alice"
+        assert env.events[0].content == "hello"
+
+    def test_broadcast_visible_to_all(self) -> None:
+        env = Environment()
+        env.emit("alice", "broadcast")
+        assert len(env.events_for("bob")) == 1
+        assert len(env.events_for("carol")) == 1
+
+    def test_targeted_visible_only_to_targets_and_author(self) -> None:
+        env = Environment()
+        env.emit("alice", "private", targets=("bob",))
+        assert len(env.events_for("bob")) == 1
+        assert len(env.events_for("carol")) == 0
+        # Author always sees their own when include_own=True (default)
+        assert len(env.events_for("alice")) == 1
+        # ...but not when include_own=False
+        assert len(env.events_for("alice", include_own=False)) == 0
+
+    def test_since_tick_filter(self) -> None:
+        env = Environment()
+        env.advance_tick()
+        env.emit("a", "t1")
+        env.advance_tick()
+        env.emit("a", "t2")
+        recent = env.events_for("b", since_tick=2)
+        assert len(recent) == 1
+        assert recent[0].content == "t2"
+
+    def test_kind_and_topic_filter(self) -> None:
+        env = Environment()
+        env.emit("a", "x", kind="say", topic="news")
+        env.emit("a", "y", kind="act", topic="news")
+        env.emit("a", "z", kind="say", topic="weather")
+        out = env.events_for("b", kinds=("say",), topics=("news",))
+        assert len(out) == 1
+        assert out[0].content == "x"
+
+    def test_state_and_callbacks(self) -> None:
+        state_log: list[tuple[str, Any]] = []
+        event_log: list[Event] = []
+        env = Environment(
+            initial_state={"weather": "sunny"},
+            on_state_update=lambda k, v: state_log.append((k, v)),
+            on_event=lambda e: event_log.append(e),
+        )
+        assert env.get("weather") == "sunny"
+        env.set("weather", "rain")
+        env.emit("a", "hi")
+        assert state_log == [("weather", "rain")]
+        assert len(event_log) == 1
+
+    def test_seed_helper(self) -> None:
+        env = Environment()
+        env.seed("the news")
+        ev = env.events[0]
+        assert ev.kind == "seed"
+        assert ev.agent_id == "__env__"
+        assert ev.content == "the news"
+
+    def test_last_n_caps_results(self) -> None:
+        env = Environment()
+        for i in range(5):
+            env.emit("a", f"msg{i}")
+        out = env.events_for("b", last_n=2)
+        assert [e.content for e in out] == ["msg3", "msg4"]
+
+
+# ----------------------------------------------------------------------
+# Memory
+# ----------------------------------------------------------------------
+
+
+class TestInMemoryStore:
+    def test_add_and_recent(self) -> None:
+        m = InMemoryStore()
+        m.add("alice", "first")
+        m.add("alice", "second")
+        m.add("alice", "third")
+        recent = m.recent("alice", k=2)
+        assert [r.content for r in recent] == ["second", "third"]
+
+    def test_search_returns_keyword_matches(self) -> None:
+        m = InMemoryStore()
+        m.add("alice", "the weather is sunny")
+        m.add("alice", "tax policy is changing")
+        m.add("alice", "weather forecast next week")
+        out = m.search("alice", "weather")
+        assert len(out) == 2
+        assert all("weather" in r.content for r in out)
+
+    def test_search_empty_query_falls_back_to_recent(self) -> None:
+        m = InMemoryStore()
+        m.add("alice", "one")
+        m.add("alice", "two")
+        out = m.search("alice", "")
+        assert [r.content for r in out] == ["one", "two"]
+
+    def test_per_agent_isolation(self) -> None:
+        m = InMemoryStore()
+        m.add("alice", "alice secret")
+        m.add("bob", "bob secret")
+        assert len(m.recent("alice")) == 1
+        assert len(m.recent("bob")) == 1
+        assert m.recent("alice")[0].content == "alice secret"
+
+    def test_clear(self) -> None:
+        m = InMemoryStore()
+        m.add("alice", "a")
+        m.add("bob", "b")
+        m.clear("alice")
+        assert m.recent("alice") == []
+        assert len(m.recent("bob")) == 1
+        m.clear()
+        assert m.recent("bob") == []
+
+
+# ----------------------------------------------------------------------
+# Schedulers
+# ----------------------------------------------------------------------
+
+
+class TestSchedulers:
+    def test_all_scheduler_returns_every_agent(self) -> None:
+        env = Environment()
+        agents = [_make_swarm_agent(f"a{i}") for i in range(3)]
+        out = AllScheduler().select(agents, env, 1)
+        assert out == agents
+
+    def test_sample_scheduler_returns_k_distinct(self) -> None:
+        env = Environment()
+        agents = [_make_swarm_agent(f"a{i}") for i in range(5)]
+        rng = random.Random(42)
+        out = SampleScheduler(k=3, rng=rng).select(agents, env, 1)
+        assert len(out) == 3
+        assert len({a.name for a in out}) == 3
+
+    def test_sample_scheduler_clamps_to_population(self) -> None:
+        env = Environment()
+        agents = [_make_swarm_agent(f"a{i}") for i in range(2)]
+        out = SampleScheduler(k=10).select(agents, env, 1)
+        assert len(out) == 2
+
+    def test_round_robin_rotates(self) -> None:
+        env = Environment()
+        agents = [_make_swarm_agent(f"a{i}") for i in range(3)]
+        sched = RoundRobinScheduler()
+        picks = [sched.select(agents, env, t)[0].name for t in range(1, 5)]
+        assert picks == ["a0", "a1", "a2", "a0"]
+
+    def test_round_robin_batch(self) -> None:
+        env = Environment()
+        agents = [_make_swarm_agent(f"a{i}") for i in range(4)]
+        sched = RoundRobinScheduler(batch_size=2)
+        out1 = [a.name for a in sched.select(agents, env, 1)]
+        out2 = [a.name for a in sched.select(agents, env, 2)]
+        assert out1 == ["a0", "a1"]
+        assert out2 == ["a2", "a3"]
+
+    def test_priority_scheduler_filters_and_orders(self) -> None:
+        env = Environment()
+        a = _make_swarm_agent("a", priority=0.0)
+        b = _make_swarm_agent("b", priority=3.0)
+        c = _make_swarm_agent("c", priority=2.0)
+        sched = PriorityScheduler(lambda a, e, t: a.priority, threshold=1.0)
+        out = sched.select([a, b, c], env, 1)
+        assert [x.name for x in out] == ["b", "c"]
+
+    def test_priority_scheduler_max_active(self) -> None:
+        env = Environment()
+        agents = [_make_swarm_agent(f"a{i}", priority=float(i + 1)) for i in range(4)]
+        sched = PriorityScheduler(lambda a, e, t: a.priority, max_active=2)
+        out = sched.select(agents, env, 1)
+        assert [x.name for x in out] == ["a3", "a2"]
+
+    def test_callable_scheduler(self) -> None:
+        env = Environment()
+        agents = [_make_swarm_agent(f"a{i}") for i in range(3)]
+        sched = CallableScheduler(lambda ags, e, t: [a for a in ags if a.name != "a1"])
+        out = sched.select(agents, env, 1)
+        assert [x.name for x in out] == ["a0", "a2"]
+
+
+# ----------------------------------------------------------------------
+# SwarmAgent
+# ----------------------------------------------------------------------
+
+
+class TestSwarmAgent:
+    def test_default_observe_includes_role_and_events(self) -> None:
+        env = Environment()
+        env.seed("breaking news")
+        sa = _make_swarm_agent("alice", role="reporter")
+        obs = sa.build_observation(env, tick=1)
+        assert "alice" in obs
+        assert "reporter" in obs
+        assert "breaking news" in obs
+
+    def test_default_observe_includes_memory(self) -> None:
+        env = Environment()
+        memory = InMemoryStore()
+        memory.add("alice", "I covered taxes last year")
+        sa = _make_swarm_agent("alice", memory=memory)
+        obs = sa.build_observation(env, tick=1)
+        assert "taxes last year" in obs
+
+    def test_default_observe_filters_by_kind(self) -> None:
+        env = Environment()
+        env.emit("bob", "loud", kind="shout")
+        env.emit("bob", "quiet", kind="say")
+        sa = _make_swarm_agent("alice", observe_kinds=("say",))
+        obs = sa.build_observation(env, tick=1)
+        assert "quiet" in obs
+        assert "loud" not in obs
+
+    def test_run_step_emits_event_and_records_tick(self) -> None:
+        env = Environment()
+        sa = _make_swarm_agent("alice", outputs=["I disagree"])
+        sa.run_step(env, tick=1, prompt="React.")
+        assert sa._last_acted_tick == 1
+        assert len(env.events) == 1
+        assert env.events[0].content == "I disagree"
+        assert env.events[0].agent_id == "alice"
+
+    def test_run_step_writes_memory(self) -> None:
+        env = Environment()
+        memory = InMemoryStore()
+        sa = _make_swarm_agent("alice", outputs=["a fresh take"], memory=memory)
+        sa.run_step(env, tick=1, prompt="React.")
+        recent = memory.recent("alice")
+        assert len(recent) == 1
+        assert recent[0].content == "a fresh take"
+        assert recent[0].tick == 1
+
+    def test_custom_post_act_overrides_default(self) -> None:
+        env = Environment()
+        called: list[str] = []
+
+        def custom_post_act(agent, result, env, tick):
+            called.append(result.output_text)
+            env.emit(agent.name, f"transformed: {result.output_text}", kind="custom")
+
+        sa = _make_swarm_agent("alice", outputs=["raw"], post_act=custom_post_act)
+        sa.run_step(env, tick=1, prompt="React.")
+        assert called == ["raw"]
+        assert env.events[0].kind == "custom"
+        assert env.events[0].content == "transformed: raw"
+
+
+# ----------------------------------------------------------------------
+# Swarm
+# ----------------------------------------------------------------------
+
+
+class TestSwarm:
+    def test_runs_max_ticks(self) -> None:
+        agents = [
+            _make_swarm_agent("a", outputs=["a1", "a2", "a3"]),
+            _make_swarm_agent("b", outputs=["b1", "b2", "b3"]),
+        ]
+        swarm = Swarm(agents=agents, max_ticks=3)
+        result = swarm.run(seed="go")
+        assert result.ticks_run == 3
+        assert result.success
+        # 2 agents x 3 ticks
+        assert len(result.timeline) == 6
+        # seed + 6 say events
+        assert len(result.events) == 7
+
+    def test_aggregate_usage(self) -> None:
+        agents = [_make_swarm_agent("a"), _make_swarm_agent("b")]
+        swarm = Swarm(agents=agents, max_ticks=2)
+        result = swarm.run()
+        assert result.aggregate_usage["total_tokens"] == 15 * 4
+        assert result.aggregate_usage["total_cost"] == pytest.approx(0.001 * 4)
+
+    def test_duplicate_names_rejected(self) -> None:
+        agents = [_make_swarm_agent("a"), _make_swarm_agent("a")]
+        with pytest.raises(ValueError, match="Duplicate"):
+            Swarm(agents=agents)
+
+    def test_empty_agents_rejected(self) -> None:
+        with pytest.raises(ValueError, match="at least one"):
+            Swarm(agents=[])
+
+    def test_stop_when(self) -> None:
+        agents = [_make_swarm_agent("a")]
+        swarm = Swarm(agents=agents, max_ticks=10, stop_when=lambda env, t: t > 2)
+        result = swarm.run()
+        assert result.ticks_run == 2
+        assert "stop_when" in (result.stopped_reason or "")
+
+    def test_stop_method(self) -> None:
+        agents = [_make_swarm_agent("a"), _make_swarm_agent("b")]
+        swarm: Swarm | None = None
+
+        def on_tick_complete(tick: int) -> None:
+            assert swarm is not None
+            if tick == 2:
+                swarm.stop("external halt")
+
+        swarm = Swarm(
+            agents=agents,
+            max_ticks=10,
+            callbacks=SwarmCallbacks(on_tick_complete=on_tick_complete),
+        )
+        result = swarm.run()
+        assert result.ticks_run == 2
+        assert result.stopped_reason == "external halt"
+
+    def test_fail_fast_on_error(self) -> None:
+        good = _make_swarm_agent("good")
+        bad = MagicMock()
+        bad.run.side_effect = RuntimeError("boom")
+        bad_sa = SwarmAgent(agent=bad, name="bad")
+        swarm = Swarm(agents=[good, bad_sa], max_ticks=3)
+        result = swarm.run()
+        assert not result.success
+        assert result.errors
+        assert result.errors[0][0] == "bad"
+        # fail_fast: ends after first errored tick
+        assert result.ticks_run == 1
+
+    def test_continue_on_error(self) -> None:
+        good = _make_swarm_agent("good")
+        bad = MagicMock()
+        bad.run.side_effect = RuntimeError("boom")
+        bad_sa = SwarmAgent(agent=bad, name="bad")
+        swarm = Swarm(
+            agents=[good, bad_sa],
+            max_ticks=2,
+            error_policy=ErrorPolicy.continue_on_error,
+        )
+        result = swarm.run()
+        assert not result.success
+        assert len(result.errors) == 2  # bad errors both ticks
+        assert result.ticks_run == 2
+
+    def test_raise_on_error(self) -> None:
+        bad = MagicMock()
+        bad.run.side_effect = RuntimeError("boom")
+        swarm = Swarm(
+            agents=[SwarmAgent(agent=bad, name="bad")],
+            max_ticks=3,
+            error_policy=ErrorPolicy.raise_on_error,
+        )
+        with pytest.raises(RuntimeError, match="boom"):
+            swarm.run()
+
+    def test_round_robin_scheduling(self) -> None:
+        agents = [
+            _make_swarm_agent("a", outputs=["a"] * 10),
+            _make_swarm_agent("b", outputs=["b"] * 10),
+            _make_swarm_agent("c", outputs=["c"] * 10),
+        ]
+        swarm = Swarm(agents=agents, scheduler=RoundRobinScheduler(), max_ticks=4)
+        result = swarm.run()
+        actors = [s.agent_id for s in result.timeline]
+        assert actors == ["a", "b", "c", "a"]
+
+    def test_default_memory_applied_to_agents(self) -> None:
+        memory = InMemoryStore()
+        agents = [_make_swarm_agent("a"), _make_swarm_agent("b")]
+        swarm = Swarm(agents=agents, memory=memory, max_ticks=1)
+        swarm.run()
+        assert memory.recent("a")
+        assert memory.recent("b")
+
+    def test_per_agent_memory_not_overridden(self) -> None:
+        global_mem = InMemoryStore()
+        local_mem = InMemoryStore()
+        agents = [
+            _make_swarm_agent("a", memory=local_mem),
+            _make_swarm_agent("b"),
+        ]
+        Swarm(agents=agents, memory=global_mem, max_ticks=1).run()
+        # a kept its own memory store
+        assert local_mem.recent("a")
+        assert not global_mem.recent("a")
+        # b inherited the default
+        assert global_mem.recent("b")
+
+    def test_callbacks_fire(self) -> None:
+        ticks_started: list[int] = []
+        agents_completed: list[str] = []
+        events_seen: list[Event] = []
+        swarm = Swarm(
+            agents=[_make_swarm_agent("a")],
+            max_ticks=2,
+            callbacks=SwarmCallbacks(
+                on_tick_start=lambda t, names: ticks_started.append(t),
+                on_agent_complete=lambda name, r, t: agents_completed.append(name),
+                on_event=lambda e: events_seen.append(e),
+            ),
+        )
+        swarm.run(seed="hi")
+        assert ticks_started == [1, 2]
+        assert agents_completed == ["a", "a"]
+        # seed + 2 say events
+        assert len(events_seen) == 3
+
+    def test_budget_cap_stops_run(self) -> None:
+        agents = [_make_swarm_agent("a"), _make_swarm_agent("b")]
+        # Each agent run costs 0.001; cap at 0.0025 → run for 2 agents on tick 1
+        # then bail at the start of tick 2.
+        swarm = Swarm(agents=agents, max_ticks=5, max_total_cost=0.0025)
+        result = swarm.run()
+        assert result.stopped_reason is not None
+        assert "budget" in result.stopped_reason
+
+    def test_action_prompt_callable(self) -> None:
+        captured: list[str] = []
+
+        def custom_observe(agent, env, tick):
+            captured.append(agent._pending_prompt)
+            return agent._pending_prompt
+
+        agent = _make_swarm_agent("a", observe=custom_observe)
+        swarm = Swarm(
+            agents=[agent],
+            action_prompt=lambda env, tick: f"tick {tick} go",
+            max_ticks=2,
+        )
+        swarm.run()
+        assert captured == ["tick 1 go", "tick 2 go"]
+
+    def test_action_prompt_template(self) -> None:
+        captured: list[str] = []
+
+        def custom_observe(agent, env, tick):
+            captured.append(agent._pending_prompt)
+            return agent._pending_prompt
+
+        agent = _make_swarm_agent("a", observe=custom_observe)
+        swarm = Swarm(agents=[agent], action_prompt="go tick={tick}", max_ticks=2)
+        swarm.run()
+        assert captured == ["go tick=1", "go tick=2"]
+
+    def test_result_export_serialises(self) -> None:
+        swarm = Swarm(agents=[_make_swarm_agent("a")], max_ticks=1)
+        result = swarm.run(seed="hi")
+        export = result.export()
+        assert export["ticks_run"] == 1
+        assert export["success"] is True
+        assert export["events"][0]["kind"] == "seed"
+        assert export["timeline"][0]["agent_id"] == "a"
+
+
+# ----------------------------------------------------------------------
+# End-to-end interaction scenario
+# ----------------------------------------------------------------------
+
+
+def test_two_agent_dialogue_uses_each_others_events() -> None:
+    """The second agent's observation includes the first agent's emission."""
+    seen_by_bob: list[str] = []
+
+    def alice_observe(agent, env, tick):
+        return agent._pending_prompt  # noop
+
+    def bob_observe(agent, env, tick):
+        events = env.events_for(agent.name)
+        seen_by_bob.append(" | ".join(e.content for e in events))
+        return agent._pending_prompt
+
+    alice = SwarmAgent(
+        agent=_mock_agent("alice", ["alice says hi"]),
+        name="alice",
+        observe=alice_observe,
+    )
+    bob = SwarmAgent(
+        agent=_mock_agent("bob", ["bob says yo"]),
+        name="bob",
+        observe=bob_observe,
+    )
+
+    swarm = Swarm(agents=[alice, bob], max_ticks=1)
+    result = swarm.run(seed="hello world")
+
+    # Bob's observation step happens after Alice's emission this tick,
+    # so it should include the seed + alice's say.
+    assert seen_by_bob == ["hello world | alice says hi"]
+    assert result.success
+    assert len(result.events) == 3  # seed + 2 says


### PR DESCRIPTION
Eighteen commits, eight phases, and one PEP-604 paper cut. This pulls in the structured/agentic pieces the library was missing — live event streaming for tool calls (the "Claude Code feel"), deep-research building blocks (citations, session memory, checkpoints, knowledge graph), a Swarm multi-agent runtime, three new query-side RAG retrievers, an LLM-as-judge eval framework, synthetic dataset modernization, vLLM constrained decoding, Claude prompt caching, and a stack of typing / lint / code-quality cleanups on top.

### Highlights

- Conversations gain `ask_live(...)` — text and tool calls now interleave as a stream of events, so agents narrate between actions instead of stalling, then dumping everything at once.
- Anthropic prompt caching is on by default for Claude drivers. Long system prompts and tool bundles get cached automatically; repeat input costs drop to roughly 10% of normal, with `cache_prompt: False` to opt out.
- New deep-research toolkit: inline citations with provenance, session memory with summarization, run checkpoints, and a knowledge graph — each with an in-memory + SQLite store.
- New Swarm multi-agent runtime: coordinated agents with shared environment, memory, and pluggable schedulers (round-robin, priority, sample, all, callable).
- Three new query-side RAG retrievers (HyDE, MultiQuery, StepBack) plus a `ContextualChunker` that prepends per-chunk context, plus few-shot example selection for `extract_with_model`.
- LLM-as-judge evaluation framework: single-answer, pairwise, faithfulness, and self-consistency evaluators.
- Constrained decoding on vLLM-style backends: `options={"guided_decoding": "xgrammar"}` flips on logit-FSM sampling for any OpenAI-compatible driver, with an `extra_body` escape hatch for everything else.
- Partial-JSON streaming surfaces the extraction as it's built, and the extraction retry loop now feeds the schema validation error back to the model rather than just retrying blindly.
- Synthetic dataset pipeline: seed (Self-Instruct), evol (Evol-Instruct), filter, and dedup stages — composable end-to-end.
- Reranker arg now accepts a `"provider/model"` string, matching every other model param in the library.
- Optional fields written as `str | None` no longer get silently coerced to `None` — the PEP-604 union form is finally a first-class citizen.
- Bad provider credentials now raise `ConfigurationError` at driver construction instead of surfacing as a cryptic SDK error on the first call.
- **Breaking:** Python 3.10+ is now required (was 3.9). The typing modernisation across the codebase needs it.

<details>
<summary>Technical changes</summary>

**Live agentic event streaming**
- New `prompture/agents/live_events.py` with frozen dataclasses: `AssistantTurnStart`, `TextDelta`, `ThinkingDelta`, `ToolUseStart`, `ToolInputDelta`, `ToolUseStop`, `ToolResult`, `MessageStop`, `TurnComplete`.
- `Conversation.ask_live` and `AsyncConversation.ask_live` drive the agentic loop, forwarding driver events and emitting `ToolResult` after each tool execution.
- Base `Driver.generate_messages_with_tools_stream` provides a default synthetic event sequence over `generate_messages_with_tools` so non-streaming drivers still satisfy the live API.
- New `supports_streaming_tool_use` flag on `Driver`, wired into `prompture/testing/driver_contract.py` (`FLAG_TO_METHOD`) so the contract suite asserts the method on flagged drivers.
- Native `generate_messages_with_tools_stream` for `ClaudeDriver` / `AsyncClaudeDriver`, `OpenAIDriver` / `AsyncOpenAIDriver`, `GroqDriver` / `AsyncGroqDriver`.
- New `prompture/drivers/_openai_compat_stream.py` exposes `stream_openai_compat_tool_call` / `astream_openai_compat_tool_call`. `CachibotDriver`, `GrokDriver`, `MistralDriver`, `ModelscopeDriver`, `MoonshotDriver`, `OpenRouterDriver`, `ZAIDriver` and their async siblings opt in with a 3-line override.
- Examples: `examples/agent_live_stream.py`, `examples/agent_live_to_sse.py`.

**Anthropic prompt caching**
- `_apply_cache_control_to_system` and `_apply_cache_control_to_tools` in `claude_driver.py` wrap system prompts ≥4000 chars and large tool bundles with `cache_control: ephemeral`; threshold matches Anthropic's documented 1024-token minimum cacheable block.
- Wired into all six Claude generation paths (sync + async `_do_generate`, `generate_messages_with_tools`, `generate_messages_stream`). Gated by `options["cache_prompt"]` (default `True`).
- Usage meta exposes `cached_prompt_tokens` and `cache_creation_tokens`.
- `Agent._resolve_system_prompt` documents the cache-stability invariant (persona → schema order is cache-safe; per-turn `{{iteration}}` busts the key).
- New `tests/test_claude_prompt_caching.py` with unit + stub + integration coverage.

**Deep-research building blocks**
- `prompture/citations/` — `Citation`, `Source`, `CitedAnswer`, `CitationTracker`, `extract_citations`, `CITATION_INSTRUCTION`.
- `prompture/session_memory/` — `SessionMemory`, `MemoryFact`, `MemoryKind`, `Summarizer`, plus `InMemorySessionStore` and `SQLiteSessionStore`.
- `prompture/checkpoints/` — `Checkpoint`, `CheckpointManager`, `RunStatus`, `snapshot_conversation`, `restore_conversation`; in-memory / file / SQLite stores.
- `prompture/kg/` — `KnowledgeGraph`, `Entity`, `Relation`, `Mention`, `extract_entities`, `extract_relations`; in-memory and SQLite entity stores.
- Example: `examples/deep_research_example.py`.

**Swarm runtime**
- `prompture/swarm/` — `Swarm`, `SwarmAgent`, `Environment`, `Memory`/`MemoryStore`/`InMemoryStore`, scheduler family (`RoundRobinScheduler`, `PriorityScheduler`, `SampleScheduler`, `AllScheduler`, `CallableScheduler`), `Event`, `EventKind`, `SwarmResult`, `SwarmStep`, `SwarmCallbacks`.
- Example: `examples/swarm_example.py`.

**RAG advances**
- `prompture/rag/retrievers/hyde.py`, `multi_query.py`, `step_back.py` add HyDE, MultiQuery, and StepBack retrievers; shared `_fusion.py` provides RRF-style merging.
- `prompture/rag/chunkers/contextual.py` — `ContextualChunker` prepends per-chunk LLM-generated context.
- `RAGPipeline` / `AsyncRAGPipeline` `reranker` parameter accepts a `"provider/model"` string. New `_resolve_reranker()` helper routes through `get_rerank_driver_for_model` (sync) or `get_async_rerank_driver_for_model` (async, with sync fallback). Malformed strings raise `ValueError` with a hint.
- Examples: `examples/rag_advanced_retrievers_example.py`, `examples/rag_with_rerank_example.py`.

**Extraction quality-of-life**
- `prompture/extraction/few_shot.py` — example selection (semantic + random selectors); plumbed into `extract_with_model` via `examples=` / `example_selector=`. Example: `examples/few_shot_extraction_example.py`.
- `prompture/extraction/streaming.py` — partial-JSON parser that yields incomplete object trees as tokens arrive; wired into streaming extraction helpers. Example: `examples/streaming_extraction_example.py`.
- `extract_with_model` retry loop now feeds schema-validation failures back to the model as targeted feedback rather than blind retry.

**Eval framework**
- `prompture/eval/` — `LLMJudge`, `PairwiseJudge`, `FaithfulnessEvaluator`, `SelfConsistencyEvaluator`, plus base `Evaluator` and result dataclasses (`JudgeResult`, `PairwiseResult`, `FaithfulnessResult`, `SelfConsistencyResult`).
- Example: `examples/eval_example.py`.

**Synthetic dataset pipeline**
- `prompture/dataset/seed.py` — `SeedGenerator` / `SelfInstruct`.
- `prompture/dataset/evol.py` — `EvolInstruct`-style mutation operators.
- `prompture/dataset/filters.py` — length / language / PII / quality filters.
- `prompture/dataset/dedup.py` — MinHash and embedding-based dedup.
- `prompture/dataset/synth.py` rewired to compose the new modules.
- Example: `examples/dataset_modernization_example.py`.

**Constrained decoding (vLLM / LMStudio / OpenRouter)**
- New `prompture/drivers/_openai_compat.py` builds the vLLM `guided_json` + `extra_body` request shape.
- Wired into `OpenAICompatibleDriver`, `OpenRouterDriver`, `LMStudioDriver` (sync + async). `options={"guided_decoding": True}` ships the schema; `"outlines"` / `"xgrammar"` / `"lm-format-enforcer"` pins a backend; `options={"extra_body": {...}}` mirrors the OpenAI SDK escape hatch.
- Unknown servers ignore the extra fields, so it is safe to leave on.
- Example: `examples/constrained_decoding_example.py`.

**Ollama JSON schema tightening**
- `OllamaDriver` / `AsyncOllamaDriver` chat + streaming-chat paths: `json_schema` is dropped directly into `payload["format"]` and implies JSON mode. `json_mode=True` without a schema still falls back to the loose `"json"` grammar.

**Driver / infra cleanup (Phase 0)**
- Cache `AsyncAnthropic` client in `AsyncClaudeDriver.__init__` (eliminates per-request TLS handshake; matches the `AsyncOpenAI` pattern).
- Remove stray `pytest.skip` from sync + async `extract_and_jsonify` production paths; drop the now-unused `import sys`.
- Conversation auto-save errors now log at WARNING with `exc_info` instead of being silently swallowed at DEBUG (sync + async).
- New `prompture/_internal/json_encoder.py` (`PromptureJSONEncoder`) replaces 12+ `json.dumps(..., default=str)` call sites and two inline `ExtendedJSONEncoder` classes. Handles `datetime` / `Decimal` / `UUID` / `Enum` / `Path` / Pydantic / `set` / `bytes` with deterministic ordering for non-comparable set items.
- API-key validation at driver construction for OpenAI, Claude, Google, Groq (sync + async): raises `ConfigurationError` early instead of letting the provider SDK surface a cryptic auth error on first call. Google's existing `ValueError` is upgraded to `ConfigurationError`.

**PEP-604 union fix**
- `prompture/extraction/tools.py` introduces `_is_union_origin(origin)` recognising both `typing.Union` and `types.UnionType`. `convert_value` (None-handling and main Union branch) and `get_type_default` all use it. Fields typed `str | None` now extract correctly instead of being coerced to `None` via the `'types.UnionType' object is not callable` fallthrough.

**Python 3.10+ and typing modernisation (Phase 7)**
- `pyproject.toml`: `requires-python = ">=3.10"`, `ruff target-version = "py310"`.
- Hundreds of files updated to PEP-604 unions and built-in generics (`Optional[X]` → `X | None`, `List[X]` → `list[X]`, etc.). Affects most of `prompture/drivers/`, `prompture/extraction/`, `prompture/agents/`, `prompture/infra/`, `prompture/rag/`, examples, and tests.
- Isort import reordering across `prompture/__init__.py`, `dataset/`, `kg/stores.py`, `rag/retrievers/_fusion.py`, `swarm/scheduler.py`.

**Security tooling**
- `dev.ps1` adds `bandit -q -r prompture -c pyproject.toml` to `Invoke-AllChecks`, matching `.github/workflows/security.yml`. Failures surface Severity/Location lines inline.
- Five Bandit suppressions for already-safe usages (each with an inline justification): `random.Random()` in `dataset/evol.py`, `dataset/seed.py`, `swarm/scheduler.py` (B311 — non-crypto sampling); SQL `' OR '.join` in `kg/stores.py` (B608 — library-controlled clauses, parameterised values); `hashlib.sha1` in `rag/retrievers/_fusion.py` annotated `usedforsecurity=False` (content fingerprint for dedup).

**README and surface updates**
- Provider-extras install table next to the hero example.
- `Conversation` example uses `conv.ask(...)` (was the non-existent `conv.send(...)`).
- New "Constrained Decoding (vLLM / LMStudio / OpenRouter)" section.
- New "Prompt Caching (Claude)" section with usage, opt-out, and assembly-order tips.
- CLI server "single-worker constraint" callout (`uvicorn --workers 1` — per-process conversation and rate-limit state).

</details>
