### PR TITLE
Cache the conversation, not just the system prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1341,36 +1341,78 @@ if doc.found:
 
 Both helpers return plain dataclasses with no I/O of their own.  See `examples/assistant_example.py` for the assistant + review-loop + extractor flow end-to-end.
 
-### Prompt Caching (Claude)
+### Prompt Caching
 
-Anthropic prompt caching cuts input-token cost on cached prefixes to ~10% of
-the normal rate. Prompture turns it on by default for `ClaudeDriver` and
-`AsyncClaudeDriver` whenever the system prompt or tools bundle is large
-enough to benefit (≥4000 chars, roughly 1024 tokens — Anthropic's minimum
-cacheable block).
+Prompt caching cuts input-token cost on the repeated prefix to ~10% of the
+normal rate. Prompture turns it on by default, and how it works depends on
+the provider:
+
+| Provider | Mechanism | What Prompture does |
+| --- | --- | --- |
+| Claude API, Bedrock | Explicit `cache_control` breakpoints | Marks `system`, `tools`, **and the message array** |
+| OpenAI | Automatic, routed per machine | Sends a `prompt_cache_key` derived from the stable prefix |
+| Grok, DeepSeek, Moonshot, Groq | Fully automatic | Nothing to send — reports `cached_prompt_tokens` |
+| Google Gemini | Implicit (2.5+) / explicit `CachedContent` | Implicit only; explicit caching is not wired up yet |
 
 ```python
 from prompture import Conversation
 
 # Caching is automatic. The first call writes the cache (~1.25x cost on the
-# cached portion); subsequent calls within 5 minutes hit it (~0.1x cost).
+# cached portion); subsequent calls within the TTL hit it (~0.1x cost).
 conv = Conversation(model_name="claude/claude-sonnet-4-6", system_prompt=LONG_SYSTEM_PROMPT)
 conv.ask("First question")   # cache_creation_input_tokens > 0
 conv.ask("Second question")  # cache_read_input_tokens > 0
 ```
 
 To inspect cache activity, read `cached_prompt_tokens` and
