### PR TITLE
Read the SDK's field names, not only the wire spellings

### DIFF
--- a/prompture/integrations/mcp_bridge.py
+++ b/prompture/integrations/mcp_bridge.py
@@ -57,6 +57,32 @@ def _sanitize_name(name: str, prefix: str | None = None) -> str:
     return sanitized
 
 
+def _mcp_field(obj: Any, *names: str, default: Any = None) -> Any:
+    """Read the first present field from *names*, by attribute then by key.
+
+    MCP's own JSON uses camelCase (``inputSchema``, ``isError``), but the
+    ``mcp`` Python SDK models expose snake_case attributes with the camelCase
+    spelling as a pydantic *alias* — and which one is the attribute changed
+    between SDK generations. Reading a single spelling therefore fails
+    silently: the value comes back as the default, and nothing raises.
+
+    That is exactly how two bugs shipped. ``inputSchema`` read as absent left
+    every MCP tool advertised to the model with an empty parameter schema (so a
+    tool needing arguments looked like it took none), and ``isError`` read as
+    absent turned every failed MCP call into an apparently successful one. Both
+    were invisible to the tests, whose mocks used the same spelling as the code.
+    """
+    for name in names:
+        value = getattr(obj, name, None)
+        if value is not None:
+            return value
+    if isinstance(obj, dict):
+        for name in names:
+            if obj.get(name) is not None:
+                return obj[name]
+    return default
+
+
 def _serialize_content_block(block: Any) -> str:
     """Serialize a single MCP content block to a string.
 
@@ -97,7 +123,7 @@ def _make_mcp_tool_function(session: mcp.ClientSession, mcp_name: str) -> Any:
             # MCP call errors become LLM-friendly error strings (registry convention).
             return f"Error calling MCP tool '{mcp_name}': {exc}"
         text = _serialize_call_result(result)
-        if getattr(result, "isError", False):
+        if _mcp_field(result, "isError", "is_error", default=False):
             return f"Error from MCP tool '{mcp_name}': {text}"
         return text
 
@@ -149,12 +175,12 @@ async def register_mcp_tools(
 
     registered: list[str] = []
     for tool in tools:
-        mcp_name = getattr(tool, "name", None)
+        mcp_name = _mcp_field(tool, "name")
         if not mcp_name:
             continue
         name = _sanitize_name(str(mcp_name), prefix)
-        description = getattr(tool, "description", None) or f"MCP tool {mcp_name}"
-        parameters = getattr(tool, "inputSchema", None)
+        description = _mcp_field(tool, "description") or f"MCP tool {mcp_name}"
+        parameters = _mcp_field(tool, "inputSchema", "input_schema")
         if not isinstance(parameters, dict):
             parameters = {"type": "object", "properties": {}}
         registry.add(

--- a/tests/test_mcp_bridge.py
+++ b/tests/test_mcp_bridge.py
@@ -26,6 +26,23 @@ def _tool(name, description=None, input_schema=None):
     )
 
 
+def _sdk_tool(name, description=None, input_schema=None):
+    """A tool shaped like the ``mcp`` SDK's own model, not like the wire JSON.
+
+    The SDK exposes ``input_schema``/``is_error`` as the *attributes* and keeps
+    the camelCase spellings as pydantic aliases. Every mock in this file used
+    the camelCase spelling — the same one the code read — so both spellings
+    being needed went unnoticed until an SDK generation flipped which is the
+    attribute, at which point tools were silently advertised with no
+    parameters and failed calls silently looked successful.
+    """
+    return SimpleNamespace(
+        name=name,
+        description=description,
+        input_schema=input_schema,
+    )
+
+
 def _text_block(text):
     return SimpleNamespace(type="text", text=text)
 
@@ -72,6 +89,19 @@ class TestRegistration:
         assert td is not None
         assert td.description == "Get weather"
         assert td.parameters == WEATHER_SCHEMA  # JSON Schema passed through unchanged
+
+    async def test_registers_schema_under_sdk_field_name(self):
+        """``input_schema`` (SDK attribute) must work as well as ``inputSchema``."""
+        session = FakeSession(tools=[_sdk_tool("get_weather", "Get weather", WEATHER_SCHEMA)])
+        registry = ToolRegistry()
+
+        names = await register_mcp_tools(registry, session)
+
+        assert names == ["get_weather"]
+        td = registry.get("get_weather")
+        assert td.parameters == WEATHER_SCHEMA, (
+            "schema lost: the model would be told this tool takes no arguments"
+        )
 
     async def test_prefix_applied_to_names(self):
         session = FakeSession(tools=[_tool("read_file", "Read a file")])
@@ -181,6 +211,21 @@ class TestErrorMapping:
     async def test_is_error_result_becomes_error_string(self):
         result = SimpleNamespace(content=[_text_block("no such file")], isError=True)
         session = FakeSession(tools=[_tool("read_file")], call_result=result)
+        registry = ToolRegistry()
+        await register_mcp_tools(registry, session)
+
+        output = await registry.aexecute("read_file", {})
+
+        assert output == "Error from MCP tool 'read_file': no such file"
+
+    async def test_is_error_under_sdk_field_name(self):
+        """``is_error`` (SDK attribute) must also mark the result as an error.
+
+        Missing it doesn't fail loudly — it hands the model a failure message
+        formatted as ordinary output, which reads as data.
+        """
+        result = SimpleNamespace(content=[_text_block("no such file")], is_error=True)
+        session = FakeSession(tools=[_sdk_tool("read_file")], call_result=result)
         registry = ToolRegistry()
         await register_mcp_tools(registry, session)
 


### PR DESCRIPTION
The bridge read `tool.inputSchema` and `result.isError`. Those are MCP's JSON names, but the `mcp` Python SDK exposes `input_schema` / `is_error` as the attributes and keeps the camelCase spellings as pydantic aliases. Against mcp 2.x both reads therefore returned the default, silently:

- every registered MCP tool was advertised to the model with an empty parameter schema, so a tool that needs arguments looked like it took none — verified against a real stdio server, where `echo(message)` came through as `{"type": "object", "properties": {}}`
- every failed call looked successful, handing the model a failure message formatted as ordinary output

Neither failed loudly, and the tests couldn't catch either: their mocks used the same spelling as the code. `_mcp_field()` now reads the first present of several names (attribute, then key), and the tests gained a `_sdk_tool` factory shaped like the SDK's own model. Both new tests fail against the previous code.