### PR TITLE
Add Tier 2 prompted-tool streaming: live tool calls on any Ollama model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1028,6 +1028,46 @@ conv = Conversation("openai/gpt-4", tools=registry, simulated_tools=False)
 
 The simulation loop describes tools in the system prompt, asks the model to respond with JSON (`tool_call` or `final_answer`), executes tools, and feeds results back — all transparent to the caller.
 
+### Live Streaming Tool Calls (any model, including local Ollama)
+
+`Conversation.ask_live` / `Agent.run_live` yields an interleaved event stream — text deltas, tool calls, tool results — *as the model produces them*. This is the "Claude Code feel" where the model narrates between actions instead of buffering everything into one chunk per turn.
+
+For Claude, OpenAI, Groq, Grok, Mistral, OpenRouter and friends, this runs on the provider's native streaming-tool API. For **local Ollama models** Prompture ships two delivery tiers:
+
+```python
+from prompture import Agent
+
+# Tier 1 — native Ollama streaming + tool calls.
+# Works on tool-trained models (Llama 3.1+, Mistral Nemo, Qwen 2.5, …).
+agent = Agent("ollama/llama3.1:8b", tools=[lookup_country, lookup_population])
+for event in agent.run_live("Which is bigger, Tokyo or Paris?"):
+    ...   # TextDelta / ToolUseStart / ToolUseStop / ToolResult / TurnComplete
+
+# Tier 2 — prompted-tool emulation.
+# Works on ANY model — Phi-3, base Gemma, raw Llama 3 7B, etc.
+# Tool schemas are injected into the system prompt; tool calls are parsed
+# out of the token stream character-by-character via a state-machine parser.
+for event in agent.run_live(prompt, options={"prompted_tools": True}):
+    ...
+```
+
+Tier 2's grammar is pluggable (`prompture.agents.tool_grammars`). The default `xml_tags` grammar uses `<tool_call name="search">{"q": "..."}</tool_call>` blocks — explicit delimiters that don't clash with markdown narration and let `ToolUseStart` fire the moment the opening tag is seen, before the arguments finish streaming.
+
+Any text-streaming driver can opt into Tier 2 by mixing in `PromptedToolStreamMixin`:
+
+```python
+from prompture.drivers._prompted_tool_stream import PromptedToolStreamMixin
+
+class MyDriver(PromptedToolStreamMixin, Driver):
+    supports_streaming_tool_use = True
+    prompted_tool_grammar = "xml_tags"
+
+    def generate_messages_with_tools_stream(self, messages, tools, options):
+        yield from self._stream_via_prompted_emulation(messages, tools, options)
+```
+
+See `examples/agent_live_stream_ollama.py` for a complete demo of both tiers.
+
 ### Sandboxed Python execution
 
 `PythonSandboxTool` ships a ready-to-register `python_execute` tool backed

--- a/examples/agent_live_stream_ollama.py
+++ b/examples/agent_live_stream_ollama.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Live agent stream against a local Ollama model.
+
+Prompture's ``run_live`` API gives you Claude-Code-style interleaved
+streaming (text → tool call → text → tool call → final answer) on a
+**local Ollama model** — no proprietary cloud needed. This example
+demonstrates both delivery tiers:
+
+- **Tier 1 (default)** — native Ollama streaming + tool calls. Works
+  on tool-trained models (Llama 3.1+, Mistral Nemo, Qwen 2.5, ...).
+  Token deltas stream live; tool calls land at the end of the model's
+  turn and are emitted as ``ToolUseStart`` / ``ToolUseStop`` events.
+
+- **Tier 2** — prompted-tool emulation. The tool schemas are injected
+  into the system prompt, and Prompture parses tool calls out of the
+  token stream character-by-character. Works on **any** local model,
+  even ones without function-calling training (Phi-3, base Gemma 2,
+  raw Llama 3 7B, ...).
+
+Usage::
+
+    # Tier 1 (model has native tool support, e.g. Llama 3.1)
+    python examples/agent_live_stream_ollama.py --model ollama/llama3.1:8b
+
+    # Tier 2 (any model — forces prompted-tool emulation)
+    python examples/agent_live_stream_ollama.py \\
+        --model ollama/phi3:mini --prompted
+
+Requires a local Ollama server (``ollama serve``) with the chosen model
+pulled (``ollama pull llama3.1:8b``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any
+
+from prompture import Agent
+from prompture.agents.live_events import (
+    AssistantTurnStart,
+    MessageStop,
+    TextDelta,
+    ThinkingDelta,
+    ToolInputDelta,
+    ToolResult,
+    ToolUseStart,
+    ToolUseStop,
+    TurnComplete,
+)
+
+CITY_DATA: dict[str, dict[str, Any]] = {
+    "Paris": {"country": "France", "population": 2_161_000, "timezone": "CET"},
+    "Tokyo": {"country": "Japan", "population": 13_960_000, "timezone": "JST"},
+    "London": {"country": "United Kingdom", "population": 8_982_000, "timezone": "GMT"},
+    "São Paulo": {"country": "Brazil", "population": 12_396_000, "timezone": "BRT"},
+}
+
+
+def lookup_country(city: str) -> str:
+    """Return the country a city is in."""
+    info = CITY_DATA.get(city)
+    return info["country"] if info else f"Unknown city: {city}"
+
+
+def lookup_population(city: str) -> str:
+    """Return the population of a city."""
+    info = CITY_DATA.get(city)
+    return str(info["population"]) if info else f"Unknown city: {city}"
+
+
+def compare_populations(city_a: str, city_b: str) -> str:
+    """Return which city has the larger population."""
+    a, b = CITY_DATA.get(city_a), CITY_DATA.get(city_b)
+    if not a or not b:
+        return "Unknown city in comparison."
+    if a["population"] > b["population"]:
+        return f"{city_a} is larger ({a['population']:,} vs {b['population']:,})."
+    if a["population"] < b["population"]:
+        return f"{city_b} is larger ({b['population']:,} vs {a['population']:,})."
+    return f"{city_a} and {city_b} have equal populations."
+
+
+def render_event(event: Any) -> None:
+    """Pretty-print one LiveEvent so the stream is visible in a terminal."""
+    if isinstance(event, AssistantTurnStart):
+        print(f"\n--- turn {event.turn_index} ---")
+    elif isinstance(event, TextDelta):
+        print(event.text, end="", flush=True)
+    elif isinstance(event, ThinkingDelta):
+        print(f"\033[2m{event.text}\033[0m", end="", flush=True)
+    elif isinstance(event, ToolUseStart):
+        print(f"\n[> calling {event.name} ({event.id[:8]})]", flush=True)
+    elif isinstance(event, ToolInputDelta):
+        print(f"\033[2m{event.fragment}\033[0m", end="", flush=True)
+    elif isinstance(event, ToolUseStop):
+        print(f"\n[> {event.name} input ready: {event.input}]", flush=True)
+    elif isinstance(event, ToolResult):
+        out = event.output if len(event.output) < 200 else event.output[:200] + "…"
+        prefix = "!" if event.is_error else "<"
+        print(f"\n[{prefix} {event.name} -> {out}]", flush=True)
+    elif isinstance(event, MessageStop):
+        tokens = event.usage.get("total_tokens", 0)
+        print(f"\n[turn done: {tokens} tokens, stop={event.stop_reason}]")
+    elif isinstance(event, TurnComplete):
+        tokens = event.usage.get("total_tokens", 0)
+        print(f"\n[all done: {tokens} tokens]")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Live agent stream against a local Ollama model.")
+    parser.add_argument(
+        "--model",
+        default="ollama/llama3.1:8b",
+        help="provider/model string (e.g. ollama/llama3.1:8b, ollama/phi3:mini)",
+    )
+    parser.add_argument(
+        "--prompted",
+        action="store_true",
+        help=(
+            "Force Tier 2 prompted-tool emulation (tool schemas injected into "
+            "system prompt, parsed from token stream). Use for models without "
+            "native function-calling training."
+        ),
+    )
+    parser.add_argument(
+        "--prompt",
+        default=(
+            "Compare Tokyo and Paris. Tell me which is bigger and what country each is in. "
+            "Use your tools to verify the numbers."
+        ),
+    )
+    args = parser.parse_args()
+
+    tier = "Tier 2 (prompted emulation)" if args.prompted else "Tier 1 (native)"
+    print(f"Model:  {args.model}")
+    print(f"Mode:   {tier}")
+    print(f"Prompt: {args.prompt}\n")
+
+    agent = Agent(
+        args.model,
+        system_prompt=(
+            "You are a careful researcher. Use tools to verify facts before answering. "
+            "Narrate briefly what you are about to do before each tool call."
+        ),
+        tools=[lookup_country, lookup_population, compare_populations],
+    )
+
+    options: dict[str, Any] = {}
+    if args.prompted:
+        options["prompted_tools"] = True
+
+    streamed = agent.run_live(args.prompt, options=options)
+    for event in streamed:
+        render_event(event)
+
+    final = streamed.result
+    if final is not None:
+        print(f"\n\nFinal answer:\n{final.output_text}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prompture/agents/tool_grammars.py
+++ b/prompture/agents/tool_grammars.py
@@ -1,0 +1,204 @@
+"""Prompted tool-use grammars for drivers without native function-calling.
+
+When a driver lacks native tool-calling (HuggingFace inference, raw local
+HTTP, older Ollama models, AirLLM, …) Prompture can still deliver the
+``Conversation.ask_live`` interleaved streaming-tool experience by:
+
+1. Injecting tool schemas into the system prompt using a chosen *grammar*
+   (e.g. ``<tool_call name="x">{...}</tool_call>`` tags).
+2. Streaming the model's text output through
+   :class:`~prompture.drivers._prompted_tool_stream.PromptedToolStreamParser`,
+   which detects the grammar's delimiters mid-stream and emits the same
+   :mod:`~prompture.agents.live_events` as a native streaming-tool driver.
+
+The default grammar — :data:`XML_TAGS_GRAMMAR` — is the most robust choice
+for small open-weight models: explicit unambiguous delimiters, doesn't
+interfere with markdown narration, and exposes the tool name at the
+opening tag so ``ToolUseStart`` can fire before the args finish streaming.
+
+Other formats (``json_fence``, classic ReAct ``Action:`` / ``Action Input:``)
+can be plugged in via :func:`register_grammar`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ToolGrammar:
+    """Describes one prompted tool-use grammar.
+
+    The grammar drives both directions:
+
+    - **System-prompt injection** — :attr:`render_system_prompt` builds the
+      instruction block appended to the system message so the model emits
+      tool calls in the expected shape.
+    - **Streaming parser** — :attr:`open_regex` / :attr:`close_marker`
+      delimit tool-call blocks in the token stream;
+      :attr:`parse_open_tag` extracts ``(name, id)`` from the opening
+      tag so :class:`~prompture.agents.live_events.ToolUseStart` can fire
+      immediately, before the arguments finish streaming.
+    """
+
+    name: str
+    """Stable identifier (``"xml_tags"``, ``"react"`` …) used as the
+    grammar key in :data:`GRAMMARS` and the ``prompted_tool_grammar``
+    driver attribute."""
+
+    open_regex: re.Pattern[str]
+    """Compiled regex matching the opening delimiter. Must include a
+    sentinel terminator (e.g. trailing ``>``) so the parser can detect
+    completeness even when the chunk boundary falls inside the tag."""
+
+    close_marker: str
+    """Literal string that closes a tool-call block (e.g. ``</tool_call>``)."""
+
+    parse_open_tag: Callable[[re.Match[str]], tuple[str, str | None]]
+    """Given the regex match for the opening tag, return ``(tool_name, tool_id)``.
+    ``tool_id`` may be ``None`` — the parser will auto-generate one."""
+
+    render_system_prompt: Callable[[list[dict[str, Any]]], str]
+    """Given the OpenAI-style ``tools`` list, return the instruction block
+    appended to the system prompt so the model emits this grammar."""
+
+
+# ---------------------------------------------------------------------------
+# Default grammar: XML-style tags with name + id attributes
+# ---------------------------------------------------------------------------
+
+# Matches  <tool_call name="x">  or  <tool_call name="x" id="y">
+_XML_OPEN_RE = re.compile(
+    r"<tool_call\s+name\s*=\s*\"(?P<name>[^\"]+)\""
+    r"(?:\s+id\s*=\s*\"(?P<id>[^\"]+)\")?\s*>"
+)
+
+
+def _xml_parse_open(match: re.Match[str]) -> tuple[str, str | None]:
+    return match.group("name"), match.group("id")
+
+
+def _xml_render_system_prompt(tools: list[dict[str, Any]]) -> str:
+    """Build the XML-tag tool-use instruction block.
+
+    Each tool becomes a bullet point with its description and JSON schema.
+    The instructions specify the exact opening/closing tag format and
+    show one worked example so the model anchors on it.
+    """
+    lines: list[str] = [
+        "",
+        "## Available tools",
+        "",
+        "You have access to the following tools. Call them when you need information",
+        "or actions that require them — otherwise answer directly.",
+        "",
+    ]
+    for tool in tools:
+        fn = tool.get("function", tool)
+        name = fn.get("name", "")
+        desc = fn.get("description", "") or "(no description)"
+        params = fn.get("parameters", {}) or {}
+        params_json = json.dumps(params, separators=(",", ":"))
+        lines.append(f"- **{name}** — {desc}")
+        lines.append(f"  Parameters JSON Schema: `{params_json}`")
+    lines.extend(
+        [
+            "",
+            "## How to call a tool",
+            "",
+            "When you need to call a tool, emit a block exactly like this in your reply:",
+            "",
+            '<tool_call name="TOOL_NAME">',
+            '{"arg1": "value1", "arg2": 42}',
+            "</tool_call>",
+            "",
+            "Rules:",
+            '- The opening tag must be on its own and include `name="..."` matching one of the tools above.',
+            "- The body between the tags must be a single valid JSON object — the tool arguments.",
+            "- The closing tag is `</tool_call>` on its own line (or immediately after the JSON).",
+            "- You may narrate normally before, between, and after tool calls.",
+            "- Wait for the tool result before deciding what to do next; results arrive as a `tool` role message.",
+            "- If no tool is needed, just answer the user directly with no `<tool_call>` block.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+XML_TAGS_GRAMMAR = ToolGrammar(
+    name="xml_tags",
+    open_regex=_XML_OPEN_RE,
+    close_marker="</tool_call>",
+    parse_open_tag=_xml_parse_open,
+    render_system_prompt=_xml_render_system_prompt,
+)
+"""Default prompted-tool grammar — XML-style ``<tool_call name="..." [id="..."]>{json}</tool_call>``.
+
+Robust for small open-weight models: explicit delimiters, doesn't clash
+with markdown, and exposes the tool name at the opening tag so the live
+stream can emit :class:`~prompture.agents.live_events.ToolUseStart`
+before the arguments finish."""
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+GRAMMARS: dict[str, ToolGrammar] = {
+    "xml_tags": XML_TAGS_GRAMMAR,
+}
+"""Global registry of available prompted-tool grammars, keyed by
+:attr:`ToolGrammar.name`."""
+
+
+def register_grammar(grammar: ToolGrammar) -> None:
+    """Add a grammar to the registry (overwrites if name already exists)."""
+    GRAMMARS[grammar.name] = grammar
+
+
+def get_grammar(name: str) -> ToolGrammar:
+    """Look up a grammar by name. Raises ``KeyError`` if not registered."""
+    try:
+        return GRAMMARS[name]
+    except KeyError as exc:
+        available = ", ".join(sorted(GRAMMARS)) or "(none registered)"
+        raise KeyError(f"Unknown tool grammar {name!r}. Available: {available}") from exc
+
+
+def inject_tool_instructions(
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]],
+    grammar: ToolGrammar,
+) -> list[dict[str, Any]]:
+    """Return a copy of *messages* with the grammar's tool instructions
+    appended to the system message.
+
+    If no system message exists, one is inserted at index 0. The original
+    messages list is not mutated.
+    """
+    if not tools:
+        return list(messages)
+
+    instructions = grammar.render_system_prompt(tools)
+    out = [dict(m) for m in messages]
+    for msg in out:
+        if msg.get("role") == "system":
+            existing = msg.get("content", "") or ""
+            msg["content"] = (existing.rstrip() + "\n" + instructions) if existing else instructions
+            return out
+    out.insert(0, {"role": "system", "content": instructions})
+    return out
+
+
+__all__ = [
+    "GRAMMARS",
+    "XML_TAGS_GRAMMAR",
+    "ToolGrammar",
+    "get_grammar",
+    "inject_tool_instructions",
+    "register_grammar",
+]

--- a/prompture/drivers/_prompted_tool_stream.py
+++ b/prompture/drivers/_prompted_tool_stream.py
@@ -1,0 +1,412 @@
+"""Prompted tool-call streaming parser and driver mixin.
+
+This is the engine behind Prompture's *Tier 2* live streaming-tool support
+for any text-only driver. It turns a plain token stream from a model that
+doesn't have native function-calling (HuggingFace inference, raw local
+HTTP, older Ollama models, AirLLM, …) into the same interleaved
+:mod:`~prompture.agents.live_events` stream that native streaming-tool
+drivers (Claude, OpenAI, …) produce.
+
+How it works
+------------
+
+1. The mixin's :meth:`PromptedToolStreamMixin._stream_via_prompted_emulation`
+   injects tool schemas into the system prompt using a chosen
+   :class:`~prompture.agents.tool_grammars.ToolGrammar`.
+2. It then calls the driver's own :meth:`generate_messages_stream` to get
+   raw text chunks.
+3. Each chunk is fed to :class:`PromptedToolStreamParser`, which runs a
+   small state machine: ``NARRATION → TOOL_ARGS → narration``. Text outside
+   tool calls becomes :class:`~prompture.agents.live_events.TextDelta`.
+   Tool calls become :class:`~prompture.agents.live_events.ToolUseStart`
+   (fired the moment the opening tag is matched, so the user sees
+   ``calling search(...)`` before the args finish streaming),
+   :class:`~prompture.agents.live_events.ToolInputDelta` per inner-JSON
+   chunk, and :class:`~prompture.agents.live_events.ToolUseStop` with the
+   parsed argument dict at the closing tag.
+
+Partial-delimiter handling
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Token boundaries don't respect delimiters — ``<tool_`` may arrive in one
+chunk and ``call name="x">`` in the next. The parser keeps a small
+*holdback* in each state: when in narration, it never emits the trailing
+characters of pending text that could grow into an opening tag; when
+inside a tool call, it holds back the trailing characters that could
+grow into the close marker.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from ..agents.live_events import (
+    AssistantTurnStart,
+    LiveEvent,
+    MessageStop,
+    TextDelta,
+    ToolInputDelta,
+    ToolUseStart,
+    ToolUseStop,
+)
+from ..agents.tool_grammars import ToolGrammar, get_grammar, inject_tool_instructions
+
+logger = logging.getLogger(__name__)
+
+
+# The opening-delimiter prefix the parser scans for. When in narration
+# mode, the parser holds back the tail of un-emitted text that could
+# still grow into this prefix.
+_OPEN_PREFIX = "<tool_call"
+
+
+class _ParserState(Enum):
+    """Parser state machine vertices."""
+
+    NARRATION = "narration"
+    """Emitting :class:`~prompture.agents.live_events.TextDelta` events for
+    plain text — watching for ``_OPEN_PREFIX`` to start a tool call."""
+
+    TOOL_ARGS = "tool_args"
+    """Inside a tool-call block — emitting
+    :class:`~prompture.agents.live_events.ToolInputDelta` events and
+    watching for ``grammar.close_marker`` to finish the call."""
+
+
+@dataclass
+class _ToolInProgress:
+    """Mutable per-tool-call state while the parser is inside a block."""
+
+    id: str
+    name: str
+    args_buf: str = field(default_factory=str)
+    """Args text not yet emitted as a fragment (holdback for close marker)."""
+
+    full_args: str = field(default_factory=str)
+    """Complete args text seen so far — used to parse the final JSON at
+    close time, since :attr:`args_buf` gets sliced as fragments are
+    emitted."""
+
+
+class PromptedToolStreamParser:
+    """Incremental parser turning raw text chunks into
+    :mod:`~prompture.agents.live_events` events.
+
+    Usage::
+
+        parser = PromptedToolStreamParser(get_grammar("xml_tags"))
+        for chunk in text_stream:
+            yield from parser.feed(chunk)
+        yield from parser.finish()
+    """
+
+    def __init__(self, grammar: ToolGrammar) -> None:
+        self.grammar = grammar
+        self._state = _ParserState.NARRATION
+        self._narration_buf = ""
+        self._current_tool: _ToolInProgress | None = None
+        self._open_holdback = len(_OPEN_PREFIX) - 1
+        self._close_holdback = max(0, len(grammar.close_marker) - 1)
+
+    def feed(self, chunk: str) -> Iterator[LiveEvent]:
+        """Consume one text chunk and yield any events it produced.
+
+        Safe to call with empty strings (no-op). Multi-tool-call chunks
+        are handled — the parser loops until no further progress can be
+        made on the current buffer.
+        """
+        if not chunk:
+            return
+        if self._state is _ParserState.NARRATION:
+            self._narration_buf += chunk
+            yield from self._drain_narration()
+        else:
+            assert self._current_tool is not None
+            self._current_tool.args_buf += chunk
+            self._current_tool.full_args += chunk
+            yield from self._drain_tool_args()
+
+    def finish(self) -> Iterator[LiveEvent]:
+        """Flush trailing state at end-of-stream.
+
+        - Pending narration is emitted as one final
+          :class:`~prompture.agents.live_events.TextDelta`.
+        - An unclosed tool call (model stopped mid-block) emits
+          ``ToolUseStop`` with whatever args parsed cleanly, logged as
+          a warning.
+        """
+        if self._state is _ParserState.NARRATION:
+            if self._narration_buf:
+                yield TextDelta(text=self._narration_buf)
+                self._narration_buf = ""
+            return
+
+        assert self._current_tool is not None
+        logger.warning(
+            "Tool call %s (%s) was not closed before end-of-stream",
+            self._current_tool.name,
+            self._current_tool.id,
+        )
+        # Emit any held-back args as a final fragment for visibility.
+        if self._current_tool.args_buf:
+            yield ToolInputDelta(
+                id=self._current_tool.id,
+                fragment=self._current_tool.args_buf,
+            )
+        parsed = self._parse_tool_args(self._current_tool.full_args)
+        yield ToolUseStop(
+            id=self._current_tool.id,
+            name=self._current_tool.name,
+            input=parsed,
+        )
+        self._current_tool = None
+        self._state = _ParserState.NARRATION
+
+    # ------------------------------------------------------------------
+    # Internal: state-machine drivers
+    # ------------------------------------------------------------------
+
+    def _drain_narration(self) -> Iterator[LiveEvent]:
+        """In NARRATION: emit safe-prefix text; on open tag, transition."""
+        while True:
+            match = self.grammar.open_regex.search(self._narration_buf)
+            if match is None:
+                # No opening tag yet. Emit everything except a tail that
+                # could still grow into ``<tool_call``.
+                if self._buffer_could_become_open_tag():
+                    safe_len = max(0, len(self._narration_buf) - self._open_holdback)
+                else:
+                    safe_len = len(self._narration_buf)
+                if safe_len > 0:
+                    yield TextDelta(text=self._narration_buf[:safe_len])
+                    self._narration_buf = self._narration_buf[safe_len:]
+                return
+
+            # Opening tag found. Emit any text before it, then transition.
+            pre = self._narration_buf[: match.start()]
+            if pre:
+                yield TextDelta(text=pre)
+
+            name, tag_id = self.grammar.parse_open_tag(match)
+            tool_id = tag_id or f"call_{uuid.uuid4().hex[:24]}"
+            self._current_tool = _ToolInProgress(id=tool_id, name=name)
+            yield ToolUseStart(id=tool_id, name=name)
+
+            leftover = self._narration_buf[match.end() :]
+            self._narration_buf = ""
+            self._state = _ParserState.TOOL_ARGS
+            if leftover:
+                self._current_tool.args_buf = leftover
+                self._current_tool.full_args = leftover
+                yield from self._drain_tool_args()
+            # If still in TOOL_ARGS we're waiting for more chunks; if back
+            # in NARRATION (close marker was already in the leftover), the
+            # while-loop re-scans the rebuilt narration buffer.
+            if self._state is _ParserState.TOOL_ARGS:
+                return
+
+    def _drain_tool_args(self) -> Iterator[LiveEvent]:
+        """In TOOL_ARGS: emit input deltas; on close marker, finalize."""
+        assert self._current_tool is not None
+        close = self.grammar.close_marker
+        buf = self._current_tool.args_buf
+
+        idx = buf.find(close)
+        if idx == -1:
+            # Hold back the trailing characters that could grow into the
+            # close marker.
+            safe_len = max(0, len(buf) - self._close_holdback)
+            if safe_len > 0:
+                fragment = buf[:safe_len]
+                yield ToolInputDelta(id=self._current_tool.id, fragment=fragment)
+                self._current_tool.args_buf = buf[safe_len:]
+            return
+
+        # Close marker found. Emit the final args fragment (text before
+        # the close marker), then finalize and reset to narration.
+        final_fragment = buf[:idx]
+        if final_fragment:
+            yield ToolInputDelta(id=self._current_tool.id, fragment=final_fragment)
+
+        # Strip the close marker from full_args to get the JSON for parsing.
+        # Use `find` (first occurrence), not `rfind` — when two tool calls
+        # arrive in the same chunk, full_args will contain both close
+        # markers and rfind would pick up the wrong one.
+        full = self._current_tool.full_args
+        close_offset = full.find(close)
+        args_text = full[:close_offset] if close_offset != -1 else full
+        parsed = self._parse_tool_args(args_text)
+        yield ToolUseStop(
+            id=self._current_tool.id,
+            name=self._current_tool.name,
+            input=parsed,
+        )
+
+        leftover = buf[idx + len(close) :]
+        self._current_tool = None
+        self._state = _ParserState.NARRATION
+        self._narration_buf = leftover
+        if self._narration_buf:
+            yield from self._drain_narration()
+
+    # ------------------------------------------------------------------
+    # Internal: helpers
+    # ------------------------------------------------------------------
+
+    def _buffer_could_become_open_tag(self) -> bool:
+        """True iff the tail of :attr:`_narration_buf` could grow into an
+        opening tag with more characters appended.
+
+        Cheap O(holdback) check that avoids unnecessary text holdback
+        when the buffer's tail clearly can't be the start of
+        ``<tool_call``.
+        """
+        if self._open_holdback <= 0:
+            return False
+        tail = self._narration_buf[-self._open_holdback :]
+        if not tail:
+            return False
+        lt = tail.rfind("<")
+        if lt == -1:
+            return False
+        candidate = tail[lt:]
+        return _OPEN_PREFIX.startswith(candidate)
+
+    def _parse_tool_args(self, raw: str) -> dict[str, Any]:
+        """Parse the accumulated args JSON, with graceful fallback."""
+        text = raw.strip()
+        if not text:
+            return {}
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError as exc:
+            logger.warning("Failed to parse tool args JSON (%s). Raw: %r", exc, text[:200])
+            return {}
+        if isinstance(parsed, dict):
+            return parsed
+        logger.warning(
+            "Tool args parsed as %s, not dict; ignoring. Raw: %r",
+            type(parsed).__name__,
+            text[:200],
+        )
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Driver mixin
+# ---------------------------------------------------------------------------
+
+
+class PromptedToolStreamMixin:
+    """Mixin that gives any text-streaming driver Tier 2 emulated
+    streaming tool use.
+
+    The host driver must provide :meth:`generate_messages_stream` (or
+    :meth:`generate_messages` as a fallback) yielding chunks of the
+    shape::
+
+        {"type": "delta", "text": "..."}                # token chunks
+        {"type": "done",  "text": "...", "meta": {...}} # final
+
+    Set the class attributes::
+
+        supports_streaming_tool_use = True
+        prompted_tool_grammar = "xml_tags"  # or another registered grammar
+
+    and either:
+
+    - leave :meth:`generate_messages_with_tools_stream` unimplemented to
+      always emulate via :meth:`_stream_via_prompted_emulation`, or
+    - implement it to try a native path first and call the emulation as
+      fallback.
+
+    The mixin yields :class:`~prompture.agents.live_events.MessageStop`
+    at the end with whatever usage the underlying ``generate_messages_stream``
+    reports in its final ``"done"`` chunk (or zeros if absent).
+    """
+
+    prompted_tool_grammar: str = "xml_tags"
+
+    def _stream_via_prompted_emulation(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> Iterator[LiveEvent]:
+        """Synchronous Tier 2 emulation. Yields LiveEvents."""
+        grammar = get_grammar(options.get("prompted_tool_grammar") or self.prompted_tool_grammar)
+        augmented = inject_tool_instructions(messages, tools, grammar)
+        parser = PromptedToolStreamParser(grammar)
+
+        usage: dict[str, Any] = {}
+        saw_delta = False
+        full_text = ""
+        for chunk in self.generate_messages_stream(augmented, options):  # type: ignore[attr-defined]
+            ctype = chunk.get("type")
+            if ctype == "delta":
+                saw_delta = True
+                text = chunk.get("text", "")
+                full_text += text
+                yield from parser.feed(text)
+            elif ctype == "done":
+                usage = dict(chunk.get("meta", {}) or {})
+                # Some drivers only return the full text in "done" with
+                # no per-token deltas — feed it through the parser now.
+                if not saw_delta:
+                    tail = chunk.get("text", "")
+                    if tail:
+                        yield from parser.feed(tail)
+
+        yield from parser.finish()
+        yield MessageStop(stop_reason="end_turn", usage=usage)
+
+    async def _astream_via_prompted_emulation(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> AsyncIterator[LiveEvent]:
+        """Async sibling of :meth:`_stream_via_prompted_emulation`."""
+        grammar = get_grammar(options.get("prompted_tool_grammar") or self.prompted_tool_grammar)
+        augmented = inject_tool_instructions(messages, tools, grammar)
+        parser = PromptedToolStreamParser(grammar)
+
+        usage: dict[str, Any] = {}
+        saw_delta = False
+        async for chunk in self.generate_messages_stream(augmented, options):  # type: ignore[attr-defined]
+            ctype = chunk.get("type")
+            if ctype == "delta":
+                saw_delta = True
+                text = chunk.get("text", "")
+                for ev in parser.feed(text):
+                    yield ev
+            elif ctype == "done":
+                usage = dict(chunk.get("meta", {}) or {})
+                if not saw_delta:
+                    tail = chunk.get("text", "")
+                    if tail:
+                        for ev in parser.feed(tail):
+                            yield ev
+
+        for ev in parser.finish():
+            yield ev
+        yield MessageStop(stop_reason="end_turn", usage=usage)
+
+
+def emit_turn_start(turn_index: int = 0) -> AssistantTurnStart:
+    """Convenience constructor for the ``AssistantTurnStart`` event drivers
+    emit at the top of a streaming-tool turn."""
+    return AssistantTurnStart(turn_index=turn_index)
+
+
+__all__ = [
+    "PromptedToolStreamMixin",
+    "PromptedToolStreamParser",
+    "emit_turn_start",
+]

--- a/prompture/drivers/async_ollama_driver.py
+++ b/prompture/drivers/async_ollama_driver.py
@@ -6,20 +6,33 @@ import json
 import logging
 import os
 import uuid
+from collections.abc import AsyncIterator
 from typing import Any
 
 import httpx
 
+from ..agents.live_events import (
+    LiveEvent,
+    MessageStop,
+    TextDelta,
+    ToolInputDelta,
+    ToolUseStart,
+    ToolUseStop,
+)
+from ._prompted_tool_stream import PromptedToolStreamMixin
 from .async_base import AsyncDriver
 
 logger = logging.getLogger(__name__)
 
 
-class AsyncOllamaDriver(AsyncDriver):
+class AsyncOllamaDriver(PromptedToolStreamMixin, AsyncDriver):
     supports_json_mode = True
     supports_json_schema = True
+    supports_streaming = True
+    supports_streaming_tool_use = True
     supports_tool_use = True
     supports_vision = True
+    prompted_tool_grammar = "xml_tags"
 
     MODEL_PRICING = {"default": {"prompt": 0.0, "completion": 0.0}}
 
@@ -217,3 +230,194 @@ class AsyncOllamaDriver(AsyncDriver):
         if reasoning_content is not None:
             result["reasoning_content"] = reasoning_content
         return result
+
+    # ------------------------------------------------------------------
+    # Streaming
+    # ------------------------------------------------------------------
+
+    async def generate_messages_stream(
+        self,
+        messages: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Yield response chunks via Ollama streaming API."""
+        merged = self.options.copy()
+        if options:
+            merged.update(options)
+
+        messages = self._prepare_messages(messages)
+        chat_endpoint = self.endpoint.replace("/api/generate", "/api/chat")
+
+        payload: dict[str, Any] = {
+            "model": merged.get("model", self.model),
+            "messages": messages,
+            "stream": True,
+        }
+        json_schema = merged.get("json_schema")
+        if json_schema is not None:
+            payload["format"] = json_schema
+        elif merged.get("json_mode"):
+            payload["format"] = "json"
+        for key in ("temperature", "top_p", "top_k"):
+            if key in merged:
+                payload[key] = merged[key]
+
+        full_text = ""
+        full_reasoning = ""
+        prompt_tokens = 0
+        completion_tokens = 0
+
+        async with (
+            httpx.AsyncClient(timeout=merged.get("timeout", 300.0)) as client,
+            client.stream("POST", chat_endpoint, json=payload) as r,
+        ):
+            r.raise_for_status()
+            async for line in r.aiter_lines():
+                if not line:
+                    continue
+                try:
+                    chunk = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if chunk.get("done"):
+                    prompt_tokens = chunk.get("prompt_eval_count", 0)
+                    completion_tokens = chunk.get("eval_count", 0)
+                else:
+                    msg = chunk.get("message", {}) or {}
+                    thinking = msg.get("thinking", "")
+                    if thinking:
+                        full_reasoning += thinking
+                    content = msg.get("content", "")
+                    if content:
+                        full_text += content
+                        yield {"type": "delta", "text": content}
+
+        done_chunk: dict[str, Any] = {
+            "type": "done",
+            "text": full_text,
+            "meta": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": prompt_tokens + completion_tokens,
+                "cost": 0.0,
+                "raw_response": {},
+                "model_name": merged.get("model", self.model),
+            },
+        }
+        if full_reasoning:
+            done_chunk["reasoning_content"] = full_reasoning
+        yield done_chunk
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    async def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> AsyncIterator[LiveEvent]:
+        """Yield :class:`~prompture.agents.live_events.LiveEvent` for one
+        assistant turn that may interleave narration and tool calls.
+
+        ``options["prompted_tools"] = True`` switches to Tier 2 emulation
+        (grammar injected into system prompt; tool calls parsed out of
+        the token stream). Default is Tier 1 native: Ollama
+        ``/api/chat`` with ``stream=True`` and ``tools=[...]``, text
+        streamed live, tool calls emitted from the final ``done`` chunk.
+        """
+        if options.get("prompted_tools"):
+            async for ev in self._astream_via_prompted_emulation(messages, tools, options):
+                yield ev
+            return
+
+        async for ev in self._astream_native_with_tools(messages, tools, options):
+            yield ev
+
+    async def _astream_native_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> AsyncIterator[LiveEvent]:
+        """Tier 1: native async Ollama streaming with tools."""
+        merged = self.options.copy()
+        if options:
+            merged.update(options)
+
+        messages = self._prepare_messages(messages)
+        chat_endpoint = self.endpoint.replace("/api/generate", "/api/chat")
+
+        payload: dict[str, Any] = {
+            "model": merged.get("model", self.model),
+            "messages": messages,
+            "tools": tools,
+            "stream": True,
+        }
+        for key in ("temperature", "top_p", "top_k"):
+            if key in merged:
+                payload[key] = merged[key]
+
+        prompt_tokens = 0
+        completion_tokens = 0
+        stop_reason = "stop"
+        tool_calls_raw: list[dict[str, Any]] = []
+
+        async with (
+            httpx.AsyncClient(timeout=merged.get("timeout", 300.0)) as client,
+            client.stream("POST", chat_endpoint, json=payload) as r,
+        ):
+            r.raise_for_status()
+            async for line in r.aiter_lines():
+                if not line:
+                    continue
+                try:
+                    chunk = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if chunk.get("done"):
+                    prompt_tokens = chunk.get("prompt_eval_count", 0)
+                    completion_tokens = chunk.get("eval_count", 0)
+                    stop_reason = chunk.get("done_reason", "stop")
+                    msg = chunk.get("message", {}) or {}
+                    tool_calls_raw = msg.get("tool_calls", []) or []
+                    tail = msg.get("content", "")
+                    if tail:
+                        yield TextDelta(text=tail)
+                else:
+                    msg = chunk.get("message", {}) or {}
+                    content = msg.get("content", "")
+                    if content:
+                        yield TextDelta(text=content)
+
+        for tc in tool_calls_raw:
+            func = tc.get("function", {}) or {}
+            name = func.get("name", "")
+            args = func.get("arguments", {})
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args)
+                except json.JSONDecodeError:
+                    logger.warning("Failed to parse Ollama tool args for %s: %r", name, args[:200])
+                    args = {}
+            if not isinstance(args, dict):
+                args = {}
+            tool_id = tc.get("id") or f"call_{uuid.uuid4().hex[:24]}"
+            yield ToolUseStart(id=tool_id, name=name)
+            try:
+                fragment = json.dumps(args)
+            except (TypeError, ValueError):
+                fragment = "{}"
+            if fragment and fragment != "{}":
+                yield ToolInputDelta(id=tool_id, fragment=fragment)
+            yield ToolUseStop(id=tool_id, name=name, input=args)
+
+        usage = {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+            "cost": 0.0,
+            "model_name": merged.get("model", self.model),
+        }
+        yield MessageStop(stop_reason=stop_reason, usage=usage)

--- a/prompture/drivers/ollama_driver.py
+++ b/prompture/drivers/ollama_driver.py
@@ -7,17 +7,28 @@ from typing import Any
 
 import requests
 
+from ..agents.live_events import (
+    LiveEvent,
+    MessageStop,
+    TextDelta,
+    ToolInputDelta,
+    ToolUseStart,
+    ToolUseStop,
+)
+from ._prompted_tool_stream import PromptedToolStreamMixin
 from .base import Driver
 
 logger = logging.getLogger(__name__)
 
 
-class OllamaDriver(Driver):
+class OllamaDriver(PromptedToolStreamMixin, Driver):
     supports_json_mode = True
     supports_json_schema = True
     supports_streaming = True
+    supports_streaming_tool_use = True
     supports_tool_use = True
     supports_vision = True
+    prompted_tool_grammar = "xml_tags"
 
     # Ollama is free – costs are always zero.
     MODEL_PRICING = {"default": {"prompt": 0.0, "completion": 0.0}}
@@ -203,6 +214,140 @@ class OllamaDriver(Driver):
         if reasoning_content is not None:
             result["reasoning_content"] = reasoning_content
         return result
+
+    # ------------------------------------------------------------------
+    # Live streaming with interleaved tool calls
+    # ------------------------------------------------------------------
+
+    def generate_messages_with_tools_stream(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> Iterator[LiveEvent]:
+        """Yield :class:`~prompture.agents.live_events.LiveEvent` for one
+        assistant turn that may interleave narration and tool calls.
+
+        Two modes:
+
+        - **Tier 1 (default)** — uses Ollama's native ``/api/chat`` with
+          ``stream=True`` and ``tools=[...]``. Text content streams as
+          :class:`~prompture.agents.live_events.TextDelta` events as
+          tokens arrive; tool calls land in the final ``done`` chunk
+          and are emitted as ``ToolUseStart`` / ``ToolInputDelta`` /
+          ``ToolUseStop`` events. Works on tool-trained models
+          (Llama 3.1+, Mistral Nemo, Qwen 2.5, etc.).
+        - **Tier 2** — emulated streaming-tool via prompted tool use.
+          Activated by ``options["prompted_tools"] = True``. The grammar
+          is injected into the system prompt; the parser detects tool
+          calls in the token stream character-by-character. Works on
+          *any* Ollama model (including ones without native tool
+          training like Phi-3, older Gemma, base Llama 3).
+        """
+        if options.get("prompted_tools"):
+            yield from self._stream_via_prompted_emulation(messages, tools, options)
+            return
+
+        yield from self._stream_native_with_tools(messages, tools, options)
+
+    def _stream_native_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> Iterator[LiveEvent]:
+        """Tier 1: native Ollama streaming with tools.
+
+        Ollama emits content tokens incrementally and reports tool calls
+        in the final chunk (``done=True``). We stream the text live and
+        emit synthetic ``ToolUseStart`` / ``ToolInputDelta`` /
+        ``ToolUseStop`` events once the tool-call list arrives.
+        """
+        merged = self.options.copy()
+        if options:
+            merged.update(options)
+
+        messages = self._prepare_messages(messages)
+        chat_endpoint = self.endpoint.replace("/api/generate", "/api/chat")
+
+        payload: dict[str, Any] = {
+            "model": merged.get("model", self.model),
+            "messages": messages,
+            "tools": tools,
+            "stream": True,
+        }
+        for key in ("temperature", "top_p", "top_k"):
+            if key in merged:
+                payload[key] = merged[key]
+
+        prompt_tokens = 0
+        completion_tokens = 0
+        stop_reason = "stop"
+        tool_calls_raw: list[dict[str, Any]] = []
+
+        r = requests.post(  # nosec B113
+            chat_endpoint,
+            json=payload,
+            timeout=merged.get("timeout", 300),
+            stream=True,
+        )
+        r.raise_for_status()
+
+        for line in r.iter_lines():
+            if not line:
+                continue
+            try:
+                chunk = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            if chunk.get("done"):
+                prompt_tokens = chunk.get("prompt_eval_count", 0)
+                completion_tokens = chunk.get("eval_count", 0)
+                stop_reason = chunk.get("done_reason", "stop")
+                msg = chunk.get("message", {}) or {}
+                tool_calls_raw = msg.get("tool_calls", []) or []
+                # Some Ollama versions also include trailing content on
+                # the final chunk — emit it before tool events.
+                tail = msg.get("content", "")
+                if tail:
+                    yield TextDelta(text=tail)
+            else:
+                msg = chunk.get("message", {}) or {}
+                content = msg.get("content", "")
+                if content:
+                    yield TextDelta(text=content)
+
+        for tc in tool_calls_raw:
+            func = tc.get("function", {}) or {}
+            name = func.get("name", "")
+            args = func.get("arguments", {})
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args)
+                except json.JSONDecodeError:
+                    logger.warning("Failed to parse Ollama tool args for %s: %r", name, args[:200])
+                    args = {}
+            if not isinstance(args, dict):
+                args = {}
+            tool_id = tc.get("id") or f"call_{uuid.uuid4().hex[:24]}"
+            yield ToolUseStart(id=tool_id, name=name)
+            try:
+                fragment = json.dumps(args)
+            except (TypeError, ValueError):
+                fragment = "{}"
+            if fragment and fragment != "{}":
+                yield ToolInputDelta(id=tool_id, fragment=fragment)
+            yield ToolUseStop(id=tool_id, name=name, input=args)
+
+        usage = {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+            "cost": 0.0,
+            "model_name": merged.get("model", self.model),
+        }
+        yield MessageStop(stop_reason=stop_reason, usage=usage)
 
     # ------------------------------------------------------------------
     # Streaming

--- a/tests/test_driver_contract.py
+++ b/tests/test_driver_contract.py
@@ -69,8 +69,8 @@ def test_capability_resolution_uses_driver_instance() -> None:
     drops streaming support to exercise the lookup path with a known
     mismatch between provider-level claims and instance-level reality.
     """
-    from prompture.drivers.async_ollama_driver import AsyncOllamaDriver
     from prompture.drivers.async_base import AsyncDriver
+    from prompture.drivers.async_ollama_driver import AsyncOllamaDriver
     from prompture.drivers.ollama_driver import OllamaDriver
     from prompture.infra.capabilities import get_capabilities
 

--- a/tests/test_driver_contract.py
+++ b/tests/test_driver_contract.py
@@ -62,22 +62,32 @@ def test_capability_resolution_uses_driver_instance() -> None:
 
     Pre-fix, ``_populate_from_descriptors`` registered sync flags at the
     provider level and ``get_capabilities`` returned them before consulting
-    the live driver instance.  Async ollama therefore claimed streaming
-    support (inherited from the sync sibling's registry entry) even though
-    ``AsyncOllamaDriver`` does not implement ``generate_messages_stream``.
+    the live driver instance, so async drivers could claim capabilities
+    they didn't implement.
+
+    We synthesize a stripped-down ``AsyncOllamaDriver`` subclass that
+    drops streaming support to exercise the lookup path with a known
+    mismatch between provider-level claims and instance-level reality.
     """
     from prompture.drivers.async_ollama_driver import AsyncOllamaDriver
+    from prompture.drivers.async_base import AsyncDriver
     from prompture.drivers.ollama_driver import OllamaDriver
     from prompture.infra.capabilities import get_capabilities
 
     assert OllamaDriver.supports_streaming is True
-    assert getattr(AsyncOllamaDriver, "supports_streaming", False) is False
+    assert AsyncOllamaDriver.supports_streaming is True
 
-    async_driver = AsyncOllamaDriver(endpoint="http://localhost:11434")
+    class NoStreamAsyncOllama(AsyncOllamaDriver):
+        supports_streaming = False
+        # Drop the override so it falls back to AsyncDriver's NotImplementedError default.
+        generate_messages_stream = AsyncDriver.generate_messages_stream
+
+    async_driver = NoStreamAsyncOllama(endpoint="http://localhost:11434")
     caps = get_capabilities("ollama/llama3", driver=async_driver)
     assert caps.streaming is False, (
-        "Capability registry returned streaming=True for an AsyncOllamaDriver "
-        "instance — the provider-level cache is shadowing live driver flags."
+        "Capability registry returned streaming=True for an async driver "
+        "instance that explicitly opts out — the provider-level cache is "
+        "shadowing live driver flags."
     )
 
 
@@ -103,6 +113,7 @@ def test_capability_resolution_user_override_beats_driver() -> None:
 def test_validate_driver_capabilities_returns_violations() -> None:
     """Programmatic API returns a list — useful for plugin authors who
     want to integrate the check into their own assertions or CI logic."""
+    from prompture.drivers.base import Driver
     from prompture.drivers.ollama_driver import OllamaDriver
     from prompture.testing import validate_driver_capabilities
 
@@ -113,7 +124,7 @@ def test_validate_driver_capabilities_returns_violations() -> None:
         pass
 
     BrokenDriver.supports_streaming = True
-    BrokenDriver.generate_messages_stream = OllamaDriver.__bases__[0].generate_messages_stream
+    BrokenDriver.generate_messages_stream = Driver.generate_messages_stream
 
     violations = validate_driver_capabilities(BrokenDriver)
     assert any("supports_streaming" in v for v in violations)

--- a/tests/test_prompted_tool_stream.py
+++ b/tests/test_prompted_tool_stream.py
@@ -1,0 +1,361 @@
+"""Tests for :mod:`prompture.drivers._prompted_tool_stream`.
+
+These exercise the Tier-2 streaming-tool emulator that turns plain text
+output from a non-tool-calling model into the same interleaved
+:mod:`~prompture.agents.live_events` stream that native drivers produce.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from prompture.agents.live_events import (
+    LiveEvent,
+    MessageStop,
+    TextDelta,
+    ToolInputDelta,
+    ToolUseStart,
+    ToolUseStop,
+)
+from prompture.agents.tool_grammars import (
+    GRAMMARS,
+    XML_TAGS_GRAMMAR,
+    get_grammar,
+    inject_tool_instructions,
+)
+from prompture.drivers._prompted_tool_stream import (
+    PromptedToolStreamMixin,
+    PromptedToolStreamParser,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_parser(chunks: list[str]) -> list[LiveEvent]:
+    """Feed ``chunks`` into a fresh parser and return all events."""
+    parser = PromptedToolStreamParser(XML_TAGS_GRAMMAR)
+    out: list[LiveEvent] = []
+    for c in chunks:
+        out.extend(parser.feed(c))
+    out.extend(parser.finish())
+    return out
+
+
+def _text_of(events: list[LiveEvent]) -> str:
+    """Concatenate all ``TextDelta`` payloads (helper for assertions)."""
+    return "".join(e.text for e in events if isinstance(e, TextDelta))
+
+
+def _args_text_of(events: list[LiveEvent]) -> str:
+    """Concatenate all ``ToolInputDelta`` fragments."""
+    return "".join(e.fragment for e in events if isinstance(e, ToolInputDelta))
+
+
+# ---------------------------------------------------------------------------
+# Grammar registry
+# ---------------------------------------------------------------------------
+
+
+class TestGrammarRegistry:
+    def test_xml_tags_grammar_is_registered(self):
+        assert "xml_tags" in GRAMMARS
+        assert get_grammar("xml_tags") is XML_TAGS_GRAMMAR
+
+    def test_unknown_grammar_raises(self):
+        with pytest.raises(KeyError, match="Unknown tool grammar"):
+            get_grammar("nope")
+
+    def test_inject_tool_instructions_appends_to_existing_system(self):
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "hi"},
+        ]
+        tools = [{"function": {"name": "search", "description": "Search", "parameters": {}}}]
+        out = inject_tool_instructions(messages, tools, XML_TAGS_GRAMMAR)
+
+        assert out[0]["role"] == "system"
+        assert out[0]["content"].startswith("You are helpful.")
+        assert "<tool_call" in out[0]["content"]
+        assert "search" in out[0]["content"]
+        # Original list not mutated
+        assert messages[0]["content"] == "You are helpful."
+
+    def test_inject_tool_instructions_inserts_system_if_missing(self):
+        messages = [{"role": "user", "content": "hi"}]
+        tools = [{"function": {"name": "search", "description": "x", "parameters": {}}}]
+        out = inject_tool_instructions(messages, tools, XML_TAGS_GRAMMAR)
+
+        assert out[0]["role"] == "system"
+        assert "<tool_call" in out[0]["content"]
+        assert out[1]["role"] == "user"
+
+    def test_inject_tool_instructions_empty_tools_is_passthrough(self):
+        messages = [{"role": "user", "content": "hi"}]
+        out = inject_tool_instructions(messages, [], XML_TAGS_GRAMMAR)
+        assert out == messages
+        # Returns a copy though
+        assert out is not messages
+
+
+# ---------------------------------------------------------------------------
+# Parser — pure narration paths
+# ---------------------------------------------------------------------------
+
+
+class TestParserNarration:
+    def test_plain_text_no_tools(self):
+        events = _run_parser(["Hello, world!"])
+        assert _text_of(events) == "Hello, world!"
+        assert not any(isinstance(e, (ToolUseStart, ToolUseStop)) for e in events)
+
+    def test_text_split_across_many_chunks(self):
+        events = _run_parser(["Hel", "lo", ", ", "world", "!"])
+        assert _text_of(events) == "Hello, world!"
+
+    def test_empty_chunks_are_noop(self):
+        events = _run_parser(["hi", "", "", " there"])
+        assert _text_of(events) == "hi there"
+
+    def test_empty_input_emits_nothing(self):
+        events = _run_parser([])
+        assert events == []
+
+    def test_text_containing_lt_but_not_tool_call_is_emitted(self):
+        events = _run_parser(["a < b and c > d"])
+        assert _text_of(events) == "a < b and c > d"
+
+
+# ---------------------------------------------------------------------------
+# Parser — single tool call
+# ---------------------------------------------------------------------------
+
+
+class TestParserSingleToolCall:
+    def test_tool_call_only(self):
+        events = _run_parser(['<tool_call name="search">{"q": "cats"}</tool_call>'])
+        starts = [e for e in events if isinstance(e, ToolUseStart)]
+        stops = [e for e in events if isinstance(e, ToolUseStop)]
+        assert len(starts) == 1
+        assert starts[0].name == "search"
+        assert starts[0].id.startswith("call_")
+        assert len(stops) == 1
+        assert stops[0].input == {"q": "cats"}
+        # Same id flows through start → stop
+        assert starts[0].id == stops[0].id
+
+    def test_narration_before_and_after_tool_call(self):
+        events = _run_parser(['Let me search. <tool_call name="search">{"q": "cats"}</tool_call> Done.'])
+        text_blocks = [e.text for e in events if isinstance(e, TextDelta)]
+        assert "Let me search. " in text_blocks
+        assert any(" Done." in t for t in text_blocks)
+        stop = next(e for e in events if isinstance(e, ToolUseStop))
+        assert stop.input == {"q": "cats"}
+
+    def test_tool_call_with_explicit_id(self):
+        events = _run_parser(['<tool_call name="search" id="call_xyz">{"q":"a"}</tool_call>'])
+        start = next(e for e in events if isinstance(e, ToolUseStart))
+        assert start.id == "call_xyz"
+        stop = next(e for e in events if isinstance(e, ToolUseStop))
+        assert stop.id == "call_xyz"
+
+    def test_args_streamed_as_fragments(self):
+        # Force the args to arrive in many small pieces.
+        events = _run_parser(
+            [
+                '<tool_call name="search">',
+                '{"q"',
+                ': "ca',
+                "ts",
+                '"}',
+                "</tool_call>",
+            ]
+        )
+        assert _args_text_of(events) == '{"q": "cats"}'
+        stop = next(e for e in events if isinstance(e, ToolUseStop))
+        assert stop.input == {"q": "cats"}
+
+    def test_open_tag_split_across_chunks(self):
+        events = _run_parser(
+            [
+                "Before ",
+                "<tool_",
+                'call name="x">',
+                '{"a":1}',
+                "</tool_call>",
+                " after",
+            ]
+        )
+        assert "Before " in _text_of(events)
+        assert " after" in _text_of(events)
+        # The "<tool_" prefix should NOT have leaked into text output.
+        assert "<tool_" not in _text_of(events)
+        stop = next(e for e in events if isinstance(e, ToolUseStop))
+        assert stop.name == "x"
+        assert stop.input == {"a": 1}
+
+    def test_close_marker_split_across_chunks(self):
+        events = _run_parser(
+            [
+                '<tool_call name="x">{"a":1}</tool_',
+                "call>",
+                " post",
+            ]
+        )
+        stop = next(e for e in events if isinstance(e, ToolUseStop))
+        assert stop.input == {"a": 1}
+        # The "</tool_" prefix should NOT have leaked into args output.
+        assert "</tool_" not in _args_text_of(events)
+        assert " post" in _text_of(events)
+
+
+# ---------------------------------------------------------------------------
+# Parser — multi-tool & edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestParserMultiTool:
+    def test_two_tool_calls_in_one_turn(self):
+        events = _run_parser(
+            ['A <tool_call name="t1">{"x":1}</tool_call> B <tool_call name="t2">{"y":2}</tool_call> C']
+        )
+        starts = [e for e in events if isinstance(e, ToolUseStart)]
+        stops = [e for e in events if isinstance(e, ToolUseStop)]
+        assert [s.name for s in starts] == ["t1", "t2"]
+        assert [s.input for s in stops] == [{"x": 1}, {"y": 2}]
+        # All three text pieces present
+        text = _text_of(events)
+        for piece in ("A ", " B ", " C"):
+            assert piece in text
+
+    def test_two_tool_calls_each_in_their_own_chunk(self):
+        events = _run_parser(
+            [
+                '<tool_call name="t1">{"x":1}</tool_call>',
+                '<tool_call name="t2">{"y":2}</tool_call>',
+            ]
+        )
+        stops = [e for e in events if isinstance(e, ToolUseStop)]
+        assert len(stops) == 2
+        assert stops[0].input == {"x": 1}
+        assert stops[1].input == {"y": 2}
+
+
+class TestParserErrorRecovery:
+    def test_malformed_json_args_yields_empty_dict(self, caplog):
+        events = _run_parser(['<tool_call name="bad">{this is not json}</tool_call>'])
+        stop = next(e for e in events if isinstance(e, ToolUseStop))
+        assert stop.input == {}
+        assert "Failed to parse tool args JSON" in caplog.text
+
+    def test_args_parsed_as_non_dict_yields_empty_dict(self, caplog):
+        events = _run_parser(['<tool_call name="bad">[1, 2, 3]</tool_call>'])
+        stop = next(e for e in events if isinstance(e, ToolUseStop))
+        assert stop.input == {}
+        assert "not dict" in caplog.text
+
+    def test_unclosed_tool_call_at_end_emits_stop_with_warning(self, caplog):
+        events = _run_parser(['<tool_call name="search">{"q": "cats"'])
+        start = next(e for e in events if isinstance(e, ToolUseStart))
+        stops = [e for e in events if isinstance(e, ToolUseStop)]
+        assert start.name == "search"
+        assert len(stops) == 1
+        # Args won't be a complete JSON object, so input will be {} after
+        # graceful parse failure.
+        assert stops[0].input == {}
+        assert "was not closed" in caplog.text
+
+    def test_empty_args_block(self):
+        events = _run_parser(['<tool_call name="n">{}</tool_call>'])
+        stop = next(e for e in events if isinstance(e, ToolUseStop))
+        assert stop.input == {}
+
+
+# ---------------------------------------------------------------------------
+# Mixin integration with a fake driver
+# ---------------------------------------------------------------------------
+
+
+class _FakeStreamingDriver(PromptedToolStreamMixin):
+    """Minimal stand-in driver that yields a scripted token stream."""
+
+    prompted_tool_grammar = "xml_tags"
+
+    def __init__(self, chunks: list[str], meta: dict[str, Any] | None = None) -> None:
+        self._chunks = chunks
+        self._meta = meta or {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+            "cost": 0.0,
+            "model_name": "fake",
+        }
+        self.captured_messages: list[dict[str, Any]] | None = None
+
+    def generate_messages_stream(
+        self,
+        messages: list[dict[str, Any]],
+        options: dict[str, Any],
+    ) -> Iterator[dict[str, Any]]:
+        self.captured_messages = list(messages)
+        full = ""
+        for c in self._chunks:
+            full += c
+            yield {"type": "delta", "text": c}
+        yield {"type": "done", "text": full, "meta": self._meta}
+
+
+class TestMixinEmulation:
+    def test_emulation_injects_tool_instructions_into_system(self):
+        driver = _FakeStreamingDriver(chunks=["just narration"])
+        tools = [{"function": {"name": "x", "description": "x", "parameters": {}}}]
+        messages = [{"role": "user", "content": "hi"}]
+
+        list(driver._stream_via_prompted_emulation(messages, tools, {}))
+
+        assert driver.captured_messages is not None
+        assert driver.captured_messages[0]["role"] == "system"
+        assert "<tool_call" in driver.captured_messages[0]["content"]
+
+    def test_emulation_yields_text_then_message_stop(self):
+        driver = _FakeStreamingDriver(chunks=["hello", " world"])
+        events = list(
+            driver._stream_via_prompted_emulation(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[{"function": {"name": "x", "description": "x", "parameters": {}}}],
+                options={},
+            )
+        )
+        assert _text_of(events) == "hello world"
+        last = events[-1]
+        assert isinstance(last, MessageStop)
+        assert last.usage["total_tokens"] == 15
+
+    def test_emulation_detects_tool_call_in_stream(self):
+        driver = _FakeStreamingDriver(
+            chunks=[
+                "Thinking. ",
+                '<tool_call name="search">{"q":"cats"}</tool_call>',
+                " done.",
+            ],
+        )
+        events = list(
+            driver._stream_via_prompted_emulation(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[{"function": {"name": "search", "description": "x", "parameters": {}}}],
+                options={},
+            )
+        )
+
+        # We should see text, then tool, then text, then message stop.
+        kinds = [type(e).__name__ for e in events]
+        assert "ToolUseStart" in kinds
+        assert "ToolUseStop" in kinds
+        assert kinds[-1] == "MessageStop"
+
+        stop = next(e for e in events if isinstance(e, ToolUseStop))
+        assert stop.input == {"q": "cats"}


### PR DESCRIPTION
Brings the Conversation.ask_live / Agent.run_live interleaved streaming-tool experience to models without native function-calling training (Phi-3, Gemma, base Llama 3, etc.) — the parser detects tool-call delimiters in the token stream and emits the same LiveEvent sequence native drivers produce.

- prompture/agents/tool_grammars.py: ToolGrammar dataclass, XML_TAGS default grammar, system-prompt injection helper, grammar registry
- prompture/drivers/_prompted_tool_stream.py: PromptedToolStreamParser state machine (handles partial open/close delimiters across chunks, multi-tool turns, malformed-JSON recovery) + PromptedToolStreamMixin for driver opt-in
- OllamaDriver: generate_messages_with_tools_stream with Tier 1 native path (streams tokens live, emits tool events from final chunk) and Tier 2 fallback via options={"prompted_tools": True}
- AsyncOllamaDriver: same; also gains generate_messages_stream which was missing (httpx.AsyncClient.stream against /api/chat)
- driver-contract tests updated for the new mixin base ordering and the now-streaming AsyncOllamaDriver
- 25-test suite covering grammar registry, parser narration, single + multi tool calls, partial-delimiter splits, error recovery, and end-to-end mixin emulation
- examples/agent_live_stream_ollama.py demonstrating both tiers
- README "Live Streaming Tool Calls" section with the mixin opt-in pattern other drivers can follow