-`cache_creation_tokens` from the response meta. To disable caching for a
-specific call pass `options={"cache_prompt": False}`.
+`cache_creation_tokens` from the response meta.
+
+**Options** (all per-call, via `options={...}`):
+
+| Option | Default | Effect |
+| --- | --- | --- |
+| `cache_prompt` | `True` | Set `False` to disable caching entirely for the call |
+| `cache_ttl` | `"5m"` | `"1h"` keeps entries alive across gaps; writes cost 2x input instead of 1.25x |
+| `prompt_cache_key` | derived | OpenAI only — override the routing key |
+
+Use `cache_ttl="1h"` for **bursty or scheduled** workloads. A job that runs
+once every 30 minutes writes a 5-minute cache entry that always expires
+before the next run — paying the write premium for zero reads, which is the
+most common cause of a low reported cache hit rate.
+
+#### Message-level breakpoints
+
+`system` and `tools` are a fixed-size prefix; the **message array** is what
+grows during an agentic tool loop, and it is usually the larger share of the
+tokens. Prompture places two breakpoints on it: a rolling one on the last
+message, and a stride-aligned anchor counted from the front that stays put as
+the conversation grows (so its cache entry remains readable inside
+Anthropic's 20-block lookback window). Anthropic caps a request at 4
+breakpoints total, and the budget is allocated `system` → `tools` → messages.
+
+#### Per-model minimums
+
+Blocks below Anthropic's minimum cacheable size are silently ignored — no
+error, just no cache entry. The minimum is **not** monotonic across models,
+so Prompture looks it up per model rather than using one threshold:
+
+| Models | Minimum |
+| --- | --- |
+| Opus 5, Fable 5, Mythos 5 | 512 tokens |
+| Opus 4.8, Sonnet 5, Sonnet 4.6/4.5 | 1024 tokens |
+| Opus 4.7, Haiku 3.5 | 2048 tokens |
+| Opus 4.6, Opus 4.5, Haiku 4.5 | 4096 tokens |
 
 Tips:
 - Put stable content (persona, tools description, JSON schema) at the
   **start** of the system prompt; put per-call variables (user query,
   retrieved RAG context) in the message stream so they don't bust the cache.
-- Avoid `{{iteration}}` or other per-turn variables in Persona templates —
-  they rotate the cache key every turn.
-- Block size below ~1024 tokens is silently dropped by Anthropic; below
-  the threshold Prompture skips the `cache_control` marker to avoid noise.
+- Avoid `{{current_datetime}}`, `{{current_timestamp}}`, `{{iteration}}` or
+  other volatile variables in Persona templates — they rotate the cache key
+  every request and silently disable caching for the whole prefix.
+- Trimming history from the front (`max_history_messages`) shifts the prefix
+  and invalidates the cache on **every** provider. Prefer a larger window, or
+  accept the trade deliberately.
 
 ### Cost Pre-flight
 

--- a/prompture/drivers/_prompt_cache.py
+++ b/prompture/drivers/_prompt_cache.py
@@ -1,0 +1,418 @@
+"""Provider-agnostic prompt-cache helpers.
+
+Prompt caching cuts input cost by ~90% on the repeated prefix of a
+request, but providers expose it in two very different ways:
+
+**1. Explicit breakpoints — Anthropic (Claude API, Bedrock, Vertex).**
+The caller marks blocks with ``cache_control`` and the API caches
+everything up to and including the marked block. Nothing is cached
+unless you ask. This module builds those markers.
+
+**2. Automatic prefix caching — OpenAI, xAI/Grok, DeepSeek, Moonshot.**
+There is no marker to send; the provider hashes the request prefix and
+caches it for you. The only levers are (a) keeping the prefix
+byte-stable across requests and (b) on OpenAI, passing
+``prompt_cache_key`` so requests sharing a prefix land on the same
+cache node. :func:`derive_prompt_cache_key` builds that key.
+
+Either way the win comes from the same discipline: **stable content
+first, volatile content last**. Caching is a prefix match, so a single
+changed byte at position N invalidates every cache entry at or after N.
+
+Why message-level breakpoints matter
+------------------------------------
+Marking only ``system`` and ``tools`` caches a fixed-size prefix. In an
+agentic tool loop the conversation is what actually grows — ten rounds
+of tool results can dwarf the system prompt — and re-sending it
+unmarked means it is billed at full input price every round. The
+rolling breakpoint from :func:`apply_cache_control_to_messages` is what
+turns a single-digit cache hit rate into a high one.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+# Rough bytes-per-token used to translate Anthropic's token-denominated
+# cache minimums into a cheap ``len(str)`` check. Deliberately
+# conservative: undershooting means we skip a cacheable block (a missed
+# saving), overshooting means we send a marker the API silently ignores
+# (no error, no charge, just noise).
+CHARS_PER_TOKEN = 4
+
+# Anthropic's minimum cacheable prefix, in tokens. Blocks below this are
+# silently ignored — no error, no cache entry. The minimum is NOT
+# monotonic across generations, so this has to be a per-model lookup
+# rather than a single constant: Opus 4.6 needs 8x the prefix that
+# Opus 5 does.
+#
+# Keys are matched as prefixes of the model id, longest first, so
+# "claude-opus-4-6-20251101" resolves via "claude-opus-4-6".
+ANTHROPIC_CACHE_MIN_TOKENS: dict[str, int] = {
+    # 512-token tier
+    "claude-opus-5": 512,
+    "claude-fable-5": 512,
+    "claude-mythos-5": 512,
+    # 1024-token tier
+    "claude-opus-4-8": 1024,
+    "claude-sonnet-5": 1024,
+    "claude-sonnet-4-6": 1024,
+    "claude-sonnet-4-5": 1024,
+    "claude-sonnet-4": 1024,
+    "claude-opus-4-1": 1024,
+    "claude-opus-4-0": 1024,
+    "claude-opus-4": 1024,
+    # 2048-token tier
+    "claude-opus-4-7": 2048,
+    "claude-mythos-preview": 2048,
+    "claude-3-5-haiku": 2048,
+    # 4096-token tier
+    "claude-opus-4-6": 4096,
+    "claude-opus-4-5": 4096,
+    "claude-haiku-4-5": 4096,
+}
+
+# Used when the model id doesn't match any known prefix. 1024 tokens is
+# the most common tier and the safest middle ground: too low and we send
+# ignored markers, too high and we skip real savings.
+DEFAULT_CACHE_MIN_TOKENS = 1024
+
+# Backwards-compatible flat threshold (1024 tokens x 4 chars/token).
+# Retained so existing callers and tests that import this constant keep
+# working; new code should use :func:`min_cache_chars`.
+CACHE_PROMPT_MIN_CHARS = 4000
+
+# Anthropic allows at most 4 ``cache_control`` breakpoints per request;
+# a 5th is a hard API error, so the budget is split explicitly between
+# system, tools and messages by the caller.
+MAX_CACHE_BREAKPOINTS = 4
+
+# Anthropic walks back at most 20 content blocks from a breakpoint
+# looking for an existing cache entry. Anchoring the second message
+# breakpoint on this stride keeps a readable entry inside that window
+# even when a single tool round appends many messages.
+ANCHOR_STRIDE = 20
+
+# Block types that must never carry a cache_control marker — the API
+# rejects markers on reasoning blocks.
+_UNMARKABLE_BLOCK_TYPES = frozenset({"thinking", "redacted_thinking"})
+
+_VALID_TTLS = ("5m", "1h")
+
+
+def normalize_ttl(ttl: str | None) -> str:
+    """Coerce a caller-supplied TTL to one Anthropic accepts.
+
+    Anything unrecognised falls back to the 5-minute default rather than
+    raising — a bad TTL should cost a cache hit, not break the request.
+    """
+    if ttl in _VALID_TTLS:
+        return str(ttl)
+    return "5m"
+
+
+def cache_control(ttl: str | None = "5m") -> dict[str, Any]:
+    """Build a ``cache_control`` marker.
+
+    The 5-minute form is emitted without an explicit ``ttl`` key so the
+    payload stays byte-identical to what earlier versions sent (and so
+    it keeps working against older API versions).
+    """
+    normalized = normalize_ttl(ttl)
+    if normalized == "5m":
+        return {"type": "ephemeral"}
+    return {"type": "ephemeral", "ttl": normalized}
+
+
+def cache_write_multiplier(ttl: str | None = "5m") -> float:
+    """Cost multiplier to apply to the configured ``cache_write`` rate.
+
+    Rate tables store the 5-minute write price (1.25x input). A 1-hour
+    write costs 2x input, so it needs an extra 2.0 / 1.25 = 1.6x on top.
+    """
+    return 1.6 if normalize_ttl(ttl) == "1h" else 1.0
+
+
+def _lookup_min_tokens(model: str | None) -> int | None:
+    """Resolve ``model`` to a known minimum, or ``None`` if unrecognised."""
+    if not model:
+        return None
+    normalized = str(model).lower()
+    # Strip a provider prefix such as "anthropic/" or "claude/".
+    if "/" in normalized:
+        normalized = normalized.rsplit("/", 1)[-1]
+    # Bedrock ids look like "anthropic.claude-opus-5" or carry a
+    # region/version suffix; a longest-prefix match handles both.
+    best: int | None = None
+    best_len = -1
+    for prefix, minimum in ANTHROPIC_CACHE_MIN_TOKENS.items():
+        if prefix in normalized and len(prefix) > best_len:
+            best, best_len = minimum, len(prefix)
+    return best
+
+
+def min_cache_tokens(model: str | None) -> int:
+    """Return the minimum cacheable prefix for ``model``, in tokens."""
+    resolved = _lookup_min_tokens(model)
+    return resolved if resolved is not None else DEFAULT_CACHE_MIN_TOKENS
+
+
+def min_cache_chars(model: str | None = None, min_chars: int | None = None) -> int:
+    """Return the minimum cacheable prefix for ``model``, in characters.
+
+    An explicit ``min_chars`` always wins so callers (and tests) can
+    override the model-derived value. An unrecognised (or absent) model
+    keeps the legacy flat threshold rather than the slightly higher
+    tokens-based default, so behaviour is unchanged for callers that
+    never pass a model.
+    """
+    if min_chars is not None:
+        return min_chars
+    resolved = _lookup_min_tokens(model)
+    if resolved is None:
+        return CACHE_PROMPT_MIN_CHARS
+    return resolved * CHARS_PER_TOKEN
+
+
+# ----------------------------------------------------------------------
+# Anthropic — explicit cache_control breakpoints
+# ----------------------------------------------------------------------
+
+
+def apply_cache_control_to_system(
+    system_text: str | None,
+    *,
+    cache_prompt: bool,
+    model: str | None = None,
+    ttl: str | None = "5m",
+    min_chars: int | None = None,
+) -> str | list[dict[str, Any]] | None:
+    """Wrap the system prompt as a cacheable text block when worthwhile.
+
+    Returns the original string unchanged for short prompts (caching
+    would be silently dropped by the API). For longer prompts, returns
+    a single-element list ``[{"type": "text", "text": ..., "cache_control": ...}]``
+    that the Anthropic Messages API accepts in place of a plain string.
+
+    Returns ``None`` for an empty / missing system prompt so callers
+    can simply omit the ``system=`` kwarg.
+    """
+    if not system_text:
+        return None
+    if not cache_prompt or len(system_text) < min_cache_chars(model, min_chars):
+        return system_text
+    return [
+        {
+            "type": "text",
+            "text": system_text,
+            "cache_control": cache_control(ttl),
+        }
+    ]
+
+
+def apply_cache_control_to_tools(
+    tools: list[dict[str, Any]],
+    *,
+    cache_prompt: bool,
+    model: str | None = None,
+    ttl: str | None = "5m",
+    min_chars: int | None = None,
+) -> list[dict[str, Any]]:
+    """Tag the last tool dict with cache_control when the bundle is large.
+
+    Anthropic only honours one cache_control marker per logical section.
+    Putting it on the *last* tool extends the cached prefix through the
+    entire tools block. The cost of trying-and-being-ignored is tiny
+    (a few bytes per request), so we apply it whenever the combined
+    JSON for the tools meets the model's minimum.
+
+    Returns a new list (and shallow-copies the last tool dict) so the
+    caller's tool definitions aren't mutated.
+    """
+    if not cache_prompt or not tools:
+        return tools
+    combined_len = sum(len(json.dumps(t, default=str)) for t in tools)
+    if combined_len < min_cache_chars(model, min_chars):
+        return tools
+    result = list(tools)
+    last = dict(result[-1])
+    last["cache_control"] = cache_control(ttl)
+    result[-1] = last
+    return result
+
+
+def _mark_message(message: dict[str, Any], marker: dict[str, Any]) -> dict[str, Any] | None:
+    """Return a copy of ``message`` with ``marker`` on its last block.
+
+    String content is promoted to a single text block, since
+    ``cache_control`` can only live on a structured block. Returns
+    ``None`` when the message has nothing markable (empty content, or
+    only reasoning blocks) so the caller can walk further back.
+    """
+    content = message.get("content")
+
+    if isinstance(content, str):
+        if not content.strip():
+            return None
+        new_msg = dict(message)
+        new_msg["content"] = [{"type": "text", "text": content, "cache_control": marker}]
+        return new_msg
+
+    if isinstance(content, list) and content:
+        # Walk backwards to the last block that can carry a marker.
+        for idx in range(len(content) - 1, -1, -1):
+            block = content[idx]
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") in _UNMARKABLE_BLOCK_TYPES:
+                continue
+            new_blocks = list(content)
+            new_block = dict(block)
+            new_block["cache_control"] = marker
+            new_blocks[idx] = new_block
+            new_msg = dict(message)
+            new_msg["content"] = new_blocks
+            return new_msg
+
+    return None
+
+
+def _anchor_index(count: int, stride: int = ANCHOR_STRIDE) -> int | None:
+    """Pick a stable, front-counted index for the second breakpoint.
+
+    Counting from the front is what makes the anchor *stable*: the
+    message array grows append-only, so index 40 refers to the same
+    message on every subsequent request and the cache entry written
+    there stays readable. A rolling breakpoint alone would drift out of
+    the 20-block lookback window during fat tool rounds.
+
+    Returns ``None`` when the conversation is too short to need one.
+    """
+    if count <= stride:
+        return None
+    idx = ((count - 1) // stride) * stride
+    if idx <= 0 or idx >= count - 1:
+        return None
+    return idx
+
+
+def apply_cache_control_to_messages(
+    messages: list[dict[str, Any]],
+    *,
+    cache_prompt: bool,
+    model: str | None = None,
+    ttl: str | None = "5m",
+    min_chars: int | None = None,
+    max_breakpoints: int = 2,
+) -> list[dict[str, Any]]:
+    """Place rolling cache breakpoints on the conversation itself.
+
+    This is the breakpoint that matters for agentic runs. ``system`` and
+    ``tools`` are a fixed-size prefix; the message array is what grows,
+    and without a marker every tool round re-sends the whole accumulated
+    history at full input price.
+
+    Two breakpoints are placed when budget allows:
+
+    * a **rolling** one on the last message, which writes a cache entry
+      covering everything sent this round;
+    * an **anchor** one at a stride-aligned index counted from the front,
+      which stays put as the array grows and guarantees a readable entry
+      inside Anthropic's 20-block lookback window.
+
+    Returns a new list; input messages are never mutated.
+    """
+    if not cache_prompt or not messages or max_breakpoints <= 0:
+        return messages
+
+    combined_len = sum(len(json.dumps(m, default=str)) for m in messages)
+    if combined_len < min_cache_chars(model, min_chars):
+        return messages
+
+    marker = cache_control(ttl)
+    result = list(messages)
+    marked = 0
+
+    # Rolling breakpoint: last markable message, walking backwards past
+    # anything empty or reasoning-only.
+    rolling_idx: int | None = None
+    for idx in range(len(result) - 1, -1, -1):
+        updated = _mark_message(result[idx], marker)
+        if updated is not None:
+            result[idx] = updated
+            rolling_idx = idx
+            marked += 1
+            break
+
+    if rolling_idx is None:
+        return messages
+
+    # Anchor breakpoint, only if we have budget and the array is long
+    # enough for the rolling one to drift out of lookback range.
+    if marked < max_breakpoints:
+        anchor_idx = _anchor_index(len(result))
+        if anchor_idx is not None and anchor_idx != rolling_idx:
+            updated = _mark_message(result[anchor_idx], marker)
+            if updated is not None:
+                result[anchor_idx] = updated
+
+    return result
+
+
+def breakpoint_budget(*sections: Any) -> int:
+    """Remaining cache_control budget after the given sections are marked.
+
+    Anthropic hard-errors on a 5th breakpoint, so callers pass whatever
+    they already marked (a truthy value counts as one used breakpoint)
+    and get back how many are left for the messages array.
+    """
+    used = sum(1 for section in sections if _section_is_marked(section))
+    return max(0, MAX_CACHE_BREAKPOINTS - used)
+
+
+def _section_is_marked(section: Any) -> bool:
+    """True when ``section`` already carries a cache_control marker."""
+    if isinstance(section, list):
+        return any(isinstance(item, dict) and "cache_control" in item for item in section)
+    return False
+
+
+# ----------------------------------------------------------------------
+# OpenAI-family — automatic caching, routed by prompt_cache_key
+# ----------------------------------------------------------------------
+
+
+def derive_prompt_cache_key(
+    *,
+    system: str | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    explicit: str | None = None,
+    namespace: str = "prompture",
+) -> str | None:
+    """Build an OpenAI ``prompt_cache_key`` from the stable prefix.
+
+    OpenAI caches prefixes automatically, but routes requests across
+    machines; two requests sharing a prefix only share a cache if they
+    land on the same node. ``prompt_cache_key`` is the routing hint, so
+    hashing exactly the content that forms the stable prefix (system
+    prompt + tool definitions) sends every request with that prefix to
+    the same place.
+
+    Deliberately excludes the message array — that is the volatile part,
+    and including it would produce a unique key per request, which is
+    worse than sending no key at all.
+
+    Returns ``None`` when there is no stable prefix worth routing on.
+    """
+    if explicit:
+        return explicit
+    if not system and not tools:
+        return None
+    digest = hashlib.sha256()
+    if system:
+        digest.update(system.encode("utf-8", errors="replace"))
+    if tools:
+        digest.update(json.dumps(tools, sort_keys=True, default=str).encode("utf-8", errors="replace"))
+    return f"{namespace}-{digest.hexdigest()[:32]}"

--- a/prompture/drivers/async_claude_driver.py
+++ b/prompture/drivers/async_claude_driver.py
@@ -14,14 +14,28 @@ except ImportError:
     anthropic = None  # type: ignore[assignment]
 
 from ..infra.cost_mixin import CostMixin
+from ._prompt_cache import (
+    apply_cache_control_to_messages as _apply_cache_control_to_messages,
+)
+from ._prompt_cache import (
+    apply_cache_control_to_system as _apply_cache_control_to_system,
+)
+from ._prompt_cache import (
+    apply_cache_control_to_tools as _apply_cache_control_to_tools,
+)
+from ._prompt_cache import (
+    breakpoint_budget as _breakpoint_budget,
+)
+from ._prompt_cache import (
+    cache_write_multiplier as _cache_write_multiplier,
+)
 from .async_base import AsyncDriver
 from .claude_driver import (
     ClaudeDriver,
-    _apply_cache_control_to_system,
-    _apply_cache_control_to_tools,
     _build_anthropic_json_mode_tool_def,
     _build_anthropic_meta,
     _build_anthropic_stream_done,
+    _cache_opts,
     _convert_tools_to_anthropic,
     _extract_anthropic_cache_tokens,
     _extract_anthropic_system_and_messages,
@@ -84,7 +98,6 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
         model = options.get("model", self.model)
-        cache_prompt = opts.get("cache_prompt", True)
 
         # Validate capabilities against models.dev metadata
         self._validate_model_capabilities(
@@ -99,6 +112,25 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
 
         system_content, api_messages = _extract_anthropic_system_and_messages(messages)
 
+        cache_kwargs = _cache_opts(opts, model)
+        wrapped_system = _apply_cache_control_to_system(system_content, **cache_kwargs)
+
+        # Native JSON mode: use tool-use for schema enforcement
+        json_mode_tools: list[dict[str, Any]] | None = None
+        if options.get("json_mode") and options.get("json_schema"):
+            json_mode_tools = _apply_cache_control_to_tools(
+                [_build_anthropic_json_mode_tool_def(options["json_schema"])],
+                **cache_kwargs,
+            )
+
+        # Messages last: the breakpoint budget is whatever system and
+        # tools didn't already spend (Anthropic hard-errors on a 5th).
+        api_messages = _apply_cache_control_to_messages(
+            api_messages,
+            max_breakpoints=_breakpoint_budget(wrapped_system, json_mode_tools),
+            **cache_kwargs,
+        )
+
         common_kwargs: dict[str, Any] = {
             "model": model,
             "messages": api_messages,
@@ -106,18 +138,11 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
         }
         if supports_temperature:
             common_kwargs["temperature"] = opts["temperature"]
-        wrapped_system = _apply_cache_control_to_system(system_content, cache_prompt=cache_prompt)
         if wrapped_system is not None:
             common_kwargs["system"] = wrapped_system
 
-        # Native JSON mode: use tool-use for schema enforcement
         if options.get("json_mode"):
-            json_schema = options.get("json_schema")
-            if json_schema:
-                json_mode_tools = _apply_cache_control_to_tools(
-                    [_build_anthropic_json_mode_tool_def(json_schema)],
-                    cache_prompt=cache_prompt,
-                )
+            if json_mode_tools is not None:
                 resp = await client.messages.create(  # type: ignore[call-overload]
                     **common_kwargs,
                     tools=json_mode_tools,
@@ -147,6 +172,7 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
             resp.usage.output_tokens,
             cached_tokens=cache_read,
             cache_creation_tokens=cache_create,
+            cache_write_multiplier=_cache_write_multiplier(opts.get("cache_ttl", "5m")),
         )
         meta = _build_anthropic_meta(resp, model, total_cost)
 
@@ -182,7 +208,6 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
         model = options.get("model", self.model)
-        cache_prompt = opts.get("cache_prompt", True)
 
         self._validate_model_capabilities("claude", model, using_tool_use=True)
 
@@ -191,7 +216,14 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
         client = self.client
 
         system_content, api_messages = _extract_anthropic_system_and_messages(messages)
-        anthropic_tools = _apply_cache_control_to_tools(_convert_tools_to_anthropic(tools), cache_prompt=cache_prompt)
+        cache_kwargs = _cache_opts(opts, model)
+        anthropic_tools = _apply_cache_control_to_tools(_convert_tools_to_anthropic(tools), **cache_kwargs)
+        wrapped_system = _apply_cache_control_to_system(system_content, **cache_kwargs)
+        api_messages = _apply_cache_control_to_messages(
+            api_messages,
+            max_breakpoints=_breakpoint_budget(wrapped_system, anthropic_tools),
+            **cache_kwargs,
+        )
 
         kwargs: dict[str, Any] = {
             "model": model,
@@ -201,7 +233,6 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
         }
         if supports_temperature:
             kwargs["temperature"] = opts["temperature"]
-        wrapped_system = _apply_cache_control_to_system(system_content, cache_prompt=cache_prompt)
         if wrapped_system is not None:
             kwargs["system"] = wrapped_system
 
@@ -215,6 +246,7 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
             resp.usage.output_tokens,
             cached_tokens=cache_read,
             cache_creation_tokens=cache_create,
+            cache_write_multiplier=_cache_write_multiplier(opts.get("cache_ttl", "5m")),
         )
         meta = _build_anthropic_meta(resp, model, total_cost)
 
@@ -250,11 +282,17 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
         model = options.get("model", self.model)
-        cache_prompt = opts.get("cache_prompt", True)
         supports_temperature = self._get_model_config("claude", model)["supports_temperature"]
         client = self.client
 
         system_content, api_messages = _extract_anthropic_system_and_messages(messages)
+        cache_kwargs = _cache_opts(opts, model)
+        wrapped_system = _apply_cache_control_to_system(system_content, **cache_kwargs)
+        api_messages = _apply_cache_control_to_messages(
+            api_messages,
+            max_breakpoints=_breakpoint_budget(wrapped_system),
+            **cache_kwargs,
+        )
 
         kwargs: dict[str, Any] = {
             "model": model,
@@ -263,7 +301,6 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
         }
         if supports_temperature:
             kwargs["temperature"] = opts["temperature"]
-        wrapped_system = _apply_cache_control_to_system(system_content, cache_prompt=cache_prompt)
         if wrapped_system is not None:
             kwargs["system"] = wrapped_system
 
@@ -305,6 +342,7 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
             completion_tokens,
             cached_tokens=cache_read,
             cache_creation_tokens=cache_create,
+            cache_write_multiplier=_cache_write_multiplier(opts.get("cache_ttl", "5m")),
         )
         yield _build_anthropic_stream_done(
             model,
@@ -350,12 +388,18 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
 
         opts = {**{"temperature": 0.0, "max_tokens": 4096}, **options}
         model = options.get("model", self.model)
-        cache_prompt = opts.get("cache_prompt", True)
         supports_temperature = self._get_model_config("claude", model)["supports_temperature"]
         client = self.client
 
         system_content, api_messages = _extract_anthropic_system_and_messages(messages)
-        anthropic_tools = _apply_cache_control_to_tools(_convert_tools_to_anthropic(tools), cache_prompt=cache_prompt)
+        cache_kwargs = _cache_opts(opts, model)
+        anthropic_tools = _apply_cache_control_to_tools(_convert_tools_to_anthropic(tools), **cache_kwargs)
+        wrapped_system = _apply_cache_control_to_system(system_content, **cache_kwargs)
+        api_messages = _apply_cache_control_to_messages(
+            api_messages,
+            max_breakpoints=_breakpoint_budget(wrapped_system, anthropic_tools),
+            **cache_kwargs,
+        )
 
         kwargs: dict[str, Any] = {
             "model": model,
@@ -365,7 +409,6 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
         }
         if supports_temperature:
             kwargs["temperature"] = opts["temperature"]
-        wrapped_system = _apply_cache_control_to_system(system_content, cache_prompt=cache_prompt)
         if wrapped_system is not None:
             kwargs["system"] = wrapped_system
 
@@ -453,6 +496,7 @@ class AsyncClaudeDriver(CostMixin, AsyncDriver):
             completion_tokens,
             cached_tokens=cache_read,
             cache_creation_tokens=cache_create,
+            cache_write_multiplier=_cache_write_multiplier(opts.get("cache_ttl", "5m")),
         )
         meta = {
             "prompt_tokens": prompt_tokens,

--- a/prompture/drivers/async_openai_driver.py
+++ b/prompture/drivers/async_openai_driver.py
@@ -22,6 +22,7 @@ from .openai_driver import (
     _extract_openai_cached_tokens,
     _extract_openai_meta,
     _extract_openai_tool_calls,
+    _openai_prompt_cache_key,
 )
 
 logger = logging.getLogger(__name__)
@@ -89,7 +90,15 @@ class AsyncOpenAIDriver(CostMixin, AsyncDriver):
         )
 
         opts = {"temperature": 1.0, "max_tokens": 512, **options}
-        kwargs = _build_openai_base_kwargs(model, messages, opts, tokens_param, supports_temperature, 512)
+        kwargs = _build_openai_base_kwargs(
+            model,
+            messages,
+            opts,
+            tokens_param,
+            supports_temperature,
+            512,
+            prompt_cache_key=_openai_prompt_cache_key(messages, opts),
+        )
 
         # Native JSON mode support — with graceful fallback
         if options.get("json_mode"):
@@ -143,7 +152,14 @@ class AsyncOpenAIDriver(CostMixin, AsyncDriver):
 
         opts = {"temperature": 1.0, "max_tokens": 4096, **options}
         kwargs = _build_openai_base_kwargs(
-            model, messages, opts, tokens_param, supports_temperature, 4096, extra={"tools": tools}
+            model,
+            messages,
+            opts,
+            tokens_param,
+            supports_temperature,
+            4096,
+            extra={"tools": tools},
+            prompt_cache_key=_openai_prompt_cache_key(messages, opts, tools),
         )
 
         resp = await self.client.chat.completions.create(**kwargs)
@@ -200,6 +216,7 @@ class AsyncOpenAIDriver(CostMixin, AsyncDriver):
             supports_temperature,
             512,
             extra={"stream": True, "stream_options": {"include_usage": True}},
+            prompt_cache_key=_openai_prompt_cache_key(messages, opts),
         )
 
         stream = await self.client.chat.completions.create(**kwargs)

--- a/prompture/drivers/bedrock_driver.py
+++ b/prompture/drivers/bedrock_driver.py
@@ -42,6 +42,12 @@ except ImportError:  # pragma: no cover - exercised in tests via patch
     _BOTO3_AVAILABLE = False
 
 from ..infra.cost_mixin import CostMixin
+from ._prompt_cache import (
+    apply_cache_control_to_messages,
+    apply_cache_control_to_system,
+    apply_cache_control_to_tools,
+    breakpoint_budget,
+)
 from .base import Driver
 
 logger = logging.getLogger(__name__)
@@ -188,17 +194,36 @@ def _build_anthropic_request(
 ) -> dict[str, Any]:
     system_content, api_messages = _extract_system_and_messages(messages)
     api_messages = _prepare_anthropic_messages_for_bedrock(api_messages)
+
+    # Bedrock serves the same Anthropic Messages body, so the same
+    # cache_control breakpoints apply — system, tools, and (crucially for
+    # agentic loops) the message array itself.
+    cache_kwargs = {
+        "cache_prompt": options.get("cache_prompt", True),
+        "model": options.get("model"),
+        "ttl": options.get("cache_ttl", "5m"),
+    }
+    wrapped_system = apply_cache_control_to_system(system_content, **cache_kwargs)
+    anthropic_tools = (
+        apply_cache_control_to_tools(_convert_tools_to_anthropic_bedrock(tools), **cache_kwargs) if tools else None
+    )
+    api_messages = apply_cache_control_to_messages(
+        api_messages,
+        max_breakpoints=breakpoint_budget(wrapped_system, anthropic_tools),
+        **cache_kwargs,
+    )
+
     body: dict[str, Any] = {
         "anthropic_version": "bedrock-2023-05-31",
         "max_tokens": int(options.get("max_tokens", 512)),
         "messages": api_messages,
     }
-    if system_content:
-        body["system"] = system_content
+    if wrapped_system is not None:
+        body["system"] = wrapped_system
     if "temperature" in options:
         body["temperature"] = options["temperature"]
-    if tools:
-        body["tools"] = _convert_tools_to_anthropic_bedrock(tools)
+    if anthropic_tools is not None:
+        body["tools"] = anthropic_tools
     return body
 
 

--- a/prompture/drivers/claude_driver.py
+++ b/prompture/drivers/claude_driver.py
@@ -16,9 +16,33 @@ except ImportError:
     anthropic = None  # type: ignore[assignment]
 
 from ..infra.cost_mixin import CostMixin
+from ._prompt_cache import (
+    CACHE_PROMPT_MIN_CHARS,
+    MAX_CACHE_BREAKPOINTS,
+)
+from ._prompt_cache import (
+    apply_cache_control_to_messages as _apply_cache_control_to_messages,
+)
+from ._prompt_cache import (
+    apply_cache_control_to_system as _apply_cache_control_to_system,
+)
+from ._prompt_cache import (
+    apply_cache_control_to_tools as _apply_cache_control_to_tools,
+)
+from ._prompt_cache import (
+    breakpoint_budget as _breakpoint_budget,
+)
+from ._prompt_cache import (
+    cache_write_multiplier as _cache_write_multiplier,
+)
 from .base import Driver
 
 logger = logging.getLogger(__name__)
+
+# Re-exported for backwards compatibility: callers and tests have long
+# imported the cache threshold from this module. The implementation now
+# lives in ``_prompt_cache`` so the Bedrock and async drivers share it.
+__all__ = ["CACHE_PROMPT_MIN_CHARS", "MAX_CACHE_BREAKPOINTS", "ClaudeDriver"]
 
 
 # ----------------------------------------------------------------------
@@ -178,81 +202,37 @@ def _build_anthropic_json_mode_tool_def(json_schema: dict[str, Any]) -> dict[str
 # ----------------------------------------------------------------------
 # Prompt caching (Anthropic "ephemeral" cache_control blocks)
 #
-# Anthropic prompt caching delivers ~80% input-cost savings for stable
-# system prompts and tool definitions: cache_creation runs at 1.25x the
-# normal input rate, but cache_read runs at 0.1x. The cache lives for
-# ~5 minutes. Setting ``cache_control: {"type": "ephemeral"}`` on a
-# block tells the API to cache everything up to and including that
-# block.
+# Anthropic prompt caching delivers ~90% input-cost savings on the
+# repeated prefix: cache_creation runs at 1.25x the normal input rate
+# (2x for the 1-hour TTL), but cache_read runs at 0.1x. Setting
+# ``cache_control`` on a block caches everything up to and including
+# that block.
 #
-# Minimum cacheable block size (Anthropic):
-#   * 1024 tokens for Sonnet / Opus
-#   * 2048 tokens for Haiku
-# Blocks below the minimum are silently ignored — no error, just no
-# cache hit. To avoid pointless cache_control churn we only mark a
-# block when it's "substantial enough to be worth trying":
-# CACHE_PROMPT_MIN_CHARS ≈ 1024 tokens × 4 chars/token.
+# Three sections are markable and all three are marked here:
+#   * ``system``   — stable, marked once
+#   * ``tools``    — stable, marked on the last tool
+#   * ``messages`` — the one that actually grows. Without a breakpoint
+#     here, every round of an agentic tool loop re-sends the whole
+#     accumulated conversation at full input price, which is what keeps
+#     real-world cache hit rates in the single digits.
+#
+# Per-model minimums, TTL handling, and breakpoint placement all live in
+# ``_prompt_cache`` so the Bedrock driver (same Anthropic body shape)
+# and the async driver share one implementation.
 # ----------------------------------------------------------------------
 
-CACHE_PROMPT_MIN_CHARS = 4000
 
+def _cache_opts(opts: dict[str, Any], model: str) -> dict[str, Any]:
+    """Common cache kwargs derived from the caller's options.
 
-def _apply_cache_control_to_system(
-    system_text: str | None,
-    *,
-    cache_prompt: bool,
-    min_chars: int = CACHE_PROMPT_MIN_CHARS,
-) -> str | list[dict[str, Any]] | None:
-    """Wrap the system prompt as a cacheable text block when worthwhile.
-
-    Returns the original string unchanged for short prompts (caching
-    would be silently dropped by the API). For longer prompts, returns
-    a single-element list ``[{"type": "text", "text": ..., "cache_control": ...}]``
-    that the Anthropic Messages API accepts in place of a plain string.
-
-    Returns ``None`` for an empty / missing system prompt so callers
-    can simply omit the ``system=`` kwarg.
+    ``cache_prompt`` defaults on; ``cache_ttl`` selects the 5-minute
+    (default) or 1-hour cache window.
     """
-    if not system_text:
-        return None
-    if not cache_prompt or len(system_text) < min_chars:
-        return system_text
-    return [
-        {
-            "type": "text",
-            "text": system_text,
-            "cache_control": {"type": "ephemeral"},
-        }
-    ]
-
-
-def _apply_cache_control_to_tools(
-    tools: list[dict[str, Any]],
-    *,
-    cache_prompt: bool,
-    min_chars: int = CACHE_PROMPT_MIN_CHARS,
-) -> list[dict[str, Any]]:
-    """Tag the last tool dict with cache_control when the bundle is large.
-
-    Anthropic only honours one cache_control marker per logical section.
-    Putting it on the *last* tool extends the cached prefix through the
-    entire tools block. The cost of trying-and-being-ignored is tiny
-    (a few bytes per request), so we apply it whenever the combined
-    JSON for the tools meets ``min_chars``.
-
-    Returns a new list (and shallow-copies the last tool dict) so the
-    caller's tool definitions aren't mutated.
-    """
-    if not cache_prompt or not tools:
-        return tools
-    combined_len = sum(len(json.dumps(t, default=str)) for t in tools)
-    if combined_len < min_chars:
-        return tools
-    result = list(tools)
-    last = dict(result[-1])
-    last["cache_control"] = {"type": "ephemeral"}
-    result[-1] = last
-    return result
+    return {
+        "cache_prompt": opts.get("cache_prompt", True),
+        "model": model,
+        "ttl": opts.get("cache_ttl", "5m"),
+    }
 
 
 def _build_anthropic_stream_done(
@@ -362,7 +342,6 @@ class ClaudeDriver(CostMixin, Driver):
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
         model = options.get("model", self.model)
-        cache_prompt = opts.get("cache_prompt", True)
 
         # Validate capabilities against models.dev metadata
         self._validate_model_capabilities(
@@ -386,6 +365,25 @@ class ClaudeDriver(CostMixin, Driver):
             else:
                 api_messages.append(msg)
 
+        cache_kwargs = _cache_opts(opts, model)
+        wrapped_system = _apply_cache_control_to_system(system_content, **cache_kwargs)
+
+        # Native JSON mode: use tool-use for schema enforcement
+        json_mode_tools: list[dict[str, Any]] | None = None
+        if options.get("json_mode") and options.get("json_schema"):
+            json_mode_tools = _apply_cache_control_to_tools(
+                [_build_anthropic_json_mode_tool_def(options["json_schema"])],
+                **cache_kwargs,
+            )
+
+        # Messages last: the breakpoint budget is whatever system and
+        # tools didn't already spend (Anthropic hard-errors on a 5th).
+        api_messages = _apply_cache_control_to_messages(
+            api_messages,
+            max_breakpoints=_breakpoint_budget(wrapped_system, json_mode_tools),
+            **cache_kwargs,
+        )
+
         common_kwargs: dict[str, Any] = {
             "model": model,
             "messages": api_messages,
@@ -393,18 +391,11 @@ class ClaudeDriver(CostMixin, Driver):
         }
         if supports_temperature:
             common_kwargs["temperature"] = opts["temperature"]
-        wrapped_system = _apply_cache_control_to_system(system_content, cache_prompt=cache_prompt)
         if wrapped_system is not None:
             common_kwargs["system"] = wrapped_system
 
-        # Native JSON mode: use tool-use for schema enforcement
         if options.get("json_mode"):
-            json_schema = options.get("json_schema")
-            if json_schema:
-                json_mode_tools = _apply_cache_control_to_tools(
-                    [_build_anthropic_json_mode_tool_def(json_schema)],
-                    cache_prompt=cache_prompt,
-                )
+            if json_mode_tools is not None:
                 resp = client.messages.create(  # type: ignore[call-overload]
                     **common_kwargs,
                     tools=json_mode_tools,
@@ -434,6 +425,7 @@ class ClaudeDriver(CostMixin, Driver):
             resp.usage.output_tokens,
             cached_tokens=cache_read,
             cache_creation_tokens=cache_create,
+            cache_write_multiplier=_cache_write_multiplier(opts.get("cache_ttl", "5m")),
         )
         meta = _build_anthropic_meta(resp, model, total_cost)
 
@@ -480,7 +472,6 @@ class ClaudeDriver(CostMixin, Driver):
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
         model = options.get("model", self.model)
-        cache_prompt = opts.get("cache_prompt", True)
 
         self._validate_model_capabilities("claude", model, using_tool_use=True)
 
@@ -489,7 +480,14 @@ class ClaudeDriver(CostMixin, Driver):
         client = anthropic.Anthropic(api_key=self.api_key)
 
         system_content, api_messages = _extract_anthropic_system_and_messages(messages)
-        anthropic_tools = _apply_cache_control_to_tools(_convert_tools_to_anthropic(tools), cache_prompt=cache_prompt)
+        cache_kwargs = _cache_opts(opts, model)
+        anthropic_tools = _apply_cache_control_to_tools(_convert_tools_to_anthropic(tools), **cache_kwargs)
+        wrapped_system = _apply_cache_control_to_system(system_content, **cache_kwargs)
+        api_messages = _apply_cache_control_to_messages(
+            api_messages,
+            max_breakpoints=_breakpoint_budget(wrapped_system, anthropic_tools),
+            **cache_kwargs,
+        )
 
         kwargs: dict[str, Any] = {
             "model": model,
@@ -499,7 +497,6 @@ class ClaudeDriver(CostMixin, Driver):
         }
         if supports_temperature:
             kwargs["temperature"] = opts["temperature"]
-        wrapped_system = _apply_cache_control_to_system(system_content, cache_prompt=cache_prompt)
         if wrapped_system is not None:
             kwargs["system"] = wrapped_system
 
@@ -513,6 +510,7 @@ class ClaudeDriver(CostMixin, Driver):
             resp.usage.output_tokens,
             cached_tokens=cache_read,
             cache_creation_tokens=cache_create,
+            cache_write_multiplier=_cache_write_multiplier(opts.get("cache_ttl", "5m")),
         )
         meta = _build_anthropic_meta(resp, model, total_cost)
 
@@ -548,11 +546,17 @@ class ClaudeDriver(CostMixin, Driver):
 
         opts = {**{"temperature": 0.0, "max_tokens": 512}, **options}
         model = options.get("model", self.model)
-        cache_prompt = opts.get("cache_prompt", True)
         supports_temperature = self._get_model_config("claude", model)["supports_temperature"]
         client = anthropic.Anthropic(api_key=self.api_key)
 
         system_content, api_messages = _extract_anthropic_system_and_messages(messages)
+        cache_kwargs = _cache_opts(opts, model)
+        wrapped_system = _apply_cache_control_to_system(system_content, **cache_kwargs)
+        api_messages = _apply_cache_control_to_messages(
+            api_messages,
+            max_breakpoints=_breakpoint_budget(wrapped_system),
+            **cache_kwargs,
+        )
 
         kwargs: dict[str, Any] = {
             "model": model,
@@ -561,7 +565,6 @@ class ClaudeDriver(CostMixin, Driver):
         }
         if supports_temperature:
             kwargs["temperature"] = opts["temperature"]
-        wrapped_system = _apply_cache_control_to_system(system_content, cache_prompt=cache_prompt)
         if wrapped_system is not None:
             kwargs["system"] = wrapped_system
 
@@ -603,6 +606,7 @@ class ClaudeDriver(CostMixin, Driver):
             completion_tokens,
             cached_tokens=cache_read,
             cache_creation_tokens=cache_create,
+            cache_write_multiplier=_cache_write_multiplier(opts.get("cache_ttl", "5m")),
         )
         yield _build_anthropic_stream_done(
             model,
@@ -657,12 +661,18 @@ class ClaudeDriver(CostMixin, Driver):
 
         opts = {**{"temperature": 0.0, "max_tokens": 4096}, **options}
         model = options.get("model", self.model)
-        cache_prompt = opts.get("cache_prompt", True)
         supports_temperature = self._get_model_config("claude", model)["supports_temperature"]
         client = anthropic.Anthropic(api_key=self.api_key)
 
         system_content, api_messages = _extract_anthropic_system_and_messages(messages)
-        anthropic_tools = _apply_cache_control_to_tools(_convert_tools_to_anthropic(tools), cache_prompt=cache_prompt)
+        cache_kwargs = _cache_opts(opts, model)
+        anthropic_tools = _apply_cache_control_to_tools(_convert_tools_to_anthropic(tools), **cache_kwargs)
+        wrapped_system = _apply_cache_control_to_system(system_content, **cache_kwargs)
+        api_messages = _apply_cache_control_to_messages(
+            api_messages,
+            max_breakpoints=_breakpoint_budget(wrapped_system, anthropic_tools),
+            **cache_kwargs,
+        )
 
         kwargs: dict[str, Any] = {
             "model": model,
@@ -672,7 +682,6 @@ class ClaudeDriver(CostMixin, Driver):
         }
         if supports_temperature:
             kwargs["temperature"] = opts["temperature"]
-        wrapped_system = _apply_cache_control_to_system(system_content, cache_prompt=cache_prompt)
         if wrapped_system is not None:
             kwargs["system"] = wrapped_system
 
@@ -760,6 +769,7 @@ class ClaudeDriver(CostMixin, Driver):
             completion_tokens,
             cached_tokens=cache_read,
             cache_creation_tokens=cache_create,
+            cache_write_multiplier=_cache_write_multiplier(opts.get("cache_ttl", "5m")),
         )
         meta = {
             "prompt_tokens": prompt_tokens,

--- a/prompture/drivers/openai_driver.py
+++ b/prompture/drivers/openai_driver.py
@@ -13,6 +13,7 @@ except ImportError:
     OpenAI = None  # type: ignore[misc, assignment]
 
 from ..infra.cost_mixin import CostMixin, prepare_strict_schema
+from ._prompt_cache import derive_prompt_cache_key
 from .base import Driver, _parse_tool_arguments
 
 logger = logging.getLogger(__name__)
@@ -32,6 +33,7 @@ def _build_openai_base_kwargs(
     default_max_tokens: int,
     *,
     extra: dict[str, Any] | None = None,
+    prompt_cache_key: str | None = None,
 ) -> dict[str, Any]:
     kwargs: dict[str, Any] = {"model": model, "messages": messages}
     if extra:
@@ -39,7 +41,42 @@ def _build_openai_base_kwargs(
     kwargs[tokens_param] = opts.get("max_tokens", default_max_tokens)
     if supports_temperature and "temperature" in opts:
         kwargs["temperature"] = opts["temperature"]
+    # Opt-in only: OpenAI-compatible third-party endpoints (Grok, DeepSeek,
+    # Moonshot, Groq) share this builder and reject unknown fields, so
+    # callers pass the key explicitly rather than it being derived here.
+    if prompt_cache_key:
+        kwargs["prompt_cache_key"] = prompt_cache_key
     return kwargs
+
+
+def _openai_prompt_cache_key(
+    messages: list[dict[str, Any]],
+    opts: dict[str, Any],
+    tools: list[dict[str, Any]] | None = None,
+) -> str | None:
+    """Derive OpenAI's ``prompt_cache_key`` from the stable request prefix.
+
+    OpenAI caches prefixes automatically — there is no ``cache_control``
+    equivalent to send — but it routes requests across machines, and two
+    requests only share a cache if they land on the same one. Hashing the
+    system prompt and tool definitions (the stable prefix, never the
+    volatile message tail) sends every request built on that prefix to
+    the same node, which is what lifts the hit rate at any real volume.
+
+    Honours an explicit ``prompt_cache_key`` option, and is disabled
+    alongside the rest of caching via ``cache_prompt=False``.
+    """
+    if not opts.get("cache_prompt", True):
+        return None
+    system_text = next(
+        (str(m.get("content", "")) for m in messages if m.get("role") == "system"),
+        None,
+    )
+    return derive_prompt_cache_key(
+        system=system_text,
+        tools=tools,
+        explicit=opts.get("prompt_cache_key"),
+    )
 
 
 def _build_openai_json_mode_response_format(json_schema: dict[str, Any]) -> dict[str, Any]:
@@ -199,7 +236,15 @@ class OpenAIDriver(CostMixin, Driver):
         )
 
         opts = {"temperature": 1.0, "max_tokens": 512, **options}
-        kwargs = _build_openai_base_kwargs(model, messages, opts, tokens_param, supports_temperature, 512)
+        kwargs = _build_openai_base_kwargs(
+            model,
+            messages,
+            opts,
+            tokens_param,
+            supports_temperature,
+            512,
+            prompt_cache_key=_openai_prompt_cache_key(messages, opts),
+        )
 
         # Native JSON mode support — with graceful fallback
         if options.get("json_mode"):
@@ -253,7 +298,14 @@ class OpenAIDriver(CostMixin, Driver):
 
         opts = {"temperature": 1.0, "max_tokens": 4096, **options}
         kwargs = _build_openai_base_kwargs(
-            model, messages, opts, tokens_param, supports_temperature, 4096, extra={"tools": tools}
+            model,
+            messages,
+            opts,
+            tokens_param,
+            supports_temperature,
+            4096,
+            extra={"tools": tools},
+            prompt_cache_key=_openai_prompt_cache_key(messages, opts, tools),
         )
 
         resp = self.client.chat.completions.create(**kwargs)
@@ -310,6 +362,7 @@ class OpenAIDriver(CostMixin, Driver):
             supports_temperature,
             512,
             extra={"stream": True, "stream_options": {"include_usage": True}},
+            prompt_cache_key=_openai_prompt_cache_key(messages, opts),
         )
 
         stream = self.client.chat.completions.create(**kwargs)

--- a/prompture/infra/cost_mixin.py
+++ b/prompture/infra/cost_mixin.py
@@ -92,6 +92,7 @@ class CostMixin:
         *,
         cached_tokens: int | float = 0,
         cache_creation_tokens: int | float = 0,
+        cache_write_multiplier: float = 1.0,
     ) -> float:
         """Calculate USD cost for a generation call.
 
@@ -102,6 +103,11 @@ class CostMixin:
         ``cache_read`` rate (and ``cache_write`` rate for Anthropic-style
         cache writes) when the rate is available; otherwise they fall back
         to the full input rate.
+
+        ``cache_write_multiplier`` scales the stored ``cache_write`` rate.
+        Rate tables carry Anthropic's 5-minute write price (1.25x input);
+        a 1-hour write costs 2x input, so that TTL passes 1.6 here rather
+        than duplicating every model's rate row.
 
         ``prompt_tokens`` is treated as the *total* prompt token count
         reported by the provider (which already includes any cached tokens
@@ -117,7 +123,7 @@ class CostMixin:
         input_rate = live_rates.get("input", 0.0)
         output_rate = live_rates.get("output", 0.0)
         cache_read_rate = live_rates.get("cache_read", input_rate)
-        cache_write_rate = live_rates.get("cache_write", input_rate)
+        cache_write_rate = live_rates.get("cache_write", input_rate) * cache_write_multiplier
 
         cached = max(0, cached_tokens)
         cache_created = max(0, cache_creation_tokens)

--- a/tests/test_prompt_cache_messages.py
+++ b/tests/test_prompt_cache_messages.py
@@ -1,0 +1,356 @@
+"""Tests for message-level prompt caching, per-model minimums and TTL.
+
+The system/tools breakpoints are covered by ``test_claude_prompt_caching``.
+This file covers the pieces added to lift real-world cache hit rates:
+
+1. **Message breakpoints** — the rolling + anchor placement that keeps a
+   growing agentic conversation cacheable.
+2. **Per-model minimums** — Anthropic's minimum cacheable prefix varies
+   8x across models, so a flat char threshold both skipped cacheable
+   prompts and marked blocks the API ignores.
+3. **TTL** — the 1-hour cache window and its 2x write pricing.
+4. **OpenAI routing** — ``prompt_cache_key`` derivation.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from prompture.drivers._prompt_cache import (
+    MAX_CACHE_BREAKPOINTS,
+    apply_cache_control_to_messages,
+    apply_cache_control_to_system,
+    breakpoint_budget,
+    cache_control,
+    cache_write_multiplier,
+    derive_prompt_cache_key,
+    min_cache_chars,
+    min_cache_tokens,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _msg(role: str, text: str) -> dict[str, Any]:
+    return {"role": role, "content": text}
+
+
+def _conversation(turns: int, *, chars: int = 1500) -> list[dict[str, Any]]:
+    """A conversation guaranteed to clear any model's cache minimum."""
+    out: list[dict[str, Any]] = []
+    for i in range(turns):
+        role = "user" if i % 2 == 0 else "assistant"
+        out.append(_msg(role, f"turn-{i} " + "x" * chars))
+    return out
+
+
+def _markers(messages: list[dict[str, Any]]) -> list[int]:
+    """Indices of messages carrying a cache_control marker."""
+    found: list[int] = []
+    for idx, m in enumerate(messages):
+        content = m.get("content")
+        if isinstance(content, list) and any(isinstance(b, dict) and "cache_control" in b for b in content):
+            found.append(idx)
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Per-model minimums
+# ---------------------------------------------------------------------------
+
+
+class TestModelMinimums:
+    def test_opus_5_uses_512_token_minimum(self) -> None:
+        assert min_cache_tokens("claude-opus-5") == 512
+
+    def test_sonnet_5_uses_1024_token_minimum(self) -> None:
+        assert min_cache_tokens("claude-sonnet-5") == 1024
+
+    def test_haiku_45_uses_4096_token_minimum(self) -> None:
+        assert min_cache_tokens("claude-haiku-4-5") == 4096
+
+    def test_dated_snapshot_resolves_via_prefix(self) -> None:
+        assert min_cache_tokens("claude-haiku-4-5-20251001") == 4096
+
+    def test_bedrock_prefixed_id_resolves(self) -> None:
+        assert min_cache_tokens("anthropic.claude-opus-5") == 512
+
+    def test_unknown_model_falls_back_to_default(self) -> None:
+        assert min_cache_tokens("some-future-model") == 1024
+
+    def test_none_model_falls_back_to_default(self) -> None:
+        assert min_cache_tokens(None) == 1024
+
+    def test_longest_prefix_wins(self) -> None:
+        # "claude-opus-4-6" must not be shadowed by a shorter "claude-opus-4".
+        assert min_cache_tokens("claude-opus-4-6") == 4096
+
+    def test_explicit_min_chars_overrides_model(self) -> None:
+        assert min_cache_chars("claude-haiku-4-5", 50) == 50
+
+    def test_opus_5_prompt_below_old_flat_threshold_now_caches(self) -> None:
+        """The regression the flat 4000-char threshold caused.
+
+        A ~2500-char system prompt clears Opus 5's 512-token minimum but
+        sat under the old flat threshold, so it was silently never cached.
+        """
+        text = "x" * 2500
+        out = apply_cache_control_to_system(text, cache_prompt=True, model="claude-opus-5")
+        assert isinstance(out, list)
+        assert out[0]["cache_control"] == {"type": "ephemeral"}
+
+    def test_haiku_45_prompt_below_its_minimum_is_not_marked(self) -> None:
+        """Inverse case: don't send markers Haiku 4.5 will ignore."""
+        text = "x" * 5000
+        out = apply_cache_control_to_system(text, cache_prompt=True, model="claude-haiku-4-5")
+        assert out == text
+
+
+# ---------------------------------------------------------------------------
+# TTL
+# ---------------------------------------------------------------------------
+
+
+class TestCacheTTL:
+    def test_default_ttl_omits_key_for_wire_compatibility(self) -> None:
+        assert cache_control("5m") == {"type": "ephemeral"}
+
+    def test_one_hour_ttl_sets_key(self) -> None:
+        assert cache_control("1h") == {"type": "ephemeral", "ttl": "1h"}
+
+    def test_unknown_ttl_falls_back_to_default(self) -> None:
+        assert cache_control("7d") == {"type": "ephemeral"}
+        assert cache_control(None) == {"type": "ephemeral"}
+
+    def test_write_multiplier_is_neutral_for_5m(self) -> None:
+        assert cache_write_multiplier("5m") == 1.0
+
+    def test_write_multiplier_scales_1h_to_2x_input(self) -> None:
+        # Rate tables store the 5m write price (1.25x input); 1h is 2x.
+        assert cache_write_multiplier("1h") * 1.25 == 2.0
+
+    def test_ttl_propagates_into_system_block(self) -> None:
+        out = apply_cache_control_to_system("x" * 5000, cache_prompt=True, model="claude-sonnet-5", ttl="1h")
+        assert isinstance(out, list)
+        assert out[0]["cache_control"]["ttl"] == "1h"
+
+
+# ---------------------------------------------------------------------------
+# Message breakpoints — the actual fix
+# ---------------------------------------------------------------------------
+
+
+class TestMessageBreakpoints:
+    def test_disabled_returns_input_unchanged(self) -> None:
+        msgs = _conversation(4)
+        assert apply_cache_control_to_messages(msgs, cache_prompt=False) is msgs
+
+    def test_empty_messages_unchanged(self) -> None:
+        assert apply_cache_control_to_messages([], cache_prompt=True) == []
+
+    def test_zero_budget_returns_unchanged(self) -> None:
+        msgs = _conversation(4)
+        out = apply_cache_control_to_messages(msgs, cache_prompt=True, max_breakpoints=0)
+        assert out is msgs
+
+    def test_short_conversation_not_marked(self) -> None:
+        msgs = [_msg("user", "hi")]
+        out = apply_cache_control_to_messages(msgs, cache_prompt=True, model="claude-sonnet-5")
+        assert _markers(out) == []
+
+    def test_last_message_gets_rolling_breakpoint(self) -> None:
+        msgs = _conversation(4)
+        out = apply_cache_control_to_messages(msgs, cache_prompt=True, model="claude-sonnet-5")
+        assert len(out) - 1 in _markers(out)
+
+    def test_string_content_promoted_to_text_block(self) -> None:
+        msgs = _conversation(4)
+        out = apply_cache_control_to_messages(msgs, cache_prompt=True, model="claude-sonnet-5")
+        last = out[-1]["content"]
+        assert isinstance(last, list)
+        assert last[0]["type"] == "text"
+        assert last[0]["text"] == msgs[-1]["content"]
+
+    def test_input_messages_not_mutated(self) -> None:
+        msgs = _conversation(4)
+        original = json.dumps(msgs, sort_keys=True)
+        apply_cache_control_to_messages(msgs, cache_prompt=True, model="claude-sonnet-5")
+        assert json.dumps(msgs, sort_keys=True) == original
+
+    def test_marker_lands_on_last_block_of_list_content(self) -> None:
+        msgs = _conversation(3)
+        msgs.append(
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "a", "content": "x" * 600},
+                    {"type": "tool_result", "tool_use_id": "b", "content": "y" * 600},
+                ],
+            }
+        )
+        out = apply_cache_control_to_messages(msgs, cache_prompt=True, model="claude-sonnet-5")
+        blocks = out[-1]["content"]
+        assert "cache_control" not in blocks[0]
+        assert "cache_control" in blocks[1]
+
+    def test_thinking_blocks_are_never_marked(self) -> None:
+        """Anthropic rejects cache_control on reasoning blocks."""
+        msgs = _conversation(3)
+        msgs.append(
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "answer " + "z" * 600},
+                    {"type": "thinking", "thinking": "secret"},
+                ],
+            }
+        )
+        out = apply_cache_control_to_messages(msgs, cache_prompt=True, model="claude-sonnet-5")
+        blocks = out[-1]["content"]
+        assert "cache_control" in blocks[0]
+        assert "cache_control" not in blocks[1]
+
+    def test_empty_trailing_message_is_skipped(self) -> None:
+        msgs = _conversation(4)
+        msgs.append({"role": "assistant", "content": ""})
+        out = apply_cache_control_to_messages(msgs, cache_prompt=True, model="claude-sonnet-5")
+        marked = _markers(out)
+        assert marked, "expected the walk-back to find an earlier markable message"
+        assert len(out) - 1 not in marked
+
+    def test_long_conversation_gets_anchor_plus_rolling(self) -> None:
+        msgs = _conversation(45)
+        out = apply_cache_control_to_messages(msgs, cache_prompt=True, model="claude-sonnet-5")
+        marked = _markers(out)
+        assert len(marked) == 2, f"expected anchor + rolling, got {marked}"
+        assert marked[-1] == len(out) - 1
+
+    def test_anchor_is_stable_as_conversation_grows(self) -> None:
+        """The anchor must not drift, or its cache entry is never re-read.
+
+        Counting from the front is what makes it stable: appending more
+        turns leaves the anchor on the same message, so the entry written
+        there stays readable on later requests.
+        """
+        base = _conversation(45)
+        first = _markers(apply_cache_control_to_messages(base, cache_prompt=True, model="claude-sonnet-5"))[0]
+        grown = base + _conversation(4)
+        second = _markers(apply_cache_control_to_messages(grown, cache_prompt=True, model="claude-sonnet-5"))[0]
+        assert first == second
+
+    def test_anchor_moves_within_lookback_window_when_it_shifts(self) -> None:
+        """When the anchor does advance, it stays inside the 20-block window."""
+        a = _markers(apply_cache_control_to_messages(_conversation(41), cache_prompt=True, model="claude-sonnet-5"))[0]
+        b = _markers(apply_cache_control_to_messages(_conversation(61), cache_prompt=True, model="claude-sonnet-5"))[0]
+        assert 0 < b - a <= 20
+
+    def test_budget_of_one_places_only_rolling(self) -> None:
+        msgs = _conversation(45)
+        out = apply_cache_control_to_messages(msgs, cache_prompt=True, model="claude-sonnet-5", max_breakpoints=1)
+        assert _markers(out) == [len(out) - 1]
+
+    def test_ttl_propagates_into_message_marker(self) -> None:
+        msgs = _conversation(4)
+        out = apply_cache_control_to_messages(msgs, cache_prompt=True, model="claude-sonnet-5", ttl="1h")
+        last = out[-1]["content"][-1]
+        assert last["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
+# ---------------------------------------------------------------------------
+# Breakpoint budget — Anthropic hard-errors on a 5th marker
+# ---------------------------------------------------------------------------
+
+
+class TestBreakpointBudget:
+    def test_nothing_marked_leaves_full_budget(self) -> None:
+        assert breakpoint_budget(None, None) == MAX_CACHE_BREAKPOINTS
+
+    def test_plain_string_system_costs_nothing(self) -> None:
+        assert breakpoint_budget("a plain system prompt") == MAX_CACHE_BREAKPOINTS
+
+    def test_marked_system_and_tools_each_cost_one(self) -> None:
+        system = [{"type": "text", "text": "x", "cache_control": {"type": "ephemeral"}}]
+        tools = [{"name": "t", "cache_control": {"type": "ephemeral"}}]
+        assert breakpoint_budget(system, tools) == MAX_CACHE_BREAKPOINTS - 2
+
+    def test_unmarked_tools_cost_nothing(self) -> None:
+        assert breakpoint_budget(None, [{"name": "t"}]) == MAX_CACHE_BREAKPOINTS
+
+    def test_total_markers_never_exceed_api_limit(self) -> None:
+        system = [{"type": "text", "text": "x", "cache_control": {"type": "ephemeral"}}]
+        tools = [{"name": "t", "cache_control": {"type": "ephemeral"}}]
+        msgs = apply_cache_control_to_messages(
+            _conversation(60),
+            cache_prompt=True,
+            model="claude-sonnet-5",
+            max_breakpoints=breakpoint_budget(system, tools),
+        )
+        total = 1 + 1 + len(_markers(msgs))
+        assert total <= MAX_CACHE_BREAKPOINTS
+
+
+# ---------------------------------------------------------------------------
+# OpenAI — automatic caching, routed by prompt_cache_key
+# ---------------------------------------------------------------------------
+
+
+class TestPromptCacheKey:
+    def test_no_prefix_returns_none(self) -> None:
+        assert derive_prompt_cache_key() is None
+
+    def test_explicit_key_wins(self) -> None:
+        assert derive_prompt_cache_key(system="x", explicit="mine") == "mine"
+
+    def test_same_prefix_yields_same_key(self) -> None:
+        a = derive_prompt_cache_key(system="shared prompt", tools=[{"name": "t"}])
+        b = derive_prompt_cache_key(system="shared prompt", tools=[{"name": "t"}])
+        assert a == b and a is not None
+
+    def test_different_prefix_yields_different_key(self) -> None:
+        a = derive_prompt_cache_key(system="prompt A")
+        b = derive_prompt_cache_key(system="prompt B")
+        assert a != b
+
+    def test_tool_ordering_does_not_change_key(self) -> None:
+        a = derive_prompt_cache_key(system="s", tools=[{"a": 1, "b": 2}])
+        b = derive_prompt_cache_key(system="s", tools=[{"b": 2, "a": 1}])
+        assert a == b
+
+    def test_key_is_namespaced_and_bounded(self) -> None:
+        key = derive_prompt_cache_key(system="x")
+        assert key is not None
+        assert key.startswith("prompture-")
+        assert len(key) <= 64
+
+
+class TestOpenAIDriverCacheKey:
+    def test_derived_from_system_not_user_turn(self) -> None:
+        """The key must ignore the volatile tail, or every request is unique."""
+        from prompture.drivers.openai_driver import _openai_prompt_cache_key
+
+        base = [{"role": "system", "content": "stable"}]
+        a = _openai_prompt_cache_key([*base, {"role": "user", "content": "q1"}], {})
+        b = _openai_prompt_cache_key([*base, {"role": "user", "content": "q2"}], {})
+        assert a == b and a is not None
+
+    def test_cache_prompt_false_disables_key(self) -> None:
+        from prompture.drivers.openai_driver import _openai_prompt_cache_key
+
+        msgs = [{"role": "system", "content": "stable"}]
+        assert _openai_prompt_cache_key(msgs, {"cache_prompt": False}) is None
+
+    def test_key_omitted_from_kwargs_when_none(self) -> None:
+        """Compat endpoints (Grok/DeepSeek/Moonshot) reject unknown fields."""
+        from prompture.drivers.openai_driver import _build_openai_base_kwargs
+
+        kwargs = _build_openai_base_kwargs("m", [], {}, "max_tokens", False, 512)
+        assert "prompt_cache_key" not in kwargs
+
+    def test_key_included_when_supplied(self) -> None:
+        from prompture.drivers.openai_driver import _build_openai_base_kwargs
+
+        kwargs = _build_openai_base_kwargs("m", [], {}, "max_tokens", False, 512, prompt_cache_key="k")
+        assert kwargs["prompt_cache_key"] == "k"


### PR DESCRIPTION
Prompt caching only ever marked `system` and `tools` — a fixed-size prefix. The message array is what actually grows during an agentic tool loop, and re-sending it unmarked billed the whole accumulated history at full input price every round. A ten-round loop with a 2K-token system prompt and 30K tokens of tool results reported ~2K cache reads against 32K input, which is what kept measured hit rates in the single digits.

Adds a shared `_prompt_cache` module and wires it through both Claude drivers, Bedrock (same Anthropic body shape), and OpenAI:

- Message breakpoints: a rolling one on the last message plus a stride-aligned anchor counted from the front, so its cache entry stays readable inside Anthropic's 20-block lookback window as the array grows. Budget is allocated system -> tools -> messages so a request never exceeds the 4-breakpoint API limit.
- Per-model minimums replace the flat 4000-char threshold. The minimum is not monotonic across models (512 tokens on Opus 5, 4096 on Opus 4.6), so the old constant both skipped cacheable prompts on newer models and marked blocks Haiku 4.5 silently ignores.
- cache_ttl option for the 1-hour window, priced through a cache_write_multiplier rather than duplicating every rate row. Bursty and scheduled workloads were writing 5-minute entries that always expired before the next run.
- OpenAI caches automatically with no marker to send, so the lever there is prompt_cache_key, derived from the stable prefix (system + tools, never the volatile tail) so requests sharing a prefix route to the same cache node. Kept opt-in at the call site because the OpenAI-compatible endpoints share the kwargs builder and reject unknown fields